### PR TITLE
Nye endepunkter ofor å hente ut aktørid/personIdent

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/aktør/AktørController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/aktør/AktørController.kt
@@ -1,14 +1,13 @@
 package no.nav.familie.integrasjoner.aktør
 
+import no.nav.familie.integrasjoner.felles.Tema
 import no.nav.familie.integrasjoner.personopplysning.domene.AktørId
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.Ressurs.Companion.success
+import no.nav.familie.kontrakter.felles.personopplysning.Ident
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestHeader
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import javax.validation.constraints.NotNull
 
 @RestController
@@ -33,4 +32,21 @@ class AktørController(private val aktørService: AktørService) {
                 )
     }
 
+    @PostMapping("v2/{tema}")
+    fun finnAktørIdForPersonIdent(@RequestBody(required = true) ident: Ident,
+                                  @PathVariable tema: Tema): ResponseEntity<Ressurs<Map<String, String>>> {
+
+        return ResponseEntity.ok(success(
+                mapOf("aktørId" to aktørService.getAktørIdFraPdl(ident.ident, tema.name)),
+                "Hent aktør for personident OK"))
+    }
+
+    @PostMapping("v2/fraaktorid/{tema}")
+    fun finnPersonIdentForAktørId(@RequestBody(required = true) aktørId: String,
+                                  @PathVariable tema: Tema): ResponseEntity<Ressurs<Map<String, String>>> {
+
+        return ResponseEntity.ok(success(
+                mapOf("personIdent" to aktørService.getPersonIdentFraPdl(AktørId(aktørId), tema.name)),
+                "Hent aktør for personident OK"))
+    }
 }

--- a/src/main/java/no/nav/familie/integrasjoner/aktør/AktørController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/aktør/AktørController.kt
@@ -37,7 +37,7 @@ class AktørController(private val aktørService: AktørService) {
                                   @PathVariable tema: Tema): ResponseEntity<Ressurs<Map<String, String>>> {
 
         return ResponseEntity.ok(success(
-                mapOf("aktørId" to aktørService.getAktørIdFraPdl(ident.ident, tema.name)),
+                mapOf("aktørId" to aktørService.getAktørIdFraPdl(ident.ident, tema)),
                 "Hent aktør for personident OK"))
     }
 
@@ -46,7 +46,7 @@ class AktørController(private val aktørService: AktørService) {
                                   @PathVariable tema: Tema): ResponseEntity<Ressurs<Map<String, String>>> {
 
         return ResponseEntity.ok(success(
-                mapOf("personIdent" to aktørService.getPersonIdentFraPdl(AktørId(aktørId), tema.name)),
+                mapOf("personIdent" to aktørService.getPersonIdentFraPdl(AktørId(aktørId), tema)),
                 "Hent aktør for personident OK"))
     }
 }

--- a/src/main/java/no/nav/familie/integrasjoner/aktør/AktørService.java
+++ b/src/main/java/no/nav/familie/integrasjoner/aktør/AktørService.java
@@ -3,6 +3,7 @@ package no.nav.familie.integrasjoner.aktør;
 import no.nav.familie.integrasjoner.aktør.domene.Aktør;
 import no.nav.familie.integrasjoner.aktør.domene.Ident;
 import no.nav.familie.integrasjoner.client.rest.AktørregisterRestClient;
+import no.nav.familie.integrasjoner.client.rest.PdlRestClient;
 import no.nav.familie.integrasjoner.felles.OppslagException;
 import no.nav.familie.integrasjoner.personopplysning.domene.AktørId;
 import org.slf4j.Logger;
@@ -20,9 +21,11 @@ public class AktørService {
 
     private static final Logger secureLogger = LoggerFactory.getLogger("secureLogger");
     private final AktørregisterRestClient aktørregisterClient;
+    private final PdlRestClient pdlRestClient;
 
-    public AktørService(AktørregisterRestClient aktørregisterClient) {
+    public AktørService(AktørregisterRestClient aktørregisterClient, PdlRestClient pdlRestClient) {
         this.aktørregisterClient = aktørregisterClient;
+        this.pdlRestClient = pdlRestClient;
     }
 
     @Cacheable(value = "aktør_personIdent", unless = "#result == null")
@@ -42,6 +45,22 @@ public class AktørService {
         if (responseFraRegister != null) {
             secureLogger.info("Legger aktørid {} med fnr {} i personident-cache", aktørId.getId(), responseFraRegister);
         }
+        return responseFraRegister;
+    }
+
+    @Cacheable(value = "aktør_personIdent_pdl", unless = "#result == null")
+    public String getAktørIdFraPdl(String personIdent, String tema) {
+        requireNonNull(personIdent, "personIdent");
+        String responseFraRegister = pdlRestClient.hentGjeldendeAktørId(personIdent, tema);
+        secureLogger.info("Legger fnr {} med aktørid {} i aktør-cache", personIdent, responseFraRegister);
+        return responseFraRegister;
+    }
+
+    @Cacheable(value = "aktør_aktørId_pdl", unless = "#result == null")
+    public String getPersonIdentFraPdl(AktørId aktørId, String tema) {
+        requireNonNull(aktørId, "aktørId");
+        String responseFraRegister = pdlRestClient.hentGjeldendePersonident(aktørId.getId(), tema);
+        secureLogger.info("Legger aktørid {} med fnr {} i personident-cache", aktørId.getId(), responseFraRegister);
         return responseFraRegister;
     }
 

--- a/src/main/java/no/nav/familie/integrasjoner/aktør/AktørService.java
+++ b/src/main/java/no/nav/familie/integrasjoner/aktør/AktørService.java
@@ -5,6 +5,7 @@ import no.nav.familie.integrasjoner.aktør.domene.Ident;
 import no.nav.familie.integrasjoner.client.rest.AktørregisterRestClient;
 import no.nav.familie.integrasjoner.client.rest.PdlRestClient;
 import no.nav.familie.integrasjoner.felles.OppslagException;
+import no.nav.familie.integrasjoner.felles.Tema;
 import no.nav.familie.integrasjoner.personopplysning.domene.AktørId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,7 +50,7 @@ public class AktørService {
     }
 
     @Cacheable(value = "aktør_personIdent_pdl", unless = "#result == null")
-    public String getAktørIdFraPdl(String personIdent, String tema) {
+    public String getAktørIdFraPdl(String personIdent, Tema tema) {
         requireNonNull(personIdent, "personIdent");
         String responseFraRegister = pdlRestClient.hentGjeldendeAktørId(personIdent, tema);
         secureLogger.info("Legger fnr {} med aktørid {} i aktør-cache", personIdent, responseFraRegister);
@@ -57,7 +58,7 @@ public class AktørService {
     }
 
     @Cacheable(value = "aktør_aktørId_pdl", unless = "#result == null")
-    public String getPersonIdentFraPdl(AktørId aktørId, String tema) {
+    public String getPersonIdentFraPdl(AktørId aktørId, Tema tema) {
         requireNonNull(aktørId, "aktørId");
         String responseFraRegister = pdlRestClient.hentGjeldendePersonident(aktørId.getId(), tema);
         secureLogger.info("Legger aktørid {} med fnr {} i personident-cache", aktørId.getId(), responseFraRegister);

--- a/src/main/java/no/nav/familie/integrasjoner/config/ApiExceptionHandler.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/config/ApiExceptionHandler.kt
@@ -87,7 +87,7 @@ class ApiExceptionHandler {
     @ExceptionHandler(PdlNotFoundException::class)
     fun handleThrowable(feil: PdlNotFoundException): ResponseEntity<Ressurs<Nothing>> {
         logger.info("Finner ikke personen i PDL")
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Ressurs.failure(frontendFeilmelding = "Finner ikke personen"))
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(failure(frontendFeilmelding = "Finner ikke personen"))
     }
 
     @ExceptionHandler(OppslagException::class)

--- a/src/main/java/no/nav/familie/integrasjoner/config/ApiExceptionHandler.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/config/ApiExceptionHandler.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.integrasjoner.config
 
 import no.nav.familie.integrasjoner.felles.OppslagException
+import no.nav.familie.integrasjoner.personopplysning.PdlNotFoundException
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.Ressurs.Companion.failure
 import no.nav.security.token.support.client.core.OAuth2ClientException
@@ -81,6 +82,12 @@ class ApiExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(failure("""Det oppstod en feil. ${e.message}""", error = e))
+    }
+
+    @ExceptionHandler(PdlNotFoundException::class)
+    fun handleThrowable(feil: PdlNotFoundException): ResponseEntity<Ressurs<Nothing>> {
+        logger.info("Finner ikke personen i PDL")
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Ressurs.failure(frontendFeilmelding = "Finner ikke personen"))
     }
 
     @ExceptionHandler(OppslagException::class)

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/PdlRequestException.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/PdlRequestException.kt
@@ -1,0 +1,5 @@
+package no.nav.familie.integrasjoner.personopplysning
+
+open class PdlRequestException(melding: String? = null) : Exception(melding)
+
+class PdlNotFoundException: PdlRequestException()

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerService.kt
@@ -68,7 +68,7 @@ class PersonopplysningerService(private val personSoapClient: PersonSoapClient,
     }
 
     fun hentIdenter(personIdent: String, tema: Tema, medHistorikk: Boolean): FinnPersonidenterResponse {
-        val response = pdlRestClient.hentIdenter(personIdent, tema, medHistorikk)
+        val response = pdlRestClient.hentIdenter(personIdent, "FOLKEREGISTERIDENT", tema, medHistorikk)
         return FinnPersonidenterResponse(response.map { PersonIdentMedHistorikk(it.ident, it.historisk) })
     }
 

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlResponse.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlResponse.kt
@@ -14,6 +14,10 @@ data class PdlResponse<T>(val data: T,
     fun errorMessages(): String {
         return errors?.joinToString { it -> it.message } ?: ""
     }
+
+    fun harNotFoundFeil(): Boolean {
+        return errors?.any { it.extensions?.notFound() == true } ?: false
+    }
 }
 
 data class PdlPerson(val person: PdlPersonData?)
@@ -31,7 +35,13 @@ data class PdlPersonData(val foedsel: List<PdlFødselsDato>,
 data class PdlFødselsDato(val foedselsdato: String?)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class PdlError(val message: String)
+data class PdlError(val message: String,
+                    val extensions: PdlExtensions?)
+
+data class PdlExtensions(val code: String) {
+    fun notFound() = code == "not_found"
+}
+
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class PdlNavn(val fornavn: String,

--- a/src/test/java/no/nav/familie/integrasjoner/aktør/config/AktørServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/aktør/config/AktørServiceTest.kt
@@ -74,9 +74,9 @@ class AktørServiceTest {
         every { aktørClient.hentAktørId(eq(PERSONIDENT_UTEN_IDENT)) } returns
                 AktørResponse().withAktør(PERSONIDENT_UTEN_IDENT, Aktør()
                         .withIdenter(listOf(Ident().withIdent(null).withGjeldende(true))))
-        every { pdlRestClient.hentGjeldendeAktørId(eq(PERSONIDENT), eq(Tema.ENF.name)) } returns TESTAKTORID
-        every { pdlRestClient.hentGjeldendePersonident(eq(TESTAKTORID), eq(Tema.ENF.name)) } returns PERSONIDENT
-        every { pdlRestClient.hentGjeldendeAktørId(eq(PERSONIDENT_UTEN_IDENT), eq(Tema.ENF.name)) } throws PdlNotFoundException()
+        every { pdlRestClient.hentGjeldendeAktørId(eq(PERSONIDENT), eq(Tema.ENF)) } returns TESTAKTORID
+        every { pdlRestClient.hentGjeldendePersonident(eq(TESTAKTORID), eq(Tema.ENF)) } returns PERSONIDENT
+        every { pdlRestClient.hentGjeldendeAktørId(eq(PERSONIDENT_UTEN_IDENT), eq(Tema.ENF)) } throws PdlNotFoundException()
     }
 
     @After
@@ -95,7 +95,7 @@ class AktørServiceTest {
 
     @Test
     fun `skal returnere aktørId fra pdl første gang`() {
-        val testAktørId = aktørService.getAktørIdFraPdl(PERSONIDENT, Tema.ENF.name)
+        val testAktørId = aktørService.getAktørIdFraPdl(PERSONIDENT, Tema.ENF)
         assertThat(testAktørId).isEqualTo(TESTAKTORID)
         verify(exactly = 1) { (pdlRestClient.hentGjeldendeAktørId(any(), any())) }
     }
@@ -111,7 +111,7 @@ class AktørServiceTest {
     @Test
     fun `skal returnere aktørId fra cache når den ligger der fra pdl`() {
         repeat(2) {
-            assertThat(aktørService.getAktørIdFraPdl(PERSONIDENT, Tema.ENF.name)).isEqualTo(TESTAKTORID)
+            assertThat(aktørService.getAktørIdFraPdl(PERSONIDENT, Tema.ENF)).isEqualTo(TESTAKTORID)
         }
         verify(exactly = 1) { pdlRestClient.hentGjeldendeAktørId(any(), any()) }
     }
@@ -129,7 +129,7 @@ class AktørServiceTest {
     fun `skal ikke cachea når den feiler`() {
         repeat(2) {
             assertThrows<Exception> {
-                aktørService.getAktørIdFraPdl(PERSONIDENT_UTEN_IDENT, Tema.ENF.name)
+                aktørService.getAktørIdFraPdl(PERSONIDENT_UTEN_IDENT, Tema.ENF)
             }
         }
         verify(exactly = 2) { pdlRestClient.hentGjeldendeAktørId(any(), any()) }

--- a/src/test/java/no/nav/familie/integrasjoner/aktør/config/AktørServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/aktør/config/AktørServiceTest.kt
@@ -4,38 +4,66 @@ import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import no.nav.familie.integrasjoner.OppslagSpringRunnerTest
 import no.nav.familie.integrasjoner.aktør.AktørService
 import no.nav.familie.integrasjoner.aktør.domene.Aktør
 import no.nav.familie.integrasjoner.aktør.domene.Ident
 import no.nav.familie.integrasjoner.aktør.internal.AktørResponse
 import no.nav.familie.integrasjoner.client.rest.AktørregisterRestClient
+import no.nav.familie.integrasjoner.client.rest.PdlRestClient
+import no.nav.familie.integrasjoner.config.CacheConfig
+import no.nav.familie.integrasjoner.felles.Tema
+import no.nav.familie.integrasjoner.personopplysning.PdlNotFoundException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
 import org.springframework.context.annotation.Profile
 import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit4.SpringRunner
 
-@ActiveProfiles(profiles = ["integrasjonstest", "mock-sts", "AktørServiceTest"])
-class AktørServiceTest : OppslagSpringRunnerTest() {
+@ActiveProfiles(profiles = ["AktørServiceTest"])
+@RunWith(SpringRunner::class)
+@EnableCaching
+class AktørServiceTest {
 
     @Autowired private lateinit var aktørService: AktørService
     @Autowired private lateinit var aktørClient: AktørregisterRestClient
+    @Autowired private lateinit var pdlRestClient: PdlRestClient
     @Autowired private lateinit var cacheManager: CacheManager
+
 
     @Configuration
     @Profile("AktørServiceTest")
     class AktørClientTestConfig {
 
+        val cacheManagerToBe = CacheConfig().cacheManager()
+
         @Bean
         @Primary
         fun aktørregisterClientMock(): AktørregisterRestClient = mockk()
+
+        @Bean
+        @Primary
+        fun pdlRestClient(): PdlRestClient = mockk()
+
+        @Bean
+        @Primary
+        fun cacheManager(): CacheManager {
+            return cacheManagerToBe
+        }
+
+        @Bean
+        @Primary
+        fun aktørService(): AktørService = AktørService(aktørregisterClientMock(), pdlRestClient())
+
     }
 
     @Before
@@ -46,11 +74,15 @@ class AktørServiceTest : OppslagSpringRunnerTest() {
         every { aktørClient.hentAktørId(eq(PERSONIDENT_UTEN_IDENT)) } returns
                 AktørResponse().withAktør(PERSONIDENT_UTEN_IDENT, Aktør()
                         .withIdenter(listOf(Ident().withIdent(null).withGjeldende(true))))
+        every { pdlRestClient.hentGjeldendeAktørId(eq(PERSONIDENT), eq(Tema.ENF.name)) } returns TESTAKTORID
+        every { pdlRestClient.hentGjeldendePersonident(eq(TESTAKTORID), eq(Tema.ENF.name)) } returns PERSONIDENT
+        every { pdlRestClient.hentGjeldendeAktørId(eq(PERSONIDENT_UTEN_IDENT), eq(Tema.ENF.name)) } throws PdlNotFoundException()
     }
 
     @After
     fun tearDown() {
         clearMocks(aktørClient)
+        clearMocks(pdlRestClient)
         cacheManager.cacheNames.forEach { cacheManager.getCache(it)!!.clear() }
     }
 
@@ -62,6 +94,13 @@ class AktørServiceTest : OppslagSpringRunnerTest() {
     }
 
     @Test
+    fun `skal returnere aktørId fra pdl første gang`() {
+        val testAktørId = aktørService.getAktørIdFraPdl(PERSONIDENT, Tema.ENF.name)
+        assertThat(testAktørId).isEqualTo(TESTAKTORID)
+        verify(exactly = 1) { (pdlRestClient.hentGjeldendeAktørId(any(), any())) }
+    }
+
+    @Test
     fun `skal returnere aktørId fra cache når den ligger den`() {
         repeat(2) {
             assertThat(aktørService.getAktørId(PERSONIDENT)).isEqualTo(TESTAKTORID)
@@ -70,11 +109,30 @@ class AktørServiceTest : OppslagSpringRunnerTest() {
     }
 
     @Test
+    fun `skal returnere aktørId fra cache når den ligger der fra pdl`() {
+        repeat(2) {
+            assertThat(aktørService.getAktørIdFraPdl(PERSONIDENT, Tema.ENF.name)).isEqualTo(TESTAKTORID)
+        }
+        verify(exactly = 1) { pdlRestClient.hentGjeldendeAktørId(any(), any()) }
+    }
+
+    @Test
     fun `skal ikke cachea nullverdier`() {
         repeat(2) {
             assertThat(aktørService.getAktørId(PERSONIDENT_UTEN_IDENT)).isNull()
         }
         verify(exactly = 2) { aktørClient.hentAktørId(any()) }
+    }
+
+
+    @Test
+    fun `skal ikke cachea når den feiler`() {
+        repeat(2) {
+            assertThrows<Exception> {
+                aktørService.getAktørIdFraPdl(PERSONIDENT_UTEN_IDENT, Tema.ENF.name)
+            }
+        }
+        verify(exactly = 2) { pdlRestClient.hentGjeldendeAktørId(any(), any()) }
     }
 
     companion object {


### PR DESCRIPTION
For å fase oss vekk fra aktørregisteret har jeg lagt inn nye endepunkt som tar i bruk pdl for å hente ut gjeldende aktørid/personident (basert på motsatsen).