### PR TITLE
Service for helsesjekker

### DIFF
--- a/app-preprod.yaml
+++ b/app-preprod.yaml
@@ -10,7 +10,7 @@ spec:
   image: {{ image }}
   port: 8085
   liveness:
-    path: /internal/health
+    path: /internal/status/isAlive
     initialDelay: 30
     timeout: 5
     failureThreshold: 10

--- a/app-prod.yaml
+++ b/app-prod.yaml
@@ -10,7 +10,7 @@ spec:
   image: {{ image }}
   port: 8085
   liveness:
-    path: /internal/health
+    path: /internal/status/isAlive
     initialDelay: 30
     timeout: 5
     failureThreshold: 10

--- a/src/main/java/no/nav/familie/integrasjoner/config/ApplicationConfig.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/config/ApplicationConfig.kt
@@ -16,6 +16,7 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Import
+import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.web.client.RestOperations
 import springfox.documentation.swagger2.annotations.EnableSwagger2
 
@@ -25,6 +26,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2
 @EnableSwagger2
 @EnableJwtTokenValidation(ignore = ["org.springframework", "springfox.documentation.swagger.web.ApiResourceController"])
 @EnableOAuth2Client(cacheEnabled = true)
+@EnableScheduling
 class ApplicationConfig {
 
     private val logger = LoggerFactory.getLogger(ApplicationConfig::class.java)

--- a/src/main/java/no/nav/familie/integrasjoner/helse/TriggerHelsesjekkService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/helse/TriggerHelsesjekkService.kt
@@ -1,0 +1,26 @@
+package no.nav.familie.integrasjoner.helse
+
+import no.nav.familie.http.health.AbstractHealthIndicator
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+
+
+@Service
+class TriggerHelsesjekkService {
+    private val log: Logger = LoggerFactory.getLogger(this::class.java)
+
+    @Autowired
+    lateinit var helsesjekkerEksterneSystemer: List<AbstractHealthIndicator>
+
+    @Scheduled(fixedDelay = 30000, initialDelay = 30000)
+    fun triggerPing() {
+        log.debug("Kjører helsesjekker")
+        helsesjekkerEksterneSystemer.forEach {
+            it.health()
+        }
+    }
+
+}


### PR DESCRIPTION
Flyttet trigging av ping til en Scheduled-tjeneste. Bruker isAlive istedet hele health som trigger alle helsesjekker. Dette for å unngå nedetid, men ha mulighet til å bruke metrikker