### PR TITLE
Nytt endepunkt for å hente oppgaver i Oppgave

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/OppgaveRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/OppgaveRestClient.kt
@@ -41,13 +41,27 @@ class OppgaveRestClient(@Value("\${OPPGAVE_URL}") private val oppgaveBaseUrl: UR
         return getForEntity(requestUrl(oppgaveId.toLong()), httpHeaders())
     }
 
+    fun finnOppgaverKnyttetTilSaksbehandlerOgEnhet(tilordnetRessurs: String, tildeltEnhetsnr: String): List<OppgaveJsonDto> {
+        val uri = UriComponentsBuilder.fromUri(oppgaveBaseUrl)
+                .path(PATH_OPPGAVE)
+                .queryParam("tilordnetRessurs", tilordnetRessurs)
+                .queryParam("tildeltEnhetsnr", tildeltEnhetsnr)
+                .queryParam("oppgavetype", OPPGAVE_TYPE)
+                .build()
+                .toUri()
+
+        val finnOppgaveResponseDto = getForEntity<FinnOppgaveResponseDto>(uri, httpHeaders())
+
+        return finnOppgaveResponseDto.oppgaver
+    }
+
     fun oppdaterOppgave(patchDto: OppgaveJsonDto) {
         return Result.runCatching {
             patchForEntity<OppgaveJsonDto>(requestUrl(patchDto.id ?: error("Kan ikke finne oppgaveId på oppgaven")),
                                            patchDto,
                                            httpHeaders())
         }.fold(
-                onSuccess = { it },
+                onSuccess = { },
                 onFailure = {
                     var feilmelding = "Feil ved oppdatering av oppgave for ${patchDto.id}."
                     if (it is HttpStatusCodeException) {

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/OppgaveRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/OppgaveRestClient.kt
@@ -61,7 +61,7 @@ class OppgaveRestClient(@Value("\${OPPGAVE_URL}") private val oppgaveBaseUrl: UR
                                            patchDto,
                                            httpHeaders())
         }.fold(
-                onSuccess = { },
+                onSuccess = {},
                 onFailure = {
                     var feilmelding = "Feil ved oppdatering av oppgave for ${patchDto.id}."
                     if (it is HttpStatusCodeException) {

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/OppgaveRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/OppgaveRestClient.kt
@@ -43,20 +43,24 @@ class OppgaveRestClient(@Value("\${OPPGAVE_URL}") private val oppgaveBaseUrl: UR
     }
 
     fun finnOppgaverKnyttetTilSaksbehandlerOgEnhet(tema: String, behandlingstema: String?, oppgavetype: String?, tildeltEnhetsnr: String?, tilordnetRessurs: String?): List<OppgaveJsonDto> {
+
         fun finnAlleOppgaver(oppgaver: List<OppgaveJsonDto> = listOf(), antallHentet: Int = 0): List<OppgaveJsonDto> {
             val limit = 50
 
-            val uri = UriComponentsBuilder.fromUri(oppgaveBaseUrl)
+            val uriBuilder = UriComponentsBuilder.fromUri(oppgaveBaseUrl)
                     .path(PATH_OPPGAVE)
-                    .queryParam("limit", limit.toString())
-                    .queryParam("offset", antallHentet.toString())
                     .queryParam("statuskategori", "AAPEN")
                     .queryParam("aktivDatoTom", LocalDate.now().toString())
                     .queryParam("tema", tema)
-                    .queryParam("behandlingstema", behandlingstema)
-                    .queryParam("oppgavetype", oppgavetype)
-                    .queryParam("tildeltEnhetsnr", tildeltEnhetsnr)
-                    .queryParam("tilordnetRessurs", tilordnetRessurs)
+
+            behandlingstema?.apply { uriBuilder.queryParam("behandlingstema", this) }
+            oppgavetype?.apply { uriBuilder.queryParam("oppgavetype", this) }
+            tildeltEnhetsnr?.apply { uriBuilder.queryParam("tildeltEnhetsnr", this) }
+            tilordnetRessurs?.apply { uriBuilder.queryParam("tilordnetRessurs", this) }
+
+            val uri = uriBuilder
+                    .queryParam("limit", limit.toString())
+                    .queryParam("offset", antallHentet.toString())
                     .build()
                     .toUri()
 

--- a/src/main/java/no/nav/familie/integrasjoner/config/ApiExceptionHandler.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/config/ApiExceptionHandler.kt
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.MissingRequestHeaderException
+import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.client.RestClientResponseException
@@ -46,6 +47,14 @@ class ApiExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(failure("Mangler påkrevd request header", e))
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException::class)
+    fun handleMissingServletRequestParameterException(e: MissingServletRequestParameterException): ResponseEntity<Ressurs<Any>> {
+        logger.warn("Mangler påkrevd request parameter. {}", e.message)
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(failure("Mangler påkrevd request parameter", e))
     }
 
     @ExceptionHandler(OAuth2ClientException::class)

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping("/api/oppgave")
 class OppgaveController(private val oppgaveService: OppgaveService) {
 
-    @GetMapping(consumes = [MediaType.APPLICATION_JSON_VALUE], path = ["/"])
+    @GetMapping(produces = [MediaType.APPLICATION_JSON_VALUE], path = ["/"])
     fun finnOppgaverKnyttetTilSaksbehandlerOgEnhet(@RequestParam("tema") tema: String,
                                                    @RequestParam("behandlingstema") behandlingstema: String?,
                                                    @RequestParam("oppgavetype") oppgavetype: String?,

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
@@ -19,10 +19,10 @@ class OppgaveController(private val oppgaveService: OppgaveService) {
 
     @GetMapping(produces = [MediaType.APPLICATION_JSON_VALUE], path = ["/"])
     fun finnOppgaverKnyttetTilSaksbehandlerOgEnhet(@RequestParam("tema") tema: String,
-                                                   @RequestParam("behandlingstema") behandlingstema: String?,
-                                                   @RequestParam("oppgavetype") oppgavetype: String?,
-                                                   @RequestParam("enhet") enhet: String?,
-                                                   @RequestParam("saksbehandler") saksbehandler: String?)
+                                                   @RequestParam("behandlingstema", required = false) behandlingstema: String?,
+                                                   @RequestParam("oppgavetype", required = false) oppgavetype: String?,
+                                                   @RequestParam("enhet", required = false) enhet: String?,
+                                                   @RequestParam("saksbehandler", required = false) saksbehandler: String?)
             : ResponseEntity<Ressurs<List<OppgaveJsonDto>>> {
         val oppgaver = oppgaveService.finnOppgaverKnyttetTilSaksbehandlerOgEnhet(tema, behandlingstema, oppgavetype, enhet, saksbehandler)
         return ResponseEntity.ok().body(success(oppgaver, "Finn oppgaver OK"))

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping("/api/oppgave")
 class OppgaveController(private val oppgaveService: OppgaveService) {
 
-    @GetMapping(produces = [MediaType.APPLICATION_JSON_VALUE], path = ["/"])
+    @GetMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
     fun finnOppgaverKnyttetTilSaksbehandlerOgEnhet(@RequestParam("tema") tema: String,
                                                    @RequestParam("behandlingstema", required = false) behandlingstema: String?,
                                                    @RequestParam("oppgavetype", required = false) oppgavetype: String?,
@@ -34,7 +34,7 @@ class OppgaveController(private val oppgaveService: OppgaveService) {
         return ResponseEntity.ok().body(success(OppgaveResponse(oppgaveId = oppgaveId), "Oppdatering av oppgave OK"))
     }
 
-    @PostMapping(consumes = [MediaType.APPLICATION_JSON_VALUE], path = ["/"])
+    @PostMapping(consumes = [MediaType.APPLICATION_JSON_VALUE])
     fun opprettOppgave(@RequestBody oppgave: OpprettOppgave): ResponseEntity<Ressurs<OppgaveResponse>> {
         val oppgaveId = oppgaveService.opprettOppgave(oppgave)
         return ResponseEntity.status(HttpStatus.CREATED)

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.integrasjoner.oppgave
 
+import no.nav.familie.integrasjoner.oppgave.domene.OppgaveJsonDto
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.Ressurs.Companion.success
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
@@ -15,6 +16,13 @@ import org.springframework.web.bind.annotation.*
 @ProtectedWithClaims(issuer = "azuread")
 @RequestMapping("/api/oppgave")
 class OppgaveController(private val oppgaveService: OppgaveService) {
+
+    @GetMapping(consumes = [MediaType.APPLICATION_JSON_VALUE], path = ["/"])
+    fun finnOppgaverKnyttetTilSaksbehandlerOgEnhet(@RequestParam("saksbehandler") saksbehandler: String,
+                                                   @RequestParam("enhet") enhet: String): ResponseEntity<Ressurs<List<OppgaveJsonDto>>> {
+        val oppgaver = oppgaveService.finnOppgaverKnyttetTilSaksbehandlerOgEnhet(saksbehandler, enhet)
+        return ResponseEntity.ok().body(success(oppgaver, "Finn oppgaver OK"))
+    }
 
     @PostMapping(consumes = [MediaType.APPLICATION_JSON_VALUE], path = ["/oppdater"])
     fun oppdaterOppgave(@RequestBody oppgave: Oppgave): ResponseEntity<Ressurs<OppgaveResponse>> {

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
@@ -18,9 +18,13 @@ import org.springframework.web.bind.annotation.*
 class OppgaveController(private val oppgaveService: OppgaveService) {
 
     @GetMapping(consumes = [MediaType.APPLICATION_JSON_VALUE], path = ["/"])
-    fun finnOppgaverKnyttetTilSaksbehandlerOgEnhet(@RequestParam("saksbehandler") saksbehandler: String,
-                                                   @RequestParam("enhet") enhet: String): ResponseEntity<Ressurs<List<OppgaveJsonDto>>> {
-        val oppgaver = oppgaveService.finnOppgaverKnyttetTilSaksbehandlerOgEnhet(saksbehandler, enhet)
+    fun finnOppgaverKnyttetTilSaksbehandlerOgEnhet(@RequestParam("tema") tema: String,
+                                                   @RequestParam("behandlingstema") behandlingstema: String?,
+                                                   @RequestParam("oppgavetype") oppgavetype: String?,
+                                                   @RequestParam("enhet") enhet: String?,
+                                                   @RequestParam("saksbehandler") saksbehandler: String?)
+            : ResponseEntity<Ressurs<List<OppgaveJsonDto>>> {
+        val oppgaver = oppgaveService.finnOppgaverKnyttetTilSaksbehandlerOgEnhet(tema, behandlingstema, oppgavetype, enhet, saksbehandler)
         return ResponseEntity.ok().body(success(oppgaver, "Finn oppgaver OK"))
     }
 

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
@@ -20,7 +20,7 @@ import java.time.format.DateTimeFormatter
 class OppgaveService constructor(private val oppgaveRestClient: OppgaveRestClient) {
 
     fun finnOppgaverKnyttetTilSaksbehandlerOgEnhet(saksbehandler: String, enhet: String): List<OppgaveJsonDto> {
-        return finnOppgaverKnyttetTilSaksbehandlerOgEnhet(saksbehandler, enhet)
+        return oppgaveRestClient.finnOppgaverKnyttetTilSaksbehandlerOgEnhet(saksbehandler, enhet)
     }
 
     fun oppdaterOppgave(request: Oppgave): Long {

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
@@ -19,6 +19,10 @@ import java.time.format.DateTimeFormatter
 @Service @ApplicationScope
 class OppgaveService constructor(private val oppgaveRestClient: OppgaveRestClient) {
 
+    fun finnOppgaverKnyttetTilSaksbehandlerOgEnhet(saksbehandler: String, enhet: String): List<OppgaveJsonDto> {
+        return finnOppgaverKnyttetTilSaksbehandlerOgEnhet(saksbehandler, enhet)
+    }
+
     fun oppdaterOppgave(request: Oppgave): Long {
         val oppgaveJsonDto: OppgaveJsonDto = if (StringUtils.nullOrEmpty(request.eksisterendeOppgaveId)) {
             oppgaveRestClient.finnOppgave(request)

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
@@ -19,8 +19,8 @@ import java.time.format.DateTimeFormatter
 @Service @ApplicationScope
 class OppgaveService constructor(private val oppgaveRestClient: OppgaveRestClient) {
 
-    fun finnOppgaverKnyttetTilSaksbehandlerOgEnhet(saksbehandler: String, enhet: String): List<OppgaveJsonDto> {
-        return oppgaveRestClient.finnOppgaverKnyttetTilSaksbehandlerOgEnhet(saksbehandler, enhet)
+    fun finnOppgaverKnyttetTilSaksbehandlerOgEnhet(tema: String, behandlingstema: String?, oppgaveType: String?, enhet: String?, saksbehandler: String?): List<OppgaveJsonDto> {
+        return oppgaveRestClient.finnOppgaverKnyttetTilSaksbehandlerOgEnhet(tema, behandlingstema, oppgaveType, enhet, saksbehandler)
     }
 
     fun oppdaterOppgave(request: Oppgave): Long {

--- a/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveControllerTest.kt
@@ -282,7 +282,7 @@ class OppgaveControllerTest : OppslagSpringRunnerTest() {
                 .willReturn(okJson(gyldigOppgaveResponse("tom_response.json"))))
 
         val response: ResponseEntity<Ressurs<List<OppgaveJsonDto>>> =
-                restTemplate.exchange(localhost("/api/oppgave/?tema=BAR"), HttpMethod.GET, HttpEntity(null, headers))
+                restTemplate.exchange(localhost("/api/oppgave?tema=BAR"), HttpMethod.GET, HttpEntity(null, headers))
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
         assertThat(response.body?.data?.count()).isEqualTo(0)
@@ -294,7 +294,7 @@ class OppgaveControllerTest : OppslagSpringRunnerTest() {
                 .willReturn(okJson(gyldigOppgaveResponse("oppgave.json"))))
 
         val response: ResponseEntity<Ressurs<List<OppgaveJsonDto>>> =
-                restTemplate.exchange(localhost("/api/oppgave/?tema=BAR"), HttpMethod.GET, HttpEntity(null, headers))
+                restTemplate.exchange(localhost("/api/oppgave?tema=BAR"), HttpMethod.GET, HttpEntity(null, headers))
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
         assertThat(response.body?.data?.count()).isEqualTo(1)
@@ -312,7 +312,7 @@ class OppgaveControllerTest : OppslagSpringRunnerTest() {
                 .willReturn(okJson(objectMapper.writeValueAsString(oppgaver1stk))))
 
         val response: ResponseEntity<Ressurs<List<OppgaveJsonDto>>> =
-                restTemplate.exchange(localhost("/api/oppgave/?tema=BAR"), HttpMethod.GET, HttpEntity(null, headers))
+                restTemplate.exchange(localhost("/api/oppgave?tema=BAR"), HttpMethod.GET, HttpEntity(null, headers))
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
         assertThat(response.body?.data?.count()).isEqualTo(51)
@@ -321,7 +321,7 @@ class OppgaveControllerTest : OppslagSpringRunnerTest() {
     @Test
     fun `finnOppgaveKnyttetTilSaksbehandlerOgEnhet skal feile hvis tema ikke er angitt`() {
         val response: ResponseEntity<Ressurs<List<OppgaveJsonDto>>> =
-                restTemplate.exchange(localhost("/api/oppgave/"), HttpMethod.GET, HttpEntity(null, headers))
+                restTemplate.exchange(localhost("/api/oppgave"), HttpMethod.GET, HttpEntity(null, headers))
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
     }


### PR DESCRIPTION
Dette endepunktet lar en hente oppgaver fra Oppgave. Gitt at man spesifiserer tema (BAR f.eks.), kan man ha valgfri spørring på behandlingstema, oppgavetype, enhet og saksbehandler. Disse fungerer som enkle filtere.

- ApiExceptionHandler er utvidet til å kaste 400 dersom et tvungent request parameter mangler.
- POST og GET endepunktene på "rota" tar nå også imot urier som ikke slutter på "/"
- Oppgavetestenes stubFor-kall er forenklet (jfr. dok. i WireMock)
