### PR TITLE
Legg til v2-endepunkt for opprettoppgave

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <springfox.version>2.9.2</springfox.version>
         <common-java-modules.version>1.2019.11.06-15.14-6ca860e6cead</common-java-modules.version>
         <felles.version>1.20200429152039_3c601a5</felles.version>
-        <kontrakt.version>2.0_20200810084454_e1f6fb2</kontrakt.version>
+        <kontrakt.version>2.0_20200909120521_6da9031</kontrakt.version>
         <fasterxml.version>2.10.1</fasterxml.version>
         <cxf.version>3.3.4</cxf.version>
         <token-validation-spring.version>1.1.2</token-validation-spring.version>

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/OppgaveRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/OppgaveRestClient.kt
@@ -56,14 +56,15 @@ class OppgaveRestClient(@Value("\${OPPGAVE_URL}") private val oppgaveBaseUrl: UR
         return getForEntity(requestUrl(oppgaveId.toLong()), httpHeaders())
     }
 
+    @Deprecated("Bruk finnOppgaver med FinnOppgaveRequest")
     fun finnOppgaver(tema: String,
                      behandlingstema: String?,
                      oppgavetype: String?,
                      tildeltEnhetsnr: String?,
                      tilordnetRessurs: String?,
-                     journalpostId: String?): List<Oppgave> {
+                     journalpostId: String?): List<DeprecatedOppgave> {
 
-        tailrec fun finnAlleOppgaver(oppgaver: List<Oppgave> = listOf()): List<Oppgave> {
+        tailrec fun finnAlleOppgaver(oppgaver: List<DeprecatedOppgave> = listOf()): List<DeprecatedOppgave> {
             val limit = 50
 
             val uriBuilder = UriComponentsBuilder.fromUri(oppgaveBaseUrl)
@@ -84,7 +85,7 @@ class OppgaveRestClient(@Value("\${OPPGAVE_URL}") private val oppgaveBaseUrl: UR
                     .build()
                     .toUri()
 
-            val finnOppgaveResponseDto = getForEntity<FinnOppgaveResponseDto>(uri, httpHeaders())
+            val finnOppgaveResponseDto = getForEntity<DeprecatedFinnOppgaveResponseDto>(uri, httpHeaders())
             val nyeOppgaver = oppgaver + finnOppgaveResponseDto.oppgaver
 
             return when (nyeOppgaver.size < finnOppgaveResponseDto.antallTreffTotalt) {
@@ -96,7 +97,7 @@ class OppgaveRestClient(@Value("\${OPPGAVE_URL}") private val oppgaveBaseUrl: UR
         return finnAlleOppgaver()
     }
 
-    fun finnOppgaverV2(deprecatedFinnOppgaveRequest: DeprecatedFinnOppgaveRequest): FinnOppgaveResponseDto {
+    fun finnOppgaverV2(deprecatedFinnOppgaveRequest: DeprecatedFinnOppgaveRequest): DeprecatedFinnOppgaveResponseDto {
 
         val limitMotOppgave = 50
 
@@ -132,20 +133,20 @@ class OppgaveRestClient(@Value("\${OPPGAVE_URL}") private val oppgaveBaseUrl: UR
         }
 
         var offset = deprecatedFinnOppgaveRequest.offset ?: 0
-        val oppgaverOgAntall = getForEntity<FinnOppgaveResponseDto>(uriMotOppgave(offset), httpHeaders())
-        val oppgaver: MutableList<Oppgave> = oppgaverOgAntall.oppgaver.toMutableList()
+        val oppgaverOgAntall = getForEntity<DeprecatedFinnOppgaveResponseDto>(uriMotOppgave(offset), httpHeaders())
+        val oppgaver: MutableList<DeprecatedOppgave> = oppgaverOgAntall.oppgaver.toMutableList()
         val grense =
                 if (deprecatedFinnOppgaveRequest.limit == null) oppgaverOgAntall.antallTreffTotalt
                 else offset + deprecatedFinnOppgaveRequest.limit
         offset += limitMotOppgave
 
         while (offset < grense) {
-            val nyeOppgaver = getForEntity<FinnOppgaveResponseDto>(uriMotOppgave(offset), httpHeaders())
+            val nyeOppgaver = getForEntity<DeprecatedFinnOppgaveResponseDto>(uriMotOppgave(offset), httpHeaders())
             oppgaver.addAll(nyeOppgaver.oppgaver)
             offset += limitMotOppgave
         }
 
-        return FinnOppgaveResponseDto(oppgaverOgAntall.antallTreffTotalt, oppgaver)
+        return DeprecatedFinnOppgaveResponseDto(oppgaverOgAntall.antallTreffTotalt, oppgaver)
     }
 
     @Deprecated("Bruk finnOppgaver")
@@ -181,8 +182,6 @@ class OppgaveRestClient(@Value("\${OPPGAVE_URL}") private val oppgaveBaseUrl: UR
                     .queryParams(oppgaveRequest.toQueryParams())
                     .build()
                     .toUri()
-
-
 
     fun finnOppgaver(finnOppgaveRequest: FinnOppgaveRequest): FinnOppgaveResponseDto {
 

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
@@ -81,7 +81,15 @@ class OppgaveController(private val oppgaveService: OppgaveService) {
     }
 
     @PostMapping(consumes = [MediaType.APPLICATION_JSON_VALUE])
-    fun opprettOppgave(@RequestBody oppgave: OpprettOppgave): ResponseEntity<Ressurs<OppgaveResponse>> {
+    @Deprecated("Bruk v2-endepunkt")
+    fun opprettOppgaveV1(@RequestBody oppgave: OpprettOppgave): ResponseEntity<Ressurs<OppgaveResponse>> {
+        val oppgaveId = oppgaveService.opprettOppgaveV1(oppgave)
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(success(OppgaveResponse(oppgaveId = oppgaveId), "Opprett oppgave OK"))
+    }
+
+    @PostMapping(consumes = [MediaType.APPLICATION_JSON_VALUE], path = ["/v2"])
+    fun opprettOppgaveV2(@RequestBody oppgave: OpprettOppgaveRequest): ResponseEntity<Ressurs<OppgaveResponse>> {
         val oppgaveId = oppgaveService.opprettOppgave(oppgave)
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(success(OppgaveResponse(oppgaveId = oppgaveId), "Opprett oppgave OK"))

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
@@ -32,7 +32,7 @@ class OppgaveController(private val oppgaveService: OppgaveService) {
                      @RequestParam("enhet", required = false) enhet: String?,
                      @RequestParam("saksbehandler", required = false) saksbehandler: String?,
                      @RequestParam("journalpostId", required = false) journalpostId: String?)
-            : ResponseEntity<Ressurs<List<Oppgave>>> {
+            : ResponseEntity<Ressurs<List<DeprecatedOppgave>>> {
         val oppgaver = oppgaveService.finnOppgaver(tema,
                                                    behandlingstema,
                                                    oppgavetype,
@@ -45,7 +45,7 @@ class OppgaveController(private val oppgaveService: OppgaveService) {
     @PostMapping(path = ["/v2"], consumes = [MediaType.APPLICATION_JSON_VALUE], produces = [MediaType.APPLICATION_JSON_VALUE])
     @Deprecated("Bruk v3 endepunktet")
     fun finnOppgaverV2(@RequestBody deprecatedFinnOppgaveRequest: DeprecatedFinnOppgaveRequest)
-            : ResponseEntity<Ressurs<FinnOppgaveResponseDto>> {
+            : ResponseEntity<Ressurs<DeprecatedFinnOppgaveResponseDto>> {
         return when (deprecatedFinnOppgaveRequest.tema) {
             null -> ResponseEntity.ok().body(Ressurs.failure("påkrevd felt 'tema' mangler"))
             else -> ResponseEntity.ok()

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.integrasjoner.oppgave
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.Ressurs.Companion.success
 import no.nav.familie.kontrakter.felles.oppgave.*
@@ -9,6 +10,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+import javax.validation.constraints.Pattern
 
 @RestController
 @ProtectedWithClaims(issuer = "azuread")
@@ -52,7 +54,13 @@ class OppgaveController(private val oppgaveService: OppgaveService) {
     }
 
     @GetMapping(path = ["/v3"])
-    fun finnOppgaverV3(finnOppgaveRequest: FinnOppgaveRequest): Ressurs<FinnOppgaveResponseDto> {
+    @Deprecated("Bruk v4 endepunktet")
+    fun finnOppgaverV3(finnOppgaveRequest: FinnOppgaveRequest): Ressurs<DeprecatedFinnOppgaveResponseDto> {
+        return success(oppgaveService.finnOppgaverV3(finnOppgaveRequest))
+    }
+
+    @GetMapping(path = ["/v4"])
+    fun finnOppgaverV4(finnOppgaveRequest: FinnOppgaveRequest): Ressurs<FinnOppgaveResponseDto> {
         return success(oppgaveService.finnOppgaver(finnOppgaveRequest))
     }
 
@@ -118,3 +126,43 @@ class DeprecatedFinnOppgaveRequest(val tema: String? = null,
                                    val aktivTomDato: String? = null,
                                    val limit: Long? = null,
                                    val offset: Long? = null)
+
+@Deprecated("Benytt kontrakt")
+data class DeprecatedFinnOppgaveResponseDto(val antallTreffTotalt: Long,
+                                            val oppgaver: List<DeprecatedOppgave>)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Deprecated("Benytt kontrakt")
+data class DeprecatedOppgave(val id: Long? = null,
+                             val tildeltEnhetsnr: String? = null,
+                             val endretAvEnhetsnr: String? = null,
+                             val eksisterendeOppgaveId: String? = null,
+                             val opprettetAvEnhetsnr: String? = null,
+                             val journalpostId: String? = null,
+                             val journalpostkilde: String? = null,
+                             val behandlesAvApplikasjon: String? = null,
+                             val saksreferanse: String? = null,
+                             val bnr: String? = null,
+                             val samhandlernr: String? = null,
+                             @field:Pattern(regexp = "[0-9]{13}")
+                             val aktoerId: String? = null,
+                             val orgnr: String? = null,
+                             val tilordnetRessurs: String? = null,
+                             val beskrivelse: String? = null,
+                             val temagruppe: String? = null,
+                             val tema: Tema? = null,
+                             val behandlingstema: String? = null,
+                             val oppgavetype: String? = null,
+                             val behandlingstype: String? = null,
+                             val versjon: Int? = null,
+                             val mappeId: Long? = null,
+                             val fristFerdigstillelse: String? = null,
+                             val aktivDato: String? = null,
+                             val opprettetTidspunkt: String? = null,
+                             val opprettetAv: String? = null,
+                             val endretAv: String? = null,
+                             val ferdigstiltTidspunkt: String? = null,
+                             val endretTidspunkt: String? = null,
+                             val prioritet: OppgavePrioritet? = null,
+                             val status: StatusEnum? = null,
+                             private var metadata: MutableMap<String, String>? = null)

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.context.annotation.ApplicationScope
 import java.time.format.DateTimeFormatter
+import javax.validation.constraints.Pattern
 
 @Service @ApplicationScope
 class OppgaveService constructor(private val oppgaveRestClient: OppgaveRestClient) {
@@ -27,8 +28,14 @@ class OppgaveService constructor(private val oppgaveRestClient: OppgaveRestClien
         return oppgaveRestClient.finnOppgaver(finnOppgaveRequest)
     }
 
+    @Deprecated("Bruk finnOppgaver")
     fun finnOppgaverV2(deprecatedFinnOppgaveRequest: DeprecatedFinnOppgaveRequest): FinnOppgaveResponseDto {
         return oppgaveRestClient.finnOppgaverV2(deprecatedFinnOppgaveRequest)
+    }
+
+    @Deprecated("Bruk finnOppgaver")
+    fun finnOppgaverV3(finnOppgaveRequest: FinnOppgaveRequest): DeprecatedFinnOppgaveResponseDto {
+        return oppgaveRestClient.finnOppgaverV3(finnOppgaveRequest)
     }
 
     fun hentOppgave(oppgaveId: String): Oppgave {

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
@@ -88,7 +88,8 @@ class OppgaveService constructor(private val oppgaveRestClient: OppgaveRestClien
         return oppgave.id!!
     }
 
-    fun opprettOppgave(request: OpprettOppgave): Long {
+    @Deprecated("Bruk v2")
+    fun opprettOppgaveV1(request: OpprettOppgave): Long {
         val oppgave = Oppgave(
                 aktoerId = if (request.ident?.type == IdentType.Aktør) request.ident!!.ident else null,
                 orgnr = if (request.ident?.type == IdentType.Organisasjon) request.ident!!.ident else null,
@@ -97,6 +98,27 @@ class OppgaveService constructor(private val oppgaveRestClient: OppgaveRestClien
                 //men da må vi få applikasjonen vår inn i Felles kodeverk ellers så får vi feil: Fant ingen kode 'BA' i felles
                 // kodeverk under kodeverk 'Applikasjoner'
                 // behandlesAvApplikasjon = request.tema.fagsaksystem,
+                journalpostId = request.journalpostId,
+                prioritet = request.prioritet,
+                tema = request.tema,
+                tildeltEnhetsnr = request.enhetsnummer,
+                behandlingstema = request.behandlingstema,
+                fristFerdigstillelse = request.fristFerdigstillelse.format(DateTimeFormatter.ISO_DATE),
+                aktivDato = request.aktivFra.format(DateTimeFormatter.ISO_DATE),
+                oppgavetype = request.oppgavetype.value,
+                beskrivelse = request.beskrivelse,
+                eksisterendeOppgaveId = null,
+                behandlingstype = request.behandlingstype
+        )
+
+        return oppgaveRestClient.opprettOppgave(oppgave)
+    }
+
+    fun opprettOppgave(request: OpprettOppgaveRequest): Long {
+        val oppgave = Oppgave(
+                aktoerId = if (request.ident?.gruppe == IdentGruppe.AKTOERID) request.ident!!.ident else null,
+                orgnr = if (request.ident?.gruppe == IdentGruppe.ORGNR) request.ident!!.ident else null,
+                saksreferanse = request.saksId,
                 journalpostId = request.journalpostId,
                 prioritet = request.prioritet,
                 tema = request.tema,

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
@@ -10,17 +10,17 @@ import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.context.annotation.ApplicationScope
 import java.time.format.DateTimeFormatter
-import javax.validation.constraints.Pattern
 
 @Service @ApplicationScope
 class OppgaveService constructor(private val oppgaveRestClient: OppgaveRestClient) {
 
+    @Deprecated("Bruk finnOppgaver med FinnOppgaveRequest")
     fun finnOppgaver(tema: String,
                      behandlingstema: String?,
                      oppgaveType: String?,
                      enhet: String?,
                      saksbehandler: String?,
-                     journalpostId: String?): List<Oppgave> {
+                     journalpostId: String?): List<DeprecatedOppgave> {
         return oppgaveRestClient.finnOppgaver(tema, behandlingstema, oppgaveType, enhet, saksbehandler, journalpostId)
     }
 
@@ -29,7 +29,7 @@ class OppgaveService constructor(private val oppgaveRestClient: OppgaveRestClien
     }
 
     @Deprecated("Bruk finnOppgaver")
-    fun finnOppgaverV2(deprecatedFinnOppgaveRequest: DeprecatedFinnOppgaveRequest): FinnOppgaveResponseDto {
+    fun finnOppgaverV2(deprecatedFinnOppgaveRequest: DeprecatedFinnOppgaveRequest): DeprecatedFinnOppgaveResponseDto {
         return oppgaveRestClient.finnOppgaverV2(deprecatedFinnOppgaveRequest)
     }
 
@@ -95,7 +95,7 @@ class OppgaveService constructor(private val oppgaveRestClient: OppgaveRestClien
         return oppgave.id!!
     }
 
-    @Deprecated("Bruk v2")
+    @Deprecated("Bruk opprettOppgave")
     fun opprettOppgaveV1(request: OpprettOppgave): Long {
         val oppgave = Oppgave(
                 aktoerId = if (request.ident?.type == IdentType.Aktør) request.ident!!.ident else null,


### PR DESCRIPTION
Legg til endepunkt som tar i mot OpprettOppgaveRequest, i stedet for OpprettOppgave. Forskjellen på requestene er formatet på ident, som er oppdatert etter oppdatering hos Oppgave. 

Se fullstendige kontrakt-endringer her: https://github.com/navikt/familie-kontrakter/pull/177

Tester i miljø vil feile nå, oppdaterer kontrakt når den er merget.