### PR TITLE
Fikser response parsing bug ved ferdigstilling av journalpost

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivRestClient.kt
@@ -76,7 +76,7 @@ class DokarkivRestClient(@Value("\${DOKARKIV_V1_URL}") private val dokarkivUrl: 
         fun ferdigstillJournalpost(journalpostId: String, journalførendeEnhet: String) {
             val uri = ferdigstillJournalpostUri(journalpostId)
             try {
-                patchForEntity<Any>(uri, FerdigstillJournalPost(journalførendeEnhet))
+                patchForEntity<String>(uri, FerdigstillJournalPost(journalførendeEnhet))
             } catch (e: RestClientResponseException) {
                 if (e.rawStatusCode == HttpStatus.BAD_REQUEST.value()) {
                     throw KanIkkeFerdigstilleJournalpostException("Kan ikke ferdigstille journalpost $journalpostId body ${e.responseBodyAsString}")

--- a/src/test/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivControllerTest.kt
@@ -193,7 +193,7 @@ class DokarkivControllerTest : OppslagSpringRunnerTest() {
                                 .request()
                                 .withMethod("PATCH")
                                 .withPath("/rest/journalpostapi/v1/journalpost/123/ferdigstill"))
-                .respond(HttpResponse.response().withStatusCode(200))
+                .respond(HttpResponse.response().withStatusCode(200).withBody("Journalpost ferdigstilt"))
 
         val response: ResponseEntity<Ressurs<Map<String, String>>> =
                 restTemplate.exchange(localhost("$DOKARKIV_URL/123/ferdigstill?journalfoerendeEnhet=9999"),


### PR DESCRIPTION
Tjenesten ferdigstilte journalposten, men feilet ved parsing av response. Response forventet er bare en tekst.