### PR TITLE
Oppdatert url for oppgave

### DIFF
--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -55,7 +55,7 @@ PERSON_V3_URL: https://wasapp-q2.adeo.no/tpsws/ws/Person/v3
 DOKARKIV_V1_URL: http://dokarkiv.q2
 MEDL2_URL: https://app-q2.adeo.no/medl2
 SAF_URL: http://saf.q2
-OPPGAVE_URL: http://oppgave.q2
+OPPGAVE_URL: https://oppgave.dev.adeo.no
 KODEVERK_URL: http://kodeverk
 FOERSTESIDEGENERATOR_URL: https://foerstesidegenerator-q1.dev.adeo.no
 EGEN_ANSATT_URL: https://skjermede-personer-pip.nais.preprod.local

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -74,6 +74,7 @@ ARBEIDSFORDELING_V1_URL: https://app.adeo.no/norg2/ws/Arbeidsfordeling/v1
 PDL_URL: http://pdl-api
 AAREG_URL: https://modapp.adeo.no/aareg-services/api
 SKYGGE_SAK_URL: http://sak
+OPPGAVE_URL: https://oppgave.nais.adeo.no
 
 # Appdynamics
 APPDYNAMICS_CONTROLLER_HOST_NAME: appdynamics.adeo.no

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -43,4 +43,3 @@ GOSYS_INFOTRYGDSAK_URL: "dummy"
 
 STS_URL: http://security-token-service.default.svc.nais.local/rest/v1/sts/token
 INFOTRYGD_URL: http://infotrygd-kontantstotte
-OPPGAVE_URL: http://oppgave


### PR DESCRIPTION
Fra slack: https://nav-it.slack.com/archives/CB2N21ZME/p1606904271313100

> Vi planlegger å skru av oppgave i default namespace og q2-namespace mot slutten av uken (migrert til team-ns). 
> Disse og ev. øvrige konsumenter som benytter sd, må endre til henholdsvis https://oppgave-q1.nais.preprod.local 
> for q1 og https://oppgave.dev.adeo.no for syntetisk/q2 for å unngå feil i oppslagene. 

> Vi planlegger også å fase ut default-ns i prod om ikke alt for lenge, så det er fint om det endres til ingress 
> også der ved en passende anledning. 