### PR TITLE
Ta i bruk PDL for Tilgangskontroll

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.0.RELEASE</version>
+        <version>2.3.0.RELEASE</version>
     </parent>
 
     <groupId>no.nav.familie.integrasjoner</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/org.springframework.retry/spring-retry -->
         <dependency>
             <groupId>org.springframework.retry</groupId>

--- a/src/main/java/no/nav/familie/integrasjoner/felles/Tema.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/felles/Tema.kt
@@ -1,0 +1,7 @@
+package no.nav.familie.integrasjoner.felles
+
+enum class Tema {
+    KON,
+    BAR,
+    ENF
+}

--- a/src/main/java/no/nav/familie/integrasjoner/helse/TriggerHelsesjekkService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/helse/TriggerHelsesjekkService.kt
@@ -4,11 +4,13 @@ import no.nav.familie.http.health.AbstractHealthIndicator
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Profile
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 
 
 @Service
+@Profile("!dev")
 class TriggerHelsesjekkService {
     private val log: Logger = LoggerFactory.getLogger(this::class.java)
 

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerController.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.integrasjoner.personopplysning
 
 import no.nav.familie.integrasjoner.client.rest.PersonInfoQuery
+import no.nav.familie.integrasjoner.felles.Tema
 import no.nav.familie.integrasjoner.personopplysning.domene.PersonhistorikkInfo
 import no.nav.familie.integrasjoner.personopplysning.domene.Personinfo
 import no.nav.familie.integrasjoner.personopplysning.internal.IdentInformasjon
@@ -110,12 +111,5 @@ class PersonopplysningerController(private val personopplysningerService: Person
                             @PathVariable tema: Tema): ResponseEntity<Ressurs<List<Statsborgerskap>>> = ResponseEntity.ok()
             .body(success(personopplysningerService.hentStatsborgerskap(ident.ident, tema.toString()),
                           "Hent statsborgerskap OK"))
-
-
-    enum class Tema {
-        KON,
-        BAR,
-        ENF
-    }
 
 }

--- a/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollService.kt
@@ -3,6 +3,7 @@ package no.nav.familie.integrasjoner.tilgangskontroll
 import no.nav.familie.integrasjoner.client.rest.PersonInfoQuery
 import no.nav.familie.integrasjoner.config.TilgangConfig
 import no.nav.familie.integrasjoner.egenansatt.EgenAnsattService
+import no.nav.familie.integrasjoner.felles.Tema
 import no.nav.familie.integrasjoner.personopplysning.PersonopplysningerService
 import no.nav.familie.integrasjoner.personopplysning.internal.ADRESSEBESKYTTELSEGRADERING
 import no.nav.familie.integrasjoner.tilgangskontroll.domene.AdRolle
@@ -20,8 +21,8 @@ class CachedTilgangskontrollService(private val egenAnsattService: EgenAnsattSer
     @Cacheable(cacheNames = [TILGANG_TIL_BRUKER],
                key = "#jwtToken.subject.concat(#personIdent)",
                condition = "#personIdent != null && #jwtToken.subject != null")
-    fun sjekkTilgang(personIdent: String, jwtToken: JwtToken): Tilgang {
-        val personInfo = personopplysningerService.hentPersoninfo(personIdent, "BAR", PersonInfoQuery.ENKEL)
+    fun sjekkTilgang(personIdent: String, jwtToken: JwtToken, tema: Tema): Tilgang {
+        val personInfo = personopplysningerService.hentPersoninfo(personIdent, tema.toString(), PersonInfoQuery.ENKEL)
         val adressebeskyttelse = personInfo.adressebeskyttelseGradering
 
         if (egenAnsattService.erEgenAnsatt(personIdent)) {

--- a/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollService.kt
@@ -1,8 +1,10 @@
 package no.nav.familie.integrasjoner.tilgangskontroll
 
+import no.nav.familie.integrasjoner.client.rest.PersonInfoQuery
 import no.nav.familie.integrasjoner.config.TilgangConfig
 import no.nav.familie.integrasjoner.egenansatt.EgenAnsattService
 import no.nav.familie.integrasjoner.personopplysning.PersonopplysningerService
+import no.nav.familie.integrasjoner.personopplysning.internal.ADRESSEBESKYTTELSEGRADERING
 import no.nav.familie.integrasjoner.tilgangskontroll.domene.AdRolle
 import no.nav.familie.kontrakter.felles.tilgangskontroll.Tilgang
 import no.nav.security.token.support.core.jwt.JwtToken
@@ -19,21 +21,22 @@ class CachedTilgangskontrollService(private val egenAnsattService: EgenAnsattSer
                key = "#jwtToken.subject.concat(#personIdent)",
                condition = "#personIdent != null && #jwtToken.subject != null")
     fun sjekkTilgang(personIdent: String, jwtToken: JwtToken): Tilgang {
-        val personInfo = personopplysningerService.hentPersoninfo(personIdent)
-        val diskresjonskode = personInfo.diskresjonskode
-
-        if (DISKRESJONSKODE_KODE6 == diskresjonskode) {
-            return hentTilgangForRolle(tilgangConfig.grupper["kode6"], jwtToken, personIdent)
-        }
-
-        if (DISKRESJONSKODE_KODE7 == diskresjonskode) {
-            return hentTilgangForRolle(tilgangConfig.grupper["kode7"], jwtToken, personIdent)
-        }
+        val personInfo = personopplysningerService.hentPersoninfo(personIdent, "BAR", PersonInfoQuery.ENKEL)
+        val adressebeskyttelse = personInfo.adressebeskyttelseGradering
 
         if (egenAnsattService.erEgenAnsatt(personIdent)) {
             return hentTilgangForRolle(tilgangConfig.grupper["utvidetTilgang"], jwtToken, personIdent)
         }
-        return Tilgang(true)
+
+        return when (adressebeskyttelse) {
+            ADRESSEBESKYTTELSEGRADERING.FORTROLIG -> hentTilgangForRolle(tilgangConfig.grupper["kode7"], jwtToken, personIdent)
+            ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG, ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG_UTLAND ->
+                hentTilgangForRolle(
+                    tilgangConfig.grupper["kode6"],
+                    jwtToken,
+                    personIdent)
+            else -> Tilgang(true)
+        }
     }
 
     private fun hentTilgangForRolle(adRolle: AdRolle?, jwtToken: JwtToken, personIdent: String): Tilgang {
@@ -50,7 +53,5 @@ class CachedTilgangskontrollService(private val egenAnsattService: EgenAnsattSer
         private val secureLogger = LoggerFactory.getLogger("secureLogger")
 
         const val TILGANG_TIL_BRUKER = "tilgangTilBruker"
-        const val DISKRESJONSKODE_KODE6 = "SPSF"
-        const val DISKRESJONSKODE_KODE7 = "SPFO"
     }
 }

--- a/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/TilgangskontrollController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/TilgangskontrollController.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.integrasjoner.tilgangskontroll
 
+import no.nav.familie.integrasjoner.felles.Tema
 import no.nav.familie.kontrakter.felles.tilgangskontroll.Tilgang
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.context.annotation.Profile
@@ -20,5 +21,17 @@ class TilgangskontrollController(private val tilgangskontrollService: Tilgangsko
     @ProtectedWithClaims(issuer = "azuread")
     fun tilgangTilPersoner(@RequestBody personIdenter: List<String>): List<Tilgang> {
         return tilgangskontrollService.sjekkTilgangTilBrukere(personIdenter)
+    }
+
+    @GetMapping(path = ["/v2/person"])
+    @ProtectedWithClaims(issuer = "azuread")
+    fun tilgangTilPerson(@RequestHeader(name = "Nav-Personident") personIdent: String, @RequestHeader(name = "Nav-Tema") tema: Tema): Tilgang {
+        return tilgangskontrollService.sjekkTilgangTilBruker(personIdent, tema)
+    }
+
+    @PostMapping(path = ["/v2/personer"])
+    @ProtectedWithClaims(issuer = "azuread")
+    fun tilgangTilPersoner(@RequestBody personIdenter: List<String>, @RequestHeader(name = "Nav-Tema") tema: Tema): List<Tilgang> {
+        return tilgangskontrollService.sjekkTilgangTilBrukere(personIdenter, tema)
     }
 }

--- a/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/TilgangskontrollService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/TilgangskontrollService.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.integrasjoner.tilgangskontroll
 
+import no.nav.familie.integrasjoner.felles.Tema
 import no.nav.familie.kontrakter.felles.tilgangskontroll.Tilgang
 import no.nav.security.token.support.core.jwt.JwtToken
 import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
@@ -8,17 +9,17 @@ import org.springframework.stereotype.Service
 @Service
 class TilgangskontrollService(private val cachedTilgangskontrollService: CachedTilgangskontrollService) {
 
-    fun sjekkTilgangTilBrukere(personIdenter: List<String>): List<Tilgang> {
-        return personIdenter.map(this::sjekkTilgangTilBruker)
+    fun sjekkTilgangTilBrukere(personIdenter: List<String>, tema: Tema = Tema.BAR): List<Tilgang> {
+        return personIdenter.map { ident -> sjekkTilgangTilBruker(ident, tema) }
     }
 
-    fun sjekkTilgangTilBruker(personIdent: String): Tilgang {
+    fun sjekkTilgangTilBruker(personIdent: String, tema: Tema = Tema.BAR): Tilgang {
         val jwtToken = SpringTokenValidationContextHolder().tokenValidationContext.getJwtToken("azuread")
-        return cachedTilgangskontrollService.sjekkTilgang(personIdent, jwtToken)
+        return cachedTilgangskontrollService.sjekkTilgang(personIdent, jwtToken, tema)
     }
 
-    fun sjekkTilgang(personIdent: String, jwtToken: JwtToken): Tilgang {
-        return cachedTilgangskontrollService.sjekkTilgang(personIdent, jwtToken)
+    fun sjekkTilgang(personIdent: String, jwtToken: JwtToken, tema: Tema = Tema.BAR): Tilgang {
+        return cachedTilgangskontrollService.sjekkTilgang(personIdent, jwtToken, tema)
     }
 
 }

--- a/src/test/java/no/nav/familie/integrasjoner/dokdist/DokdistControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/dokdist/DokdistControllerTest.kt
@@ -77,7 +77,9 @@ class DokdistControllerTest : OppslagSpringRunnerTest() {
                 .`when`(HttpRequest.request()
                                 .withMethod("POST")
                                 .withPath("/rest/v1/distribuerjournalpost"))
-                .respond(HttpResponse.response().withStatusCode(400).withBody(badRequestResponse()))
+                .respond(HttpResponse.response().withStatusCode(400)
+                                 .withHeader("Content-Type", "application/json; charset=utf-8")
+                                 .withBody(badRequestResponse()))
 
         val body = DistribuerJournalpostRequest(JOURNALPOST_ID, "IT", "ba-sak")
         val response: ResponseEntity<Ressurs<String>> = restTemplate.exchange(localhost(DOKDIST_URL),
@@ -91,8 +93,7 @@ class DokdistControllerTest : OppslagSpringRunnerTest() {
     }
 
     @Throws(IOException::class) private fun badRequestResponse(): String {
-        return Files.readString(ClassPathResource("dokdist/badrequest.json").file.toPath(),
-                                StandardCharsets.UTF_8)
+        return Files.readString(ClassPathResource("dokdist/badrequest.json").file.toPath(), StandardCharsets.UTF_8)
     }
 
     companion object {

--- a/src/test/java/no/nav/familie/integrasjoner/tilgangskontroll/TilgangskontrollServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/tilgangskontroll/TilgangskontrollServiceTest.kt
@@ -5,7 +5,6 @@ import io.mockk.mockk
 import no.nav.familie.integrasjoner.config.TilgangConfig
 import no.nav.familie.integrasjoner.egenansatt.EgenAnsattService
 import no.nav.familie.integrasjoner.personopplysning.PersonopplysningerService
-import no.nav.familie.integrasjoner.personopplysning.domene.PersonIdent
 import no.nav.familie.integrasjoner.personopplysning.internal.ADRESSEBESKYTTELSEGRADERING
 import no.nav.familie.integrasjoner.personopplysning.internal.Person
 import no.nav.familie.integrasjoner.tilgangskontroll.domene.AdRolle
@@ -72,7 +71,7 @@ class TilgangskontrollServiceTest {
                 .returns(false)
         every { tilgangConfig.grupper["utvidetTilgang"] }
                 .returns(AdRolle("8796", "NAV-Ansatt"))
-        every { personopplysningerService.hentPersoninfo("123", "BAR", any()) }
+        every { personopplysningerService.hentPersoninfo("123", any(), any()) }
                 .returns(personMedAdressebeskyttelse(null))
 
         assertThat(tilgangskontrollService.sjekkTilgang("123",
@@ -92,7 +91,7 @@ class TilgangskontrollServiceTest {
                 .returns(listOf("id1"))
         every { jwtTokenClaims.get("preferred_username") }
                 .returns(listOf("bob"))
-        every { personopplysningerService.hentPersoninfo("123", "BAR", any()) }
+        every { personopplysningerService.hentPersoninfo("123", any(), any()) }
                 .returns(personMedAdressebeskyttelse(ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG))
 
         assertThat(tilgangskontrollService.sjekkTilgang("123",
@@ -112,7 +111,7 @@ class TilgangskontrollServiceTest {
                 .returns(listOf("id1"))
         every { jwtTokenClaims.get("preferred_username") }
                 .returns(listOf("bob"))
-        every { personopplysningerService.hentPersoninfo("123", "BAR", any()) }
+        every { personopplysningerService.hentPersoninfo("123", any(), any()) }
                 .returns(personMedAdressebeskyttelse(ADRESSEBESKYTTELSEGRADERING.FORTROLIG))
 
         assertThat(tilgangskontrollService.sjekkTilgang("123",
@@ -130,7 +129,7 @@ class TilgangskontrollServiceTest {
                 .returns(listOf("bob"))
         every { jwtTokenClaims.getAsList(any()) }
                 .returns(listOf("8796"))
-        every { personopplysningerService.hentPersoninfo("123", "BAR", any()) }
+        every { personopplysningerService.hentPersoninfo("123", any(), any()) }
                 .returns(personMedAdressebeskyttelse(ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG))
         every { tilgangConfig.grupper["kode6"] }
                 .returns(AdRolle("8796", "Strengt fortrolig adresse"))
@@ -150,7 +149,7 @@ class TilgangskontrollServiceTest {
                 .returns(listOf("bob"))
         every { jwtTokenClaims.getAsList(any()) }
                 .returns(listOf("8796"))
-        every { personopplysningerService.hentPersoninfo("123", "BAR", any()) }
+        every { personopplysningerService.hentPersoninfo("123", any(), any()) }
                 .returns(personMedAdressebeskyttelse(ADRESSEBESKYTTELSEGRADERING.FORTROLIG))
         every { tilgangConfig.grupper["kode7"] }
                 .returns(AdRolle("8796", "Fortrolig adresse"))
@@ -161,17 +160,11 @@ class TilgangskontrollServiceTest {
     }
 
     private fun personMedAdressebeskyttelse(adressebeskyttelsegradering: ADRESSEBESKYTTELSEGRADERING?): Person {
-        return Person(navn = NAVN,
+        return Person(navn = "Navn Navnesen",
                       fødselsdato = "1980-01-01",
                       kjønn = "KVINNE",
                       familierelasjoner = emptySet(),
                       adressebeskyttelseGradering = adressebeskyttelsegradering,
                       sivilstand = SIVILSTAND.UGIFT)
-    }
-
-    companion object {
-        private const val NAVN = "Navn Navnesen"
-        private const val FNR = "fnr"
-        private val PERSON_IDENT = PersonIdent(FNR)
     }
 }


### PR DESCRIPTION
Hadde en plan om å fjerne all intern bruk av TPS i familie-integrasjoner. ArbeidsfordelingService trenger imidlertid geografisk tilknytning på bruker, og det er ikke klart fra PDL sin side helt enda (ref https://navikt.github.io/pdl/#_geografisk_tilh%C3%B8righet_gt). 

Lager likevel en PR på bruk av PDL i TilgangskontrollService. I tillegg er det litt div rydd og oppdateringer her fordi jeg sleit veldig med å kjøre opp familie-integrasjoner på min mac med java 14. Så jeg bumpet like gjerne spring boot fra 2.2.0 til 2.3.0 🤡 