### PR TITLE
hent oppgave på id og utvidet hent opppgaver til å støtte journalpost

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
@@ -17,16 +17,31 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping("/api/oppgave")
 class OppgaveController(private val oppgaveService: OppgaveService) {
 
+
+    @GetMapping(path = ["/{oppgaveId}"], produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun hentOppgave(@PathVariable(name = "oppgaveId") oppgaveId: String)
+            : ResponseEntity<Ressurs<OppgaveJsonDto>> {
+        val oppgave = oppgaveService.hentOppgave(oppgaveId)
+        return ResponseEntity.ok().body(success(oppgave, "Hent Oppgave OK"))
+    }
+
     @GetMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
-    fun finnOppgaverKnyttetTilSaksbehandlerOgEnhet(@RequestParam("tema") tema: String,
-                                                   @RequestParam("behandlingstema", required = false) behandlingstema: String?,
-                                                   @RequestParam("oppgavetype", required = false) oppgavetype: String?,
-                                                   @RequestParam("enhet", required = false) enhet: String?,
-                                                   @RequestParam("saksbehandler", required = false) saksbehandler: String?)
+    fun finnOppgaver(@RequestParam("tema") tema: String,
+                     @RequestParam("behandlingstema", required = false) behandlingstema: String?,
+                     @RequestParam("oppgavetype", required = false) oppgavetype: String?,
+                     @RequestParam("enhet", required = false) enhet: String?,
+                     @RequestParam("saksbehandler", required = false) saksbehandler: String?,
+                     @RequestParam("journalpostId", required = false) journalpostId: String?)
             : ResponseEntity<Ressurs<List<OppgaveJsonDto>>> {
-        val oppgaver = oppgaveService.finnOppgaverKnyttetTilSaksbehandlerOgEnhet(tema, behandlingstema, oppgavetype, enhet, saksbehandler)
+        val oppgaver = oppgaveService.finnOppgaver(tema,
+                                                   behandlingstema,
+                                                   oppgavetype,
+                                                   enhet,
+                                                   saksbehandler,
+                                                   journalpostId)
         return ResponseEntity.ok().body(success(oppgaver, "Finn oppgaver OK"))
     }
+
 
     @PostMapping(consumes = [MediaType.APPLICATION_JSON_VALUE], path = ["/oppdater"])
     fun oppdaterOppgave(@RequestBody oppgave: Oppgave): ResponseEntity<Ressurs<OppgaveResponse>> {

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
@@ -19,8 +19,17 @@ import java.time.format.DateTimeFormatter
 @Service @ApplicationScope
 class OppgaveService constructor(private val oppgaveRestClient: OppgaveRestClient) {
 
-    fun finnOppgaverKnyttetTilSaksbehandlerOgEnhet(tema: String, behandlingstema: String?, oppgaveType: String?, enhet: String?, saksbehandler: String?): List<OppgaveJsonDto> {
-        return oppgaveRestClient.finnOppgaverKnyttetTilSaksbehandlerOgEnhet(tema, behandlingstema, oppgaveType, enhet, saksbehandler)
+    fun finnOppgaver(tema: String,
+                     behandlingstema: String?,
+                     oppgaveType: String?,
+                     enhet: String?,
+                     saksbehandler: String?,
+                     journalpostId: String?): List<OppgaveJsonDto> {
+        return oppgaveRestClient.finnOppgaver(tema, behandlingstema, oppgaveType, enhet, saksbehandler, journalpostId)
+    }
+
+    fun hentOppgave(oppgaveId: String): OppgaveJsonDto {
+        return oppgaveRestClient.finnOppgaveMedId(oppgaveId)
     }
 
     fun oppdaterOppgave(request: Oppgave): Long {
@@ -87,6 +96,8 @@ class OppgaveService constructor(private val oppgaveRestClient: OppgaveRestClien
         }
 
     }
+
+
 
 
     companion object {


### PR DESCRIPTION
- GET oppgave/id for å hente oppgave basert på id
- GET oppgave?journalpostId=journalpostid. Utvidelse av finnOppgaver til å støtte filtrering på journalpostId.

