### PR TITLE
Bugfix/sette tema header mot pdl

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/PdlRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/PdlRestClient.kt
@@ -27,7 +27,7 @@ class PdlRestClient(@Value("\${PDL_URL}") pdlBaseUrl: URI,
         try {
             val response = postForEntity<PdlHentPersonResponse>(pdlUri,
                                                                 pdlFødselsdatoRequest,
-                                                                httpHeaders())
+                                                                httpHeaders(tema))
 
             if (response != null && !response.harFeil()) {
                 return  Person(response?.data?.person?.foedsel!!.first().foedselsdato ?:
@@ -54,11 +54,12 @@ class PdlRestClient(@Value("\${PDL_URL}") pdlBaseUrl: URI,
         }
     }
 
-    private fun httpHeaders(): HttpHeaders {
+    private fun httpHeaders(tema: String): HttpHeaders {
         return HttpHeaders().apply {
             contentType = MediaType.APPLICATION_JSON
             accept = listOf(MediaType.APPLICATION_JSON)
             add("Nav-Consumer-Token", "Bearer ${stsRestClient.systemOIDCToken}")
+            add("Tema", tema)
         }
     }
 

--- a/src/test/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerControllerTest.kt
@@ -39,7 +39,7 @@ class PersonopplysningerControllerTest : OppslagSpringRunnerTest() {
         headers.apply {
             add("Nav-Personident", "12345678901")
         }.setBearerAuth(JwtTokenGenerator.signedJWTAsString("testbruker"))
-        uriHentPersoninfo = UriComponentsBuilder.fromHttpUrl(localhost(PDL_BASE_URL) + "v1/info/BAR").toUriString()
+        uriHentPersoninfo = UriComponentsBuilder.fromHttpUrl("${localhost(PDL_BASE_URL)}v1/info/$TEMA").toUriString()
     }
 
     @Test
@@ -48,6 +48,7 @@ class PersonopplysningerControllerTest : OppslagSpringRunnerTest() {
                 .`when`(HttpRequest.request()
                                 .withMethod("POST")
                                 .withPath("/rest/pdl/graphql")
+                                .withHeader("Tema", TEMA)
                                 .withBody(testdata("pdlGyldigRequest.json"))
                 )
                 .respond(HttpResponse.response().withBody(testdata("pdlOkResponse.json"))
@@ -129,5 +130,6 @@ class PersonopplysningerControllerTest : OppslagSpringRunnerTest() {
         const val MOCK_SERVER_PORT = 18321
         const val FØDSELSDATO = "1955-09-13"
         const val PDL_BASE_URL = "/api/personopplysning/"
+        const val TEMA = "BAR"
     }
 }


### PR DESCRIPTION
Kom nok dessverre til å slette koden for å sette header "Tema" mot pdl under en tidligere rydderunde. Lagt tilbake nå, med test for at den settes korrekt. Testet OK i preprod.