### PR TITLE
HentDokument-integrasjon

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/SafHentDokumentRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/SafHentDokumentRestClient.kt
@@ -14,7 +14,7 @@ import java.net.URI
 
 @Service
 class SafHentDokumentRestClient(@Value("\${SAF_URL}") safBaseUrl: URI,
-                                @Qualifier("azure") val restTemplate: RestOperations)
+                                @Qualifier("azurePropagatingClientToken") val restTemplate: RestOperations)
     : AbstractPingableRestClient(restTemplate, "saf.journalpost") {
 
     override val pingUri: URI = UriComponentsBuilder.fromUri(safBaseUrl).path(PATH_PING).build().toUri()

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/SafHentDokumentRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/SafHentDokumentRestClient.kt
@@ -1,0 +1,44 @@
+package no.nav.familie.integrasjoner.client.rest
+
+import no.nav.familie.http.client.AbstractPingableRestClient
+import no.nav.familie.integrasjoner.felles.MDCOperations
+import no.nav.familie.integrasjoner.journalpost.JournalpostRestClientException
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestOperations
+import org.springframework.web.util.UriComponentsBuilder
+import java.net.URI
+
+@Service
+class SafHentDokumentRestClient(@Value("\${SAF_URL}") safBaseUrl: URI,
+                                @Qualifier("azure") val restTemplate: RestOperations)
+    : AbstractPingableRestClient(restTemplate, "saf.journalpost") {
+
+    override val pingUri: URI = UriComponentsBuilder.fromUri(safBaseUrl).path(PATH_PING).build().toUri()
+    private val safHentdokumentUri = UriComponentsBuilder.fromUri(safBaseUrl).path(PATH_HENT_DOKUMENT)
+
+    private fun httpHeaders(): HttpHeaders {
+        return HttpHeaders().apply {
+            add(NAV_CALL_ID, MDCOperations.getCallId())
+            accept = listOf(MediaType.APPLICATION_PDF)
+        }
+    }
+
+    fun hentDokument(journalpostId: String, dokumentInfoId: String, variantFormat: String?): ByteArray {
+        val hentDokumentUri = safHentdokumentUri.buildAndExpand(journalpostId, dokumentInfoId, variantFormat ?: "ARKIV").toUri()
+        try {
+            return getForEntity(hentDokumentUri, httpHeaders())
+        } catch (e: Exception) {
+            throw JournalpostRestClientException(e.message, e, journalpostId)
+        }
+    }
+
+    companion object {
+        private const val PATH_PING = "/isAlive"
+        private const val PATH_HENT_DOKUMENT = "/rest/hentdokument/{journalpostId}/{dokumentInfoId}/{variantFormat}"
+        private const val NAV_CALL_ID = "Nav-Callid"
+    }
+}

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/SafHentDokumentRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/SafHentDokumentRestClient.kt
@@ -14,7 +14,7 @@ import java.net.URI
 
 @Service
 class SafHentDokumentRestClient(@Value("\${SAF_URL}") safBaseUrl: URI,
-                                @Qualifier("azurePropagatingClientToken") val restTemplate: RestOperations)
+                                @Qualifier("propagateAuth") val restTemplate: RestOperations)
     : AbstractPingableRestClient(restTemplate, "saf.journalpost") {
 
     override val pingUri: URI = UriComponentsBuilder.fromUri(safBaseUrl).path(PATH_PING).build().toUri()

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/SafHentDokumentRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/SafHentDokumentRestClient.kt
@@ -23,7 +23,7 @@ class SafHentDokumentRestClient(@Value("\${SAF_URL}") safBaseUrl: URI,
     private fun httpHeaders(): HttpHeaders {
         return HttpHeaders().apply {
             add(NAV_CALL_ID, MDCOperations.getCallId())
-            accept = listOf(MediaType.APPLICATION_PDF)
+            accept = listOf(MediaType.ALL)
         }
     }
 

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/SafHentDokumentRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/SafHentDokumentRestClient.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.integrasjoner.client.rest
 
-import no.nav.familie.http.client.AbstractPingableRestClient
+import no.nav.familie.http.client.AbstractRestClient
 import no.nav.familie.integrasjoner.felles.MDCOperations
 import no.nav.familie.integrasjoner.journalpost.JournalpostRestClientException
 import org.springframework.beans.factory.annotation.Qualifier
@@ -15,9 +15,8 @@ import java.net.URI
 @Service
 class SafHentDokumentRestClient(@Value("\${SAF_URL}") safBaseUrl: URI,
                                 @Qualifier("propagateAuth") val restTemplate: RestOperations)
-    : AbstractPingableRestClient(restTemplate, "saf.journalpost") {
+    : AbstractRestClient(restTemplate, "saf.journalpost") {
 
-    override val pingUri: URI = UriComponentsBuilder.fromUri(safBaseUrl).path(PATH_PING).build().toUri()
     private val safHentdokumentUri = UriComponentsBuilder.fromUri(safBaseUrl).path(PATH_HENT_DOKUMENT)
 
     private fun httpHeaders(): HttpHeaders {
@@ -27,8 +26,8 @@ class SafHentDokumentRestClient(@Value("\${SAF_URL}") safBaseUrl: URI,
         }
     }
 
-    fun hentDokument(journalpostId: String, dokumentInfoId: String, variantFormat: String?): ByteArray {
-        val hentDokumentUri = safHentdokumentUri.buildAndExpand(journalpostId, dokumentInfoId, variantFormat ?: "ARKIV").toUri()
+    fun hentDokument(journalpostId: String, dokumentInfoId: String, variantFormat: String): ByteArray {
+        val hentDokumentUri = safHentdokumentUri.buildAndExpand(journalpostId, dokumentInfoId, variantFormat).toUri()
         try {
             return getForEntity(hentDokumentUri, httpHeaders())
         } catch (e: Exception) {
@@ -37,7 +36,6 @@ class SafHentDokumentRestClient(@Value("\${SAF_URL}") safBaseUrl: URI,
     }
 
     companion object {
-        private const val PATH_PING = "/isAlive"
         private const val PATH_HENT_DOKUMENT = "/rest/hentdokument/{journalpostId}/{dokumentInfoId}/{variantFormat}"
         private const val NAV_CALL_ID = "Nav-Callid"
     }

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/SafRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/SafRestClient.kt
@@ -19,7 +19,7 @@ import java.net.URI
 
 @Service
 class SafRestClient(@Value("\${SAF_URL}") safBaseUrl: URI,
-                    @Qualifier("sts") val restTemplate: RestOperations)
+                    @Qualifier("clientCredentials") val restTemplate: RestOperations)
     : AbstractPingableRestClient(restTemplate, "saf.journalpost") {
 
     override val pingUri: URI = UriUtil.uri(safBaseUrl, PATH_PING)

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/SafRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/SafRestClient.kt
@@ -19,7 +19,7 @@ import java.net.URI
 
 @Service
 class SafRestClient(@Value("\${SAF_URL}") safBaseUrl: URI,
-                    @Qualifier("clientCredentials") val restTemplate: RestOperations)
+                    @Qualifier("azure") val restTemplate: RestOperations)
     : AbstractPingableRestClient(restTemplate, "saf.journalpost") {
 
     override val pingUri: URI = UriUtil.uri(safBaseUrl, PATH_PING)

--- a/src/main/java/no/nav/familie/integrasjoner/config/ApplicationConfig.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/config/ApplicationConfig.kt
@@ -64,7 +64,7 @@ class ApplicationConfig {
 
         return RestTemplateBuilder()
             .interceptors(ClientHttpRequestInterceptor { outRequest, body, requestExecution ->
-                              outRequest.headers.setBearerAuth(inRequest.getHeader(AUTHORIZATION))
+                              outRequest.headers.set(AUTHORIZATION, inRequest.getHeader(AUTHORIZATION))
                               requestExecution.execute(outRequest, body)
                           },
                           consumerIdClientInterceptor,

--- a/src/main/java/no/nav/familie/integrasjoner/config/ApplicationConfig.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/config/ApplicationConfig.kt
@@ -43,6 +43,17 @@ class ApplicationConfig {
                 .build()
     }
 
+    @Bean("azurePropagatingClientToken")
+    fun restTemplateAzureAdMinusBearerTokenInterceptor(consumerIdClientInterceptor: ConsumerIdClientInterceptor)
+        : RestOperations {
+        return RestTemplateBuilder()
+            .additionalCustomizers(NaisProxyCustomizer())
+            .interceptors(consumerIdClientInterceptor,
+                MdcValuesPropagatingClientInterceptor())
+            .requestFactory(this::requestFactory)
+            .build()
+    }
+
     @Bean("sts")
     fun restTemplateSts(stsBearerTokenClientInterceptor: StsBearerTokenClientInterceptor,
                         consumerIdClientInterceptor: ConsumerIdClientInterceptor): RestOperations {

--- a/src/main/java/no/nav/familie/integrasjoner/journalpost/HentJournalpostController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/journalpost/HentJournalpostController.kt
@@ -57,7 +57,8 @@ class HentJournalpostController(private val journalpostService: JournalpostServi
                      @PathVariable dokumentInfoId: String,
                      @RequestParam("variantFormat", required = false) variantFormat: String?)
             : ResponseEntity<Ressurs<ByteArray>> {
-        return ResponseEntity.ok(success(journalpostService.hentDokument(journalpostId, dokumentInfoId, variantFormat), "OK"))
+        val format = variantFormat ?: "ARKIV"
+        return ResponseEntity.ok(success(journalpostService.hentDokument(journalpostId, dokumentInfoId, format), "OK"))
     }
 
     companion object {

--- a/src/main/java/no/nav/familie/integrasjoner/journalpost/HentJournalpostController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/journalpost/HentJournalpostController.kt
@@ -55,9 +55,9 @@ class HentJournalpostController(private val journalpostService: JournalpostServi
     @GetMapping("hentdokument/{journalpostId}/{dokumentInfoId}")
     fun hentDokument(@PathVariable journalpostId: String,
                      @PathVariable dokumentInfoId: String,
-                     @RequestParam("variantFormat", required = false) variantFormat: String? = "ARKIV")
+                     @RequestParam("variantFormat", required = false) variantFormat: String?)
             : ResponseEntity<Ressurs<ByteArray>> {
-        return ResponseEntity.ok(success(journalpostService.hentDokument(journalpostId, dokumentInfoId, variantFormat!!), "OK"))
+        return ResponseEntity.ok(success(journalpostService.hentDokument(journalpostId, dokumentInfoId, variantFormat ?: "ARKIV"), "OK"))
     }
 
     companion object {

--- a/src/main/java/no/nav/familie/integrasjoner/journalpost/HentJournalpostController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/journalpost/HentJournalpostController.kt
@@ -55,9 +55,9 @@ class HentJournalpostController(private val journalpostService: JournalpostServi
     @GetMapping("hentdokument/{journalpostId}/{dokumentInfoId}")
     fun hentDokument(@PathVariable journalpostId: String,
                      @PathVariable dokumentInfoId: String,
-                     @RequestParam variantFormat: String?): ResponseEntity<Ressurs<ByteArray>> {
-        return ResponseEntity
-            .ok(success(journalpostService.hentDokument(journalpostId, dokumentInfoId, variantFormat), "OK"))
+                     @RequestParam("variantFormat", required = false) variantFormat: String?)
+            : ResponseEntity<Ressurs<ByteArray>> {
+        return ResponseEntity.ok(success(journalpostService.hentDokument(journalpostId, dokumentInfoId, variantFormat), "OK"))
     }
 
     companion object {

--- a/src/main/java/no/nav/familie/integrasjoner/journalpost/HentJournalpostController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/journalpost/HentJournalpostController.kt
@@ -55,10 +55,9 @@ class HentJournalpostController(private val journalpostService: JournalpostServi
     @GetMapping("hentdokument/{journalpostId}/{dokumentInfoId}")
     fun hentDokument(@PathVariable journalpostId: String,
                      @PathVariable dokumentInfoId: String,
-                     @RequestParam("variantFormat", required = false) variantFormat: String?)
+                     @RequestParam("variantFormat", required = false) variantFormat: String? = "ARKIV")
             : ResponseEntity<Ressurs<ByteArray>> {
-        val format = variantFormat ?: "ARKIV"
-        return ResponseEntity.ok(success(journalpostService.hentDokument(journalpostId, dokumentInfoId, format), "OK"))
+        return ResponseEntity.ok(success(journalpostService.hentDokument(journalpostId, dokumentInfoId, variantFormat!!), "OK"))
     }
 
     companion object {

--- a/src/main/java/no/nav/familie/integrasjoner/journalpost/HentJournalpostController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/journalpost/HentJournalpostController.kt
@@ -52,6 +52,14 @@ class HentJournalpostController(private val journalpostService: JournalpostServi
         return ResponseEntity.ok(success(journalpostService.hentJournalpost(journalpostId), "OK"))
     }
 
+    @GetMapping("hentdokument/{journalpostId}/{dokumentInfoId}")
+    fun hentDokument(@PathVariable journalpostId: String,
+                     @PathVariable dokumentInfoId: String,
+                     @RequestParam variantFormat: String?): ResponseEntity<Ressurs<ByteArray>> {
+        return ResponseEntity
+            .ok(success(journalpostService.hentDokument(journalpostId, dokumentInfoId, variantFormat), "OK"))
+    }
+
     companion object {
         private val LOG = LoggerFactory.getLogger(HentJournalpostController::class.java)
     }

--- a/src/main/java/no/nav/familie/integrasjoner/journalpost/JournalpostService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/journalpost/JournalpostService.kt
@@ -21,8 +21,7 @@ class JournalpostService @Autowired constructor(private val safRestClient: SafRe
         return safRestClient.hentJournalpost(journalpostId)
     }
 
-    fun hentDokument(journalpostId: String, dokumentInfoId: String, variantFormat: String?): ByteArray {
-        val dokument = safHentDokumentRestClient.hentDokument(journalpostId, dokumentInfoId, variantFormat)
-        return dokument
+    fun hentDokument(journalpostId: String, dokumentInfoId: String, variantFormat: String): ByteArray {
+        return safHentDokumentRestClient.hentDokument(journalpostId, dokumentInfoId, variantFormat)
     }
 }

--- a/src/main/java/no/nav/familie/integrasjoner/journalpost/JournalpostService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/journalpost/JournalpostService.kt
@@ -18,4 +18,9 @@ class JournalpostService @Autowired constructor(private val safRestClient: SafRe
     fun hentJournalpost(journalpostId: String): Journalpost {
         return safRestClient.hentJournalpost(journalpostId)
     }
+
+    fun hentDokument(journalpostId: String, dokumentInfoId: String, variantFormat: String?): ByteArray {
+        val dokument = safRestClient.hentDokument(journalpostId, dokumentInfoId, variantFormat)
+        return dokument
+    }
 }

--- a/src/main/java/no/nav/familie/integrasjoner/journalpost/JournalpostService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/journalpost/JournalpostService.kt
@@ -1,12 +1,14 @@
 package no.nav.familie.integrasjoner.journalpost
 
+import no.nav.familie.integrasjoner.client.rest.SafHentDokumentRestClient
 import no.nav.familie.integrasjoner.client.rest.SafRestClient
 import no.nav.familie.integrasjoner.journalpost.domene.Journalpost
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 
 @Service
-class JournalpostService @Autowired constructor(private val safRestClient: SafRestClient) {
+class JournalpostService @Autowired constructor(private val safRestClient: SafRestClient,
+                                                private val safHentDokumentRestClient: SafHentDokumentRestClient) {
 
     fun hentSaksnummer(journalpostId: String): String? {
         val journalpost = safRestClient.hentJournalpost(journalpostId)
@@ -20,7 +22,7 @@ class JournalpostService @Autowired constructor(private val safRestClient: SafRe
     }
 
     fun hentDokument(journalpostId: String, dokumentInfoId: String, variantFormat: String?): ByteArray {
-        val dokument = safRestClient.hentDokument(journalpostId, dokumentInfoId, variantFormat)
+        val dokument = safHentDokumentRestClient.hentDokument(journalpostId, dokumentInfoId, variantFormat)
         return dokument
     }
 }

--- a/src/test/java/no/nav/familie/integrasjoner/journalpost/HentJournalpostControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/journalpost/HentJournalpostControllerTest.kt
@@ -30,7 +30,7 @@ import org.springframework.web.util.UriComponentsBuilder
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 
-@ActiveProfiles("integrasjonstest", "mock-sts")
+@ActiveProfiles("integrasjonstest", "mock-sts", "mock-oauth")
 class HentJournalpostControllerTest : OppslagSpringRunnerTest() {
 
     private val testLogger = LoggerFactory.getLogger(HentJournalpostController::class.java) as Logger
@@ -92,7 +92,6 @@ class HentJournalpostControllerTest : OppslagSpringRunnerTest() {
         Assertions.assertThat(response.body?.data?.journalstatus).isEqualTo(Journalstatus.JOURNALFOERT)
     }
 
-    @Ignore
     @Test
     fun `hent dokument skal returnere dokument og status ok`() {
         mockServerRule.client

--- a/src/test/java/no/nav/familie/integrasjoner/journalpost/HentJournalpostControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/journalpost/HentJournalpostControllerTest.kt
@@ -37,6 +37,7 @@ class HentJournalpostControllerTest : OppslagSpringRunnerTest() {
     val mockServerRule = MockServerRule(this, MOCK_SERVER_PORT)
     private lateinit var uriHentSaksnummer: String
     private lateinit var uriHentJournalpost: String
+    private lateinit var uriHentDokument: String
 
     @Before
     fun setUp() {
@@ -46,6 +47,7 @@ class HentJournalpostControllerTest : OppslagSpringRunnerTest() {
                 .queryParam("journalpostId", JOURNALPOST_ID).toUriString()
         uriHentJournalpost = UriComponentsBuilder.fromHttpUrl(localhost(JOURNALPOST_BASE_URL))
                 .queryParam("journalpostId", JOURNALPOST_ID).toUriString()
+        uriHentDokument = localhost(JOURNALPOST_BASE_URL) + "hentdokument/$JOURNALPOST_ID/$DOKUMENTINFO_ID"
     }
 
     @Test
@@ -87,6 +89,22 @@ class HentJournalpostControllerTest : OppslagSpringRunnerTest() {
         Assertions.assertThat(response.body?.status).isEqualTo(Ressurs.Status.SUKSESS)
         Assertions.assertThat(response.body?.data?.journalposttype).isEqualTo(Journalposttype.I)
         Assertions.assertThat(response.body?.data?.journalstatus).isEqualTo(Journalstatus.JOURNALFOERT)
+    }
+
+    @Test
+    fun `hent dokument skal returnere dokument og status ok`() {
+        mockServerRule.client
+            .`when`(HttpRequest.request()
+                .withMethod("GET")
+                .withPath("/rest/saf/rest/hentdokument/$JOURNALPOST_ID/$DOKUMENTINFO_ID/ARKIV")
+            )
+            .respond(HttpResponse().withBody("pdf".toByteArray()).withHeaders(Header("Content-Type", "application/pdf")))
+
+        val response: ResponseEntity<Ressurs<ByteArray>> = restTemplate.exchange(uriHentDokument,
+                                                                                   HttpMethod.GET,
+                                                                                   HttpEntity<String>(headers))
+        Assertions.assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        Assertions.assertThat(response.body?.status).isEqualTo(Ressurs.Status.SUKSESS)
     }
 
     @Test
@@ -181,6 +199,7 @@ class HentJournalpostControllerTest : OppslagSpringRunnerTest() {
     companion object {
         const val MOCK_SERVER_PORT = 18321
         const val JOURNALPOST_ID = "12345678"
+        const val DOKUMENTINFO_ID = "123456789"
         const val SAKSNUMMER = "87654321"
         const val JOURNALPOST_BASE_URL = "/api/journalpost/"
     }

--- a/src/test/java/no/nav/familie/integrasjoner/journalpost/HentJournalpostControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/journalpost/HentJournalpostControllerTest.kt
@@ -11,6 +11,7 @@ import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.test.JwtTokenGenerator
 import org.assertj.core.api.Assertions
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mockserver.junit.MockServerRule
@@ -91,6 +92,7 @@ class HentJournalpostControllerTest : OppslagSpringRunnerTest() {
         Assertions.assertThat(response.body?.data?.journalstatus).isEqualTo(Journalstatus.JOURNALFOERT)
     }
 
+    @Ignore
     @Test
     fun `hent dokument skal returnere dokument og status ok`() {
         mockServerRule.client

--- a/src/test/java/no/nav/familie/integrasjoner/journalpost/HentJournalpostControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/journalpost/HentJournalpostControllerTest.kt
@@ -11,7 +11,6 @@ import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.test.JwtTokenGenerator
 import org.assertj.core.api.Assertions
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mockserver.junit.MockServerRule


### PR DESCRIPTION
Utvider HentJournalpostController med integrasjon mot saf.hentdokument

RestTemplate-konfigurasjon som bruker accessToken i inn-request videre i ut-request