### PR TITLE
Lagt til endepunkt for å hente identer som ef-mottak kan bruke

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <springfox.version>3.0.0</springfox.version>
         <common-java-modules.version>1.2019.11.06-15.14-6ca860e6cead</common-java-modules.version>
         <felles.version>1.20210208115050_88991d1</felles.version>
-        <kontrakt.version>2.0_20210202101640_559def4</kontrakt.version>
+        <kontrakt.version>2.0_20210303150225_33974ba</kontrakt.version>
         <cxf.version>3.3.4</cxf.version>
         <token-validation-spring.version>1.3.3</token-validation-spring.version>
         <tjenestespesifikasjoner.version>1.2021.02.22-10.45-4201aaea72fb</tjenestespesifikasjoner.version>

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerController.kt
@@ -71,11 +71,11 @@ class PersonopplysningerController(private val personopplysningerService: Person
     }
 
     @PostMapping(produces = [MediaType.APPLICATION_JSON_VALUE], path = ["v1/identer/{tema}"])
-    fun personInfoEnkel(@RequestBody(required = true) ident: Ident,
-                        @PathVariable tema: Tema,
-                        @RequestParam(value = "historikk",
-                                      required = false,
-                                      defaultValue = "false") medHistorikk: Boolean): Ressurs<FinnPersonidenterResponse> {
+    fun hentIdenter(@RequestBody(required = true) ident: Ident,
+                    @PathVariable tema: Tema,
+                    @RequestParam(value = "historikk",
+                                  required = false,
+                                  defaultValue = "false") medHistorikk: Boolean): Ressurs<FinnPersonidenterResponse> {
         return success(personopplysningerService.hentIdenter(ident.ident, tema, medHistorikk))
     }
 }

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerController.kt
@@ -9,6 +9,7 @@ import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.Ressurs.Companion.failure
 import no.nav.familie.kontrakter.felles.Ressurs.Companion.ikkeTilgang
 import no.nav.familie.kontrakter.felles.Ressurs.Companion.success
+import no.nav.familie.kontrakter.felles.personopplysning.FinnPersonidenterResponse
 import no.nav.familie.kontrakter.felles.personopplysning.Ident
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.format.annotation.DateTimeFormat
@@ -67,5 +68,14 @@ class PersonopplysningerController(private val personopplysningerService: Person
         return ResponseEntity.ok().body(success(
                 personopplysningerService.hentPersoninfo(personIdent, tema.toString(), PersonInfoQuery.ENKEL),
                 "Hent personinfo OK"))
+    }
+
+    @PostMapping(produces = [MediaType.APPLICATION_JSON_VALUE], path = ["v1/identer/{tema}"])
+    fun personInfoEnkel(@RequestBody(required = true) ident: Ident,
+                        @PathVariable tema: Tema,
+                        @RequestParam(value = "historikk",
+                                      required = false,
+                                      defaultValue = "false") medHistorikk: Boolean): Ressurs<FinnPersonidenterResponse> {
+        return success(personopplysningerService.hentIdenter(ident.ident, tema, medHistorikk))
     }
 }

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerService.kt
@@ -3,12 +3,16 @@ package no.nav.familie.integrasjoner.personopplysning
 import no.nav.familie.integrasjoner.client.rest.PdlRestClient
 import no.nav.familie.integrasjoner.client.rest.PersonInfoQuery
 import no.nav.familie.integrasjoner.client.soap.PersonSoapClient
+import no.nav.familie.integrasjoner.felles.Tema
 import no.nav.familie.integrasjoner.felles.ws.DateUtil
 import no.nav.familie.integrasjoner.personopplysning.domene.PersonIdent
 import no.nav.familie.integrasjoner.personopplysning.domene.PersonhistorikkInfo
 import no.nav.familie.integrasjoner.personopplysning.domene.Personinfo
 import no.nav.familie.integrasjoner.personopplysning.domene.TpsOversetter
+import no.nav.familie.integrasjoner.personopplysning.internal.PdlIdent
 import no.nav.familie.integrasjoner.personopplysning.internal.Person
+import no.nav.familie.kontrakter.felles.personopplysning.FinnPersonidenterResponse
+import no.nav.familie.kontrakter.felles.personopplysning.PersonIdentMedHistorikk
 import no.nav.tjeneste.virksomhet.person.v3.informasjon.Informasjonsbehov
 import no.nav.tjeneste.virksomhet.person.v3.informasjon.NorskIdent
 import no.nav.tjeneste.virksomhet.person.v3.informasjon.Periode
@@ -63,8 +67,13 @@ class PersonopplysningerService(private val personSoapClient: PersonSoapClient,
         return pdlRestClient.hentPerson(personIdent, tema, personInfoQuery)
     }
 
+    fun hentIdenter(personIdent: String, tema: Tema, medHistorikk: Boolean): FinnPersonidenterResponse {
+        val response = pdlRestClient.hentIdenter(personIdent, tema, medHistorikk)
+        return FinnPersonidenterResponse(response.map { PersonIdentMedHistorikk(it.ident, it.historisk) })
+    }
 
     companion object {
+
         const val PERSON = "PERSON"
     }
 }

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlIdent.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlIdent.kt
@@ -1,0 +1,14 @@
+package no.nav.familie.integrasjoner.personopplysning.internal
+
+data class PdlIdentRequest(val variables: PdlIdentRequestVariables,
+                           val query: String)
+
+data class PdlIdentRequestVariables(val ident: String,
+                                    val gruppe: String,
+                                    val historikk: Boolean = false)
+
+data class PdlIdent(val ident: String, val historisk: Boolean)
+
+data class PdlIdenter(val identer: List<PdlIdent>)
+
+data class PdlHentIdenter(val hentIdenter: PdlIdenter?)

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlResponse.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlResponse.kt
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import no.nav.familie.kontrakter.felles.personopplysning.Bostedsadresse
 import no.nav.familie.kontrakter.felles.personopplysning.SIVILSTAND
 
-data class PdlHentPersonResponse(val data: PdlPerson,
-                                 val errors: List<PdlError>?) {
+data class PdlResponse<T>(val data: T,
+                          val errors: List<PdlError>?) {
 
     fun harFeil(): Boolean {
         return errors != null && errors.isNotEmpty()

--- a/src/main/resources/pdl/hentIdenter.graphql
+++ b/src/main/resources/pdl/hentIdenter.graphql
@@ -1,0 +1,8 @@
+query($ident: ID!, $gruppe: [IdentGruppe!], $historikk: Boolean = false) {
+    hentIdenter(ident: $ident, grupper: $gruppe, historikk: $historikk) {
+        identer {
+            ident
+            historisk
+        }
+    }
+}

--- a/src/test/java/no/nav/familie/integrasjoner/personopplysning/PdlGraphqlTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/personopplysning/PdlGraphqlTest.kt
@@ -1,9 +1,12 @@
 package no.nav.familie.integrasjoner.personopplysning
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-import no.nav.familie.integrasjoner.personopplysning.internal.PdlHentPersonResponse
+import no.nav.familie.integrasjoner.personopplysning.internal.PdlHentIdenter
+import no.nav.familie.integrasjoner.personopplysning.internal.PdlResponse
 import no.nav.familie.integrasjoner.personopplysning.internal.PdlNavn
+import no.nav.familie.integrasjoner.personopplysning.internal.PdlPerson
 import no.nav.familie.kontrakter.felles.personopplysning.SIVILSTAND
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -18,7 +21,7 @@ class PdlGraphqlTest {
 
     @Test
     fun testDeserialization() {
-        val resp = mapper.readValue(File(getFile("pdl/pdlOkResponse.json")), PdlHentPersonResponse::class.java)
+        val resp: PdlResponse<PdlPerson> = mapper.readValue(File(getFile("pdl/pdlOkResponse.json")))
         assertThat(resp.data.person!!.foedsel.first().foedselsdato).isEqualTo("1955-09-13")
         assertThat(resp.data.person!!.navn.first().fornavn).isEqualTo("ENGASJERT")
         assertThat(resp.data.person!!.kjoenn.first().kjoenn.toString()).isEqualTo("MANN")
@@ -34,34 +37,40 @@ class PdlGraphqlTest {
 
     @Test
     fun testTomAdresse() {
-        val resp = mapper.readValue(File(getFile("pdl/pdlTomAdresseOkResponse.json")), PdlHentPersonResponse::class.java)
+        val resp: PdlResponse<PdlPerson> = mapper.readValue(File(getFile("pdl/pdlTomAdresseOkResponse.json")))
         assertTrue(resp.data.person!!.bostedsadresse.isEmpty())
     }
 
     @Test
     fun testMatrikkelAdresse() {
-        val resp = mapper.readValue(File(getFile("pdl/pdlMatrikkelAdresseOkResponse.json")), PdlHentPersonResponse::class.java)
+        val resp: PdlResponse<PdlPerson> = mapper.readValue(File(getFile("pdl/pdlMatrikkelAdresseOkResponse.json")))
         assertThat(resp.data.person!!.bostedsadresse.first()?.matrikkeladresse?.postnummer).isEqualTo("0274")
         assertThat(resp.data.person!!.bostedsadresse.first()?.matrikkeladresse?.matrikkelId).isEqualTo(2147483649)
     }
 
     @Test
     fun testUkjentBostedAdresse() {
-        val resp = mapper.readValue(File(getFile("pdl/pdlUkjentBostedAdresseOkResponse.json")), PdlHentPersonResponse::class.java)
+        val resp: PdlResponse<PdlPerson> = mapper.readValue(File(getFile("pdl/pdlUkjentBostedAdresseOkResponse.json")))
         assertThat(resp.data.person!!.bostedsadresse.first()?.ukjentBosted?.bostedskommune).isEqualTo("Oslo")
     }
 
     @Test
     fun testDeserializationOfResponseWithErrors() {
-        val resp = mapper.readValue(File(getFile("pdl/pdlPersonIkkeFunnetResponse.json")), PdlHentPersonResponse::class.java)
+        val resp: PdlResponse<PdlPerson> = mapper.readValue(File(getFile("pdl/pdlPersonIkkeFunnetResponse.json")))
         assertThat(resp.harFeil()).isTrue()
         assertThat(resp.errorMessages()).contains("Fant ikke person", "Ikke tilgang")
     }
 
     @Test
     fun testDeserializationOfResponseWithoutFødselsdato() {
-        val resp = mapper.readValue(File(getFile("pdl/pdlManglerFoedselResponse.json")), PdlHentPersonResponse::class.java)
+        val resp: PdlResponse<PdlPerson> = mapper.readValue(File(getFile("pdl/pdlManglerFoedselResponse.json")))
         assertThat(resp.data.person!!.foedsel.first().foedselsdato).isNull()
+    }
+
+    @Test
+    fun testPdlIdenter() {
+        val resp: PdlResponse<PdlHentIdenter> = mapper.readValue(File(getFile("pdl/pdlIdenterResponse.json")))
+        assertThat(resp.data.hentIdenter!!.identer).hasSize(1)
     }
 
     @Test

--- a/src/test/resources/pdl/pdlGyldigHentIdenterRequest.json
+++ b/src/test/resources/pdl/pdlGyldigHentIdenterRequest.json
@@ -1,0 +1,1 @@
+{"variables":{"ident":"12345678901","gruppe":"FOLKEREGISTERIDENT","historikk": false },"query":"GRAPHQL-PLACEHOLDER"}

--- a/src/test/resources/pdl/pdlIdenterResponse.json
+++ b/src/test/resources/pdl/pdlIdenterResponse.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "hentIdenter": {
+      "identer": [
+        {
+          "ident": "12345678901",
+          "historisk": false
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
EF-mottak ønsker å finne identer til en person for å kunne bruke disse ved kall til infotrygd-replika. Den har ikke PDL klienten og tenkte det var smidigere å ha den endepunkten her i integrasjoner enn å legge til pdlklient i mottak.