### PR TITLE
Legg til metadata for manuelt brev Innhente opplysninger

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdInnhenteOpplysningerMetadata.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdInnhenteOpplysningerMetadata.kt
@@ -1,0 +1,20 @@
+package no.nav.familie.integrasjoner.dokarkiv.metadata
+
+import no.nav.familie.integrasjoner.dokarkiv.client.domene.JournalpostType
+import org.springframework.stereotype.Component
+
+@Component
+object BarnetrygdInnhenteOpplysningerMetadata : DokumentMetadata {
+
+    override val journalpostType: JournalpostType = JournalpostType.UTGAAENDE
+    override val fagsakSystem: String? = "BA"
+    override val tema: String = "BAR"
+    override val behandlingstema: String? = null
+    override val kanal: String? = null
+    override val dokumentTypeId: String = "BARNETRYGD_INNHENTE_OPPLYSNINGER"
+    override val tittel: String? = null
+    override val brevkode: String? = null
+    override val dokumentKategori: String = "VB"
+
+
+}

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdInnhenteOpplysningerMetadata.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdInnhenteOpplysningerMetadata.kt
@@ -14,7 +14,7 @@ object BarnetrygdInnhenteOpplysningerMetadata : DokumentMetadata {
     override val dokumentTypeId: String = "BARNETRYGD_INNHENTE_OPPLYSNINGER"
     override val tittel: String? = "Brev for innhenting av opplysninger"
     override val brevkode: String? = "innhente-opplysninger"
-    override val dokumentKategori: String = ""
+    override val dokumentKategori: String = "B"
 
 
 }

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdInnhenteOpplysningerMetadata.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdInnhenteOpplysningerMetadata.kt
@@ -12,9 +12,9 @@ object BarnetrygdInnhenteOpplysningerMetadata : DokumentMetadata {
     override val behandlingstema: String? = null
     override val kanal: String? = null
     override val dokumentTypeId: String = "BARNETRYGD_INNHENTE_OPPLYSNINGER"
-    override val tittel: String? = null
-    override val brevkode: String? = null
-    override val dokumentKategori: String = "VB"
+    override val tittel: String? = "Brev for innhenting av opplysninger"
+    override val brevkode: String? = "innhente-opplysninger"
+    override val dokumentKategori: String = ""
 
 
 }

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdVedtakMetadata.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdVedtakMetadata.kt
@@ -14,7 +14,7 @@ object BarnetrygdVedtakMetadata : DokumentMetadata {
     override val kanal: String? = ""
     override val dokumentTypeId: String = "BARNETRYGD_VEDTAK"
     override val tittel: String? = "Vedtak om innvilgelse av barnetrygd"
-    override val brevkode: String? = "BAA1"
+    override val brevkode: String? = "innvilget"
     override val dokumentKategori: String = "VB"
 
 }

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdVedtakMetadata.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdVedtakMetadata.kt
@@ -14,7 +14,7 @@ object BarnetrygdVedtakMetadata : DokumentMetadata {
     override val kanal: String? = ""
     override val dokumentTypeId: String = "BARNETRYGD_VEDTAK"
     override val tittel: String? = "Vedtak om innvilgelse av barnetrygd"
-    override val brevkode: String? = "innvilget"
+    override val brevkode: String? = "BAA1"
     override val dokumentKategori: String = "VB"
 
 }


### PR DESCRIPTION
Jeg er veldig usikker på om dette er tilstrekkelig, så ønsker gjerne tilbakemelding på om noe mangler og hvor jeg evt kan finne dette.

Utenom `dokumentTypeId ` er det identisk med metadata for vedlegget til vedtaksbrevet. Til sammenligning ser vedtaksbrevet slik ut:
`object BarnetrygdVedtakMetadata : DokumentMetadata {

    override val journalpostType: JournalpostType = JournalpostType.UTGAAENDE
    override val fagsakSystem: String? = "BA"
    override val tema: String = "BAR"
    override val behandlingstema: String? = Behandlingstema.Barnetrygd.value // https://confluence.adeo.no/display/BOA/Behandlingstema
    override val kanal: String? = ""
    override val dokumentTypeId: String = "BARNETRYGD_VEDTAK"
    override val tittel: String? = "Vedtak om innvilgelse av barnetrygd"
    override val brevkode: String? = "BAA1"
    override val dokumentKategori: String = "VB"

}`