### PR TITLE
Ikke deploy dependabotbygge automatisk

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ env:
   IMAGE: docker.pkg.github.com/${{ github.repository }}/familie-integrasjoner:${{ github.sha }}
 jobs:
   deploy-to-dev:
-    if: ${{ github.event.label.name != 'dependencies' }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name,'dependencies') }}
     name: Build, push and deploy to dev-fss
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ env:
   IMAGE: docker.pkg.github.com/${{ github.repository }}/familie-integrasjoner:${{ github.sha }}
 jobs:
   deploy-to-dev:
+    if: ${{ github.event.label.name != 'dependencies' }}
     name: Build, push and deploy to dev-fss
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Si att man har 6 pull requests med dependabot.
Hvis man då merger 1 av de så oppdateres alle andra automatisk og bygger og deployer til preprod.

Dette skaper trøbbel.
1. Når jeg merger min branch så prøver den å deploye til preprod, men så finnes det 6 andre jobb som også prøver å deploye til preprod.
2. Jeg får ikke bygget noen av de andra pga att de går i benen for hverendre 

Så dette er ett forslag på løsning. Dependabot PR's får en label, "dependencies".
For att PR skal deploye (som er requirement i familie-integrasjoner) så må bygget deploy være grønt. 
Så hvis man må bygge må man då fjerne labels og bygge manuellt. 

Tanker?