### PR TITLE
Ignorerer oppdatering av oppgave for ferdigstilte oppgaver

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.java
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.java
@@ -29,7 +29,11 @@ public class OppgaveService {
         } else {
             oppgaveJsonDto = oppgaveClient.finnOppgave(request.getEksisterendeOppgaveId());
         }
-        oppgaveClient.oppdaterOppgave(oppgaveJsonDto, request.getBeskrivelse());
+        if (oppgaveJsonDto.getStatus() == OppgaveJsonDto.StatusEnum.FERDIGSTILT) {
+            LOG.info("Ignorerer oppdatering av oppgave som er ferdigstilt for aktørId={} journalpostId={} oppgaveId={}", oppgaveJsonDto.getAktoerId(), oppgaveJsonDto.getJournalpostId(), oppgaveJsonDto.getId());
+        } else {
+            oppgaveClient.oppdaterOppgave(oppgaveJsonDto, request.getBeskrivelse());
+        }
         return oppgaveJsonDto.getId();
     }
 }

--- a/src/test/resources/oppgave/ferdigstilt_oppgave.json
+++ b/src/test/resources/oppgave/ferdigstilt_oppgave.json
@@ -1,0 +1,28 @@
+{
+  "antallTreffTotalt": 1,
+  "oppgaver": [
+    {
+      "id": 315488374,
+      "tildeltEnhetsnr": "4812",
+      "endretAvEnhetsnr": "4812",
+      "opprettetAvEnhetsnr": "9999",
+      "journalpostId": "123456789",
+      "aktoerId": "1234567891011",
+      "beskrivelse": "Behandle sak",
+      "tema": "KON",
+      "behandlingstema": "ab0084",
+      "oppgavetype": "BEH_SAK",
+      "versjon": 1,
+      "fristFerdigstillelse": "2020-01-03",
+      "aktivDato": "2020-01-02",
+      "opprettetTidspunkt": "2020-01-02T13:15:21.848+01:00",
+      "opprettetAv": "srvRuting",
+      "endretAv": "srvRuting",
+      "ferdigstiltTidspunkt": "2020-01-02T13:15:22.551+01:00",
+      "endretTidspunkt": "2020-01-02T13:15:22.551+01:00",
+      "prioritet": "NORM",
+      "status": "FERDIGSTILT",
+      "metadata": {}
+    }
+  ]
+}


### PR DESCRIPTION
Hvis en oppgave er allerede ferdistilt pga rask saksbehandling, så ignoreres oppdatering av oppgaven, siden man ikke kan oppdaterer ferdigstilte oppgaver.