### PR TITLE
Arbeidsfordeling må kjøre mot q0 eller q1 siden q2 er utdatert.

### DIFF
--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -41,5 +41,5 @@ OPPGAVE_URL: http://oppgave.q2
 EGEN_ANSATT_V1_URL: https://wasapp-q2.adeo.no/tpsws/EgenAnsatt_v1
 KODEVERK_URL: http://kodeverk
 DOKDIST_URL: http://dokdistfordeling.q2
-ARBEIDSFORDELING_V1_URL: https://app-q2.adeo.no/norg2/ws/Arbeidsfordeling/v1
 PDL_URL: http://pdl-api
+ARBEIDSFORDELING_V1_URL: https://app-q1.adeo.no/norg2/ws/Arbeidsfordeling/v1


### PR DESCRIPTION
Setter dermed til q1, siden man uansett må sette opp brukere i q1 for økonomi