### PR TITLE
opprett jp uten enhet, ferdigstill med enhet som input

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivController.java
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivController.java
@@ -59,11 +59,11 @@ public class DokarkivController {
 
     @PutMapping("v1/{journalpostId}/ferdigstill")
     @ResponseStatus(HttpStatus.OK)
-    public ResponseEntity<Ressurs> ferdigstillJournalpost(@PathVariable(name = "journalpostId") String journalpostId) {
+    public ResponseEntity<Ressurs> ferdigstillJournalpost(@PathVariable(name = "journalpostId") String journalpostId, @RequestParam(name = "journalfoerendeEnhet") String journalførendeEnhet) {
         if (journalpostId == null) {
             return ResponseEntity.badRequest().body(Ressurs.Companion.failure("journalpostId er null", null));
         }
-        journalføringService.ferdistillJournalpost(journalpostId);
+        journalføringService.ferdistillJournalpost(journalpostId, journalførendeEnhet);
         return ResponseEntity
                 .ok(Ressurs.Companion.success(Map.of("journalpostId", journalpostId), "Ferdigstilt journalpost " + journalpostId));
     }

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivService.java
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivService.java
@@ -49,8 +49,8 @@ public class DokarkivService {
         return response.map(this::mapTilArkiverDokumentResponse).orElse(null);
     }
 
-    public void ferdistillJournalpost(String journalpost) {
-        dokarkivClient.ferdigstillJournalpost(journalpost);
+    public void ferdistillJournalpost(String journalpost, String journalførendeEnhet) {
+        dokarkivClient.ferdigstillJournalpost(journalpost, journalførendeEnhet);
     }
 
     private String hentNavnForFnr(String fnr) {
@@ -80,7 +80,6 @@ public class DokarkivService {
                 .medKanal(metadataHoveddokument.getKanal())
                 .medTittel(metadataHoveddokument.getTittel())
                 .medTema(metadataHoveddokument.getTema())
-                .medJournalfoerendeEnhet(DokumentMetadata.JOURNALFØRENDE_ENHET)
                 .medAvsenderMottaker(new AvsenderMottaker(fnr, IdType.FNR, navn))
                 .medBruker(new Bruker(IdType.FNR, fnr))
                 .medDokumenter(dokumentRequest)

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/client/DokarkivClient.java
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/client/DokarkivClient.java
@@ -33,7 +33,7 @@ public class DokarkivClient {
     private static final String NAV_CONSUMER_ID = "Nav-Consumer-Id";
     private static final String NAV_CALL_ID = "Nav-Call-Id";
     private static final String NAV_PERSONIDENTER = "Nav-Personidenter";
-    public static final String FERDIGSTILL_JOURNALPOST_JSON = "{\"journalfoerendeEnhet\":9999}";
+    public static final String FERDIGSTILL_JOURNALPOST_JSON = "{\"journalfoerendeEnhet\":%s}";
     private final Timer opprettJournalpostResponstid = Metrics.timer("dokarkiv.opprett.respons.tid");
     private final Counter opprettJournalpostSuccess = Metrics.counter("dokarkiv.opprett.response", "status", "success");
     private final Counter opprettJournalpostFailure = Metrics.counter("dokarkiv.opprett.response", "status", "failure");
@@ -101,7 +101,7 @@ public class DokarkivClient {
     }
 
 
-    public void ferdigstillJournalpost(String journalpostId) {
+    public void ferdigstillJournalpost(String journalpostId, String journalførendeEnhet) {
         URI uri = URI.create(String.format("%s/rest/journalpostapi/v1/journalpost/%s/ferdigstill", dokarkivUrl, journalpostId));
         String systembrukerToken = stsRestClient.getSystemOIDCToken();
         try {
@@ -112,7 +112,7 @@ public class DokarkivClient {
                     .header(NAV_CONSUMER_ID, consumer)
                     .header(NAV_CALL_ID, MDCOperations.getCallId())
                     .header(AUTHORIZATION, "Bearer " + systembrukerToken)
-                    .method("PATCH", HttpRequest.BodyPublishers.ofString(FERDIGSTILL_JOURNALPOST_JSON))
+                    .method("PATCH", HttpRequest.BodyPublishers.ofString(String.format(FERDIGSTILL_JOURNALPOST_JSON, journalførendeEnhet)))
                     .timeout(Duration.ofSeconds(20)) // kall tar opptil 8s i preprod.
                     .build();
 

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/DokumentMetadata.java
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/DokumentMetadata.java
@@ -1,7 +1,6 @@
 package no.nav.familie.integrasjoner.dokarkiv.metadata;
 
 public interface DokumentMetadata {
-    String JOURNALFØRENDE_ENHET = "9999";
 
     String getTema();
 

--- a/src/test/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivControllerTest.java
+++ b/src/test/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivControllerTest.java
@@ -162,7 +162,7 @@ public class DokarkivControllerTest extends OppslagSpringRunnerTest {
 
 
         ResponseEntity<Ressurs> response = restTemplate.exchange(
-                localhost(DOKARKIV_URL + "/123/ferdigstill"), HttpMethod.PUT, new HttpEntity<>(null, headers), Ressurs.class
+                localhost(DOKARKIV_URL + "/123/ferdigstill?journalfoerendeEnhet=9999"), HttpMethod.PUT, new HttpEntity<>(null, headers), Ressurs.class
         );
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -184,7 +184,7 @@ public class DokarkivControllerTest extends OppslagSpringRunnerTest {
 
 
         ResponseEntity<Ressurs> response = restTemplate.exchange(
-                localhost(DOKARKIV_URL + "/123/ferdigstill"), HttpMethod.PUT, new HttpEntity<>(null, headers), Ressurs.class
+                localhost(DOKARKIV_URL + "/123/ferdigstill?journalfoerendeEnhet=9999"), HttpMethod.PUT, new HttpEntity<>(null, headers), Ressurs.class
         );
 
         assertThat(response.getStatusCode()).isEqualTo(BAD_REQUEST);

--- a/src/test/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivServiceTest.java
+++ b/src/test/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivServiceTest.java
@@ -106,7 +106,6 @@ public class DokarkivServiceTest {
         assertThat(request.getBruker().getId()).isEqualTo(FNR);
         assertThat(request.getBruker().getIdType()).isEqualTo(IdType.FNR);
         assertThat(request.getBehandlingstema()).isEqualTo(KontanstøtteSøknadMetadata.BEHANDLINGSTEMA);
-        assertThat(request.getJournalfoerendeEnhet()).isEqualTo(DokumentMetadata.JOURNALFØRENDE_ENHET);
         assertThat(request.getJournalpostType()).isEqualTo(JournalpostType.INNGAAENDE);
         assertThat(request.getKanal()).isEqualTo(KontanstøtteSøknadMetadata.KANAL);
         assertThat(request.getTema()).isEqualTo(KontanstøtteSøknadMetadata.TEMA);


### PR DESCRIPTION
Slik at ruting skal kunne gjøre ruting til riktig enhet.