### PR TITLE
Ta i bruk PDL for å hente diskresjonskode og geografisk tilknytning ved hent av arbeidsenhet

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/arbeidsfordeling/ArbeidsfordelingService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/arbeidsfordeling/ArbeidsfordelingService.kt
@@ -17,15 +17,21 @@ class ArbeidsfordelingService(
     fun finnBehandlendeEnhetForPerson(personIdent: String, tema: String): List<ArbeidsfordelingClient.Enhet> {
 
         val behandlendeEnhetData = pdlRestClient.hentBehandlendeEnhetData(personIdent, tema)
-        val geografiskTilknytning = behandlendeEnhetData.geografiskTilknytning?.gtKommune
+        val geografiskTilknytning = behandlendeEnhetData.geografiskTilknytning.gtKommune
         val diskresjonskode = when (behandlendeEnhetData.adressebeskyttelse.firstOrNull()?.gradering) {
-            ADRESSEBESKYTTELSEGRADERING.FORTROLIG -> "7"
-            ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG -> "6"
-            ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG_UTLAND -> "6" // TODO trenger avklaring
+            ADRESSEBESKYTTELSEGRADERING.FORTROLIG -> Diskresjonskode.KODE7.kode
+            ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG -> Diskresjonskode.KODE6.kode
+            ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG_UTLAND -> Diskresjonskode.KODE6.kode
             else -> null
         }
 
         return klient.finnBehandlendeEnhet(tema, geografiskTilknytning, diskresjonskode)
+    }
+
+
+    enum class Diskresjonskode(val kode: String) {
+        KODE6("SPSF"),
+        KODE7("SPFO")
     }
 
 }

--- a/src/main/java/no/nav/familie/integrasjoner/arbeidsfordeling/ArbeidsfordelingService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/arbeidsfordeling/ArbeidsfordelingService.kt
@@ -17,7 +17,7 @@ class ArbeidsfordelingService(
     fun finnBehandlendeEnhetForPerson(personIdent: String, tema: String): List<ArbeidsfordelingClient.Enhet> {
 
         val behandlendeEnhetData = pdlRestClient.hentBehandlendeEnhetData(personIdent, tema)
-        val geografiskTilknytning = behandlendeEnhetData.geografiskTilknytning.gtKommune
+        val geografiskTilknytning = behandlendeEnhetData.geografiskTilknytning?.gtKommune
         val diskresjonskode = when (behandlendeEnhetData.adressebeskyttelse.firstOrNull()?.gradering) {
             ADRESSEBESKYTTELSEGRADERING.FORTROLIG -> Diskresjonskode.KODE7.kode
             ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG -> Diskresjonskode.KODE6.kode

--- a/src/main/java/no/nav/familie/integrasjoner/arbeidsfordeling/ArbeidsfordelingService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/arbeidsfordeling/ArbeidsfordelingService.kt
@@ -1,13 +1,13 @@
 package no.nav.familie.integrasjoner.arbeidsfordeling
 
-import no.nav.familie.integrasjoner.felles.OppslagException
-import no.nav.familie.integrasjoner.personopplysning.PersonopplysningerService
+import no.nav.familie.integrasjoner.client.rest.PdlRestClient
+import no.nav.familie.integrasjoner.personopplysning.internal.ADRESSEBESKYTTELSEGRADERING
 import org.springframework.stereotype.Service
 
 @Service
 class ArbeidsfordelingService(
         private val klient: ArbeidsfordelingClient,
-        private val personopplysningerService: PersonopplysningerService) {
+        private val pdlRestClient: PdlRestClient) {
 
     fun finnBehandlendeEnhet(tema: String,
                              geografi: String?,
@@ -15,11 +15,17 @@ class ArbeidsfordelingService(
             klient.finnBehandlendeEnhet(tema, geografi, diskresjonskode)
 
     fun finnBehandlendeEnhetForPerson(personIdent: String, tema: String): List<ArbeidsfordelingClient.Enhet> {
-        val personinfo = personopplysningerService.hentPersoninfo(personIdent)
-                         ?: throw OppslagException("Kan ikke finne personinfo",
-                                                   "arbeidsfordelingservice.finnBehandlendeEnhetForPerson",
-                                                   OppslagException.Level.MEDIUM)
-        return klient.finnBehandlendeEnhet(tema, personinfo.geografiskTilknytning, personinfo.diskresjonskode)
+
+        val behandlendeEnhetData = pdlRestClient.hentBehandlendeEnhetData(personIdent, tema)
+        val geografiskTilknytning = behandlendeEnhetData.geografiskTilknytning?.gtKommune
+        val diskresjonskode = when (behandlendeEnhetData.adressebeskyttelse.firstOrNull()?.gradering) {
+            ADRESSEBESKYTTELSEGRADERING.FORTROLIG -> "7"
+            ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG -> "6"
+            ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG_UTLAND -> "6" // TODO trenger avklaring
+            else -> null
+        }
+
+        return klient.finnBehandlendeEnhet(tema, geografiskTilknytning, diskresjonskode)
     }
 
 }

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/PdlRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/PdlRestClient.kt
@@ -99,6 +99,29 @@ class PdlRestClient(@Value("\${PDL_URL}") pdlBaseUrl: URI,
                                 personIdent)
     }
 
+    fun hentBehandlendeEnhetData(ident: String, tema: String): PdlPersonData {
+
+        val pdlPersonRequest = PdlPersonRequest(variables = PdlPersonRequestVariables(ident),
+                                                query = hentGraphqlQuery("hentBehandlendeEnhetData"))
+        val response = try {
+            postForEntity<PdlHentPersonResponse>(pdlUri,
+                                                 pdlPersonRequest,
+                                                 httpHeaders(tema))
+
+        } catch (e: Exception) {
+            throw pdlOppslagException(ident, error = e)
+        }
+
+        if (response == null || response.harFeil()) {
+            throw pdlOppslagException(ident,
+                                      HttpStatus.NOT_FOUND,
+                                      feilmelding = "Fant ikke data på person: " + response?.errorMessages())
+        }
+
+        return response.data.person!!
+    }
+
+
     companion object {
         private const val PATH_GRAPHQL = "graphql"
     }

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlBehandlendeEnhetResponse.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlBehandlendeEnhetResponse.kt
@@ -19,4 +19,4 @@ data class PdlBehandlendeEnhetForPerson(val person: PdlPdlBehandlendeEnhetForPer
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class PdlPdlBehandlendeEnhetForPersonData(
         val adressebeskyttelse: List<Adressebeskyttelse>,
-        val geografiskTilknytning: GeografiskTilknytning)
+        val geografiskTilknytning: GeografiskTilknytning?)

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlBehandlendeEnhetResponse.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlBehandlendeEnhetResponse.kt
@@ -1,0 +1,22 @@
+package no.nav.familie.integrasjoner.personopplysning.internal
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+data class PdlBehandlendeEnhetForPersonResponse(val data: PdlBehandlendeEnhetForPerson,
+                                                val errors: List<PdlError>?) {
+
+    fun harFeil(): Boolean {
+        return errors != null && errors.isNotEmpty()
+    }
+
+    fun errorMessages(): String {
+        return errors?.joinToString { it -> it.message } ?: ""
+    }
+}
+
+data class PdlBehandlendeEnhetForPerson(val person: PdlPdlBehandlendeEnhetForPersonData?)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class PdlPdlBehandlendeEnhetForPersonData(
+        val adressebeskyttelse: List<Adressebeskyttelse>,
+        val geografiskTilknytning: GeografiskTilknytning)

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlBehandlendeEnhetResponse.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlBehandlendeEnhetResponse.kt
@@ -20,3 +20,15 @@ data class PdlBehandlendeEnhetForPerson(val person: PdlPdlBehandlendeEnhetForPer
 data class PdlPdlBehandlendeEnhetForPersonData(
         val adressebeskyttelse: List<Adressebeskyttelse>,
         val geografiskTilknytning: GeografiskTilknytning?)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class GeografiskTilknytning(
+        val gtKommune: String?
+)
+
+enum class GtType {
+    KOMMUNE,
+    BYDEL,
+    UTLAND,
+    UDEFINERT
+}

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlHentPersonResponse.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlHentPersonResponse.kt
@@ -25,8 +25,7 @@ data class PdlPersonData(val foedsel: List<PdlFødselsDato>,
                          val familierelasjoner: List<PdlFamilierelasjon> = emptyList(),
                          val adressebeskyttelse: List<Adressebeskyttelse>,
                          val bostedsadresse: List<Bostedsadresse?>,
-                         val sivilstand: List<Sivilstand?>,
-                         val geografiskTilknytning: GeografiskTilknytning?)
+                         val sivilstand: List<Sivilstand?>)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class PdlFødselsDato(val foedselsdato: String?)
@@ -60,21 +59,9 @@ data class Adressebeskyttelse(
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class GeografiskTilknytning(
-        val gtKommune: String?
-)
-
-@JsonIgnoreProperties(ignoreUnknown = true)
 data class Sivilstand(
         val type: SIVILSTAND
 )
-
-enum class GtType {
-    KOMMUNE,
-    BYDEL,
-    UTLAND,
-    UDEFINERT
-}
 
 enum class KJØNN {
     MANN,

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlHentPersonResponse.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlHentPersonResponse.kt
@@ -25,7 +25,8 @@ data class PdlPersonData(val foedsel: List<PdlFødselsDato>,
                          val familierelasjoner: List<PdlFamilierelasjon> = emptyList(),
                          val adressebeskyttelse: List<Adressebeskyttelse>,
                          val bostedsadresse: List<Bostedsadresse?>,
-                         val sivilstand: List<Sivilstand?>)
+                         val sivilstand: List<Sivilstand?>,
+                         val geografiskTilknytning: GeografiskTilknytning?)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class PdlFødselsDato(val foedselsdato: String?)
@@ -59,9 +60,21 @@ data class Adressebeskyttelse(
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+data class GeografiskTilknytning(
+        val gtKommune: String?
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class Sivilstand(
         val type: SIVILSTAND
 )
+
+enum class GtType {
+    KOMMUNE,
+    BYDEL,
+    UTLAND,
+    UDEFINERT
+}
 
 enum class KJØNN {
     MANN,

--- a/src/main/resources/pdl/hentBehandlendeEnhetData.graphql
+++ b/src/main/resources/pdl/hentBehandlendeEnhetData.graphql
@@ -1,0 +1,11 @@
+query($ident: ID!) {person: hentPerson(ident: $ident) {
+    adressebeskyttelse {
+        gradering
+    }
+    geografiskTilknytning {
+        gtType
+        gtKommune
+        gtLand
+        gtBydel
+    }
+}}

--- a/src/test/java/no/nav/familie/integrasjoner/arbeidsfordeling/ArbeidsfordelingControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/arbeidsfordeling/ArbeidsfordelingControllerTest.kt
@@ -52,7 +52,29 @@ class ArbeidsfordelingControllerTest : OppslagSpringRunnerTest() {
     }
 
     @Test
-    fun `skal returnere fornuftig feilmelding ved feil`() {
+    fun `skal hente diskresjonskode, mangler geografisk tilknytning for ident og kalle arbeidsfordelingklient sin hent enhet`() {
+
+        stubFor(post("/graphql")
+                        .willReturn(aResponse()
+                                            .withStatus(200)
+                                            .withHeader("Content-Type", "application/json")
+                                            .withBody(readfile("pdlEnhetManglerKommuneResponse.json"))))
+
+        val response: ResponseEntity<Ressurs<List<ArbeidsfordelingClient.Enhet>>> = restTemplate.exchange(localhost(ENHET_URL),
+                                                                                                          HttpMethod.GET,
+                                                                                                          HttpEntity(null,
+                                                                                                                     headers))
+
+
+
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body.data).hasSize(1)
+        assertThat(response.body.data!!.first().enhetId).isEqualTo("4820")
+    }
+
+    @Test
+    fun `skal returnere not valid json feilmelding ved feil`() {
 
         stubFor(post("/graphql")
                         .willReturn(aResponse()

--- a/src/test/java/no/nav/familie/integrasjoner/arbeidsfordeling/ArbeidsfordelingControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/arbeidsfordeling/ArbeidsfordelingControllerTest.kt
@@ -1,0 +1,84 @@
+package no.nav.familie.integrasjoner.arbeidsfordeling
+
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import no.nav.familie.integrasjoner.OppslagSpringRunnerTest
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.security.token.support.test.JwtTokenGenerator
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.springframework.boot.test.web.client.exchange
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+
+@ActiveProfiles("integrasjonstest", "mock-sts", "mock-arbeidsfordeling")
+@TestPropertySource(properties = ["PDL_URL=http://localhost:28085"])
+@AutoConfigureWireMock(port = 28085)
+class ArbeidsfordelingControllerTest : OppslagSpringRunnerTest() {
+
+
+    @Before
+    fun setUp() {
+        headers.apply {
+            add("Nav-Personident", "12345678901")
+        }.setBearerAuth(JwtTokenGenerator.signedJWTAsString("testbruker"))
+    }
+
+    @Test
+    fun `skal hente geografisk tilknytning og diskresjonskode for ident og kalle arbeidsfordelingklient sin hent enhet`() {
+
+        stubFor(post("/graphql")
+                        .willReturn(aResponse()
+                                            .withStatus(200)
+                                            .withHeader("Content-Type", "application/json")
+                                            .withBody(readfile("pdlEnhetResponse.json"))))
+
+        val response: ResponseEntity<Ressurs<List<ArbeidsfordelingClient.Enhet>>> = restTemplate.exchange(localhost(ENHET_URL),
+                                                                                                          HttpMethod.GET,
+                                                                                                          HttpEntity(null,
+                                                                                                                     headers))
+
+
+
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body.data).hasSize(1)
+        assertThat(response.body.data!!.first().enhetId).isEqualTo("4820")
+    }
+
+    @Test
+    fun `skal returnere fornuftig feilmelding ved feil`() {
+
+        stubFor(post("/graphql")
+                        .willReturn(aResponse()
+                                            .withStatus(200)
+                                            .withHeader("Content-Type", "application/json")
+                                            .withBody("{}")))
+
+        val response: ResponseEntity<Ressurs<List<ArbeidsfordelingClient.Enhet>>> = restTemplate.exchange(localhost(ENHET_URL),
+                                                                                                          HttpMethod.GET,
+                                                                                                          HttpEntity(null,
+                                                                                                                     headers))
+
+
+
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        assertThat(response.body.status).isEqualTo(Ressurs.Status.FEILET)
+        assertThat(response.body.melding).contains("PdlBehandlendeEnhetForPersonResponse] value failed for JSON property data due to missing (therefore NULL)")
+    }
+
+    private fun readfile(filnavn: String): String {
+        return this::class.java.getResource("/pdl/$filnavn").readText()
+    }
+
+    companion object {
+
+        private const val ENHET_URL = "/api/arbeidsfordeling/enhet/BAR"
+    }
+}

--- a/src/test/resources/pdl/pdlEnhetManglerKommuneResponse.json
+++ b/src/test/resources/pdl/pdlEnhetManglerKommuneResponse.json
@@ -1,0 +1,18 @@
+{
+  "data": {
+    "person": {
+      "navn": [
+        {
+          "fornavn": "ENGASJERT",
+          "etternavn": "FYR"
+        }
+      ],
+      "adressebeskyttelse": [
+        {
+          "gradering": "STRENGT_FORTROLIG"
+        }
+      ],
+      "geografiskTilknytning": null
+    }
+  }
+}

--- a/src/test/resources/pdl/pdlEnhetResponse.json
+++ b/src/test/resources/pdl/pdlEnhetResponse.json
@@ -1,0 +1,23 @@
+{
+  "data": {
+    "person": {
+      "navn": [
+        {
+          "fornavn": "ENGASJERT",
+          "etternavn": "FYR"
+        }
+      ],
+      "adressebeskyttelse": [
+        {
+          "gradering": "STRENGT_FORTROLIG"
+        }
+      ],
+      "geografiskTilknytning": {
+        "gtType": "KOMMUNE",
+        "gtKommune": "0128",
+        "gtLand": null,
+        "gtBydel": null
+      }
+    }
+  }
+}


### PR DESCRIPTION
GT er i beta, men vi forsøker likevel å bruke den. 