### PR TITLE
Småfikser for opprett oppgave

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,12 +23,12 @@
         <springfox.version>2.9.2</springfox.version>
         <common-java-modules.version>1.2019.11.06-15.14-6ca860e6cead</common-java-modules.version>
         <felles.version>1_20200306150159_cd278ea</felles.version>
-        <kontrakt.version>2.0_20200331150736_b142f34</kontrakt.version>
+        <kontrakt.version>2.0_20200408074716_e14d187</kontrakt.version>
         <fasterxml.version>2.10.1</fasterxml.version>
         <cxf.version>3.3.4</cxf.version>
         <token-validation-spring.version>1.1.2</token-validation-spring.version>
         <tjenestespesifikasjoner.version>1.2019.09.25-00.21-49b69f0625e0</tjenestespesifikasjoner.version>
-        <kotlin.version>1.3.61</kotlin.version>
+        <kotlin.version>1.3.71</kotlin.version>
 
         <!--suppress UnresolvedMavenProperty  Ligger som secret i github-->
         <sonar.projectKey>${SONAR_PROJECTKEY}</sonar.projectKey>

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivRestClient.kt
@@ -9,7 +9,7 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
-import org.springframework.web.client.HttpServerErrorException
+import org.springframework.web.client.HttpStatusCodeException
 import org.springframework.web.client.RestClientResponseException
 import org.springframework.web.client.RestOperations
 import org.springframework.web.util.UriComponentsBuilder
@@ -52,7 +52,7 @@ class DokarkivRestClient(@Value("\${DOKARKIV_V1_URL}") private val dokarkivUrl: 
 
     private fun oppslagExceptionVed(requestType: String, e: RuntimeException, brukerId: String?): Throwable {
         val message = "Feil ved $requestType av journalpost "
-        val sensitiveInfo = if (e is HttpServerErrorException) e.responseBodyAsString else "$message for bruker $brukerId "
+        val sensitiveInfo = if (e is HttpStatusCodeException) e.responseBodyAsString else "$message for bruker $brukerId "
         return OppslagException(message,
                                 "Dokarkiv",
                                 OppslagException.Level.MEDIUM,

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
@@ -4,7 +4,6 @@ import no.nav.familie.integrasjoner.client.rest.OppgaveRestClient
 import no.nav.familie.integrasjoner.felles.OppslagException
 import no.nav.familie.integrasjoner.felles.OppslagException.Level
 import no.nav.familie.integrasjoner.oppgave.domene.OppgaveJsonDto
-import no.nav.familie.integrasjoner.oppgave.domene.PrioritetEnum
 import no.nav.familie.integrasjoner.oppgave.domene.StatusEnum
 import no.nav.familie.kontrakter.felles.oppgave.IdentType
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
@@ -58,10 +57,12 @@ class OppgaveService constructor(private val oppgaveRestClient: OppgaveRestClien
         val oppgave = OppgaveJsonDto(
                 aktoerId = if (request.ident.type == IdentType.Aktør) request.ident.ident else null,
                 orgnr = if (request.ident.type == IdentType.Organisasjon) request.ident.ident else null,
-                behandlesAvApplikasjon = GOSYS_APP_ID,
                 saksreferanse = request.saksId,
+                //TODO oppgave-gjengen mente vi kunne sette denne til vår applikasjon, og så kan de gjøre en filtrering på sin
+                //men da må vi få applikasjonen vår inn i Felles kodeverk ellers så får vi feil: Fant ingen kode 'BA' i felles kodeverk under kodeverk 'Applikasjoner'
+//                behandlesAvApplikasjon = request.tema.fagsaksystem,
                 journalpostId = request.journalpostId,
-                prioritet = PrioritetEnum.NORM,
+                prioritet = request.prioritet.name,
                 tema = request.tema.name,
                 tildeltEnhetsnr = request.enhetsnummer,
                 behandlingstema = request.behandlingstema,
@@ -102,7 +103,6 @@ class OppgaveService constructor(private val oppgaveRestClient: OppgaveRestClien
 
     companion object {
         private val LOG = LoggerFactory.getLogger(OppgaveService::class.java)
-        private const val GOSYS_APP_ID = "FS22"
     }
 
 }

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/domene/OppgaveJsonDto.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/domene/OppgaveJsonDto.kt
@@ -31,23 +31,17 @@ data class OppgaveJsonDto(val id: Long? = null,
                           val endretAv: String? = null,
                           val ferdigstiltTidspunkt: String? = null,
                           val endretTidspunkt: String? = null,
-                          val prioritet: PrioritetEnum? = null,
+                          val prioritet: String? = null,
                           val status: StatusEnum? = null,
                           private var metadata: MutableMap<String, String>? = null)
 
 
-enum class StatusEnum(private val value: String) {
+enum class StatusEnum {
 
-    OPPRETTET("OPPRETTET"),
-    AAPNET("AAPNET"),
-    UNDER_BEHANDLING("UNDER_BEHANDLING"),
-    FERDIGSTILT("FERDIGSTILT"),
-    FEILREGISTRERT("FEILREGISTRERT");
+    OPPRETTET,
+    AAPNET,
+    UNDER_BEHANDLING,
+    FERDIGSTILT,
+    FEILREGISTRERT;
 
-}
-
-enum class PrioritetEnum(private val value: String) {
-    HOY("HOY"),
-    NORM("NORM"),
-    LAV("LAV");
 }


### PR DESCRIPTION
Fjernet FS22 fra behandlendeOppgave. Det har vært snakk om at vi skal sette vår egen applikasjon i denne, og så kan Gosys styre litt på denne, men da må vi få på plass appene våres i felles kodeverk for Applikasjoner først.

Utvidet opprettOppgave til å ta prioritet som input. Default settes til NORM, men mulighet til å overstyre. Dette for å kunne støtte caset:
_Journalføringsoppgaver har som standard påført prioritet Høy og har frist samme dag dersom overføring fra skanning/utført fordelingsoppgave er gjort før kl. 14.00. Ved overføring fra skanning/utført fordelingsoppgave etter kl. 14.00 er fristen satt til neste dag._