### PR TITLE
Tilgang familie

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/EgenAnsattRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/EgenAnsattRestClient.kt
@@ -15,13 +15,14 @@ class EgenAnsattRestClient(@Value("\${EGEN_ANSATT_URL}") private val uri: URI,
 
     override val pingUri: URI = UriUtil.uri(uri, PATH_PING)
     private val egenAnsattUri: URI = UriUtil.uri(uri, "skjermet")
+    private val egenAnsattBulkUri: URI = UriUtil.uri(uri, "skjermetBulk")
 
     data class SkjermetDataRequestDTO(val personident: String)
     data class SkjermetDataBolkRequestDTO(val personidenter: List<String>)
 
     fun erEgenAnsatt(personIdent: String): Boolean = postForEntity(egenAnsattUri, SkjermetDataRequestDTO(personIdent))
 
-    fun erEgenAnsatt(personidenter: List<String>): Map<String, Boolean> = postForEntity(egenAnsattUri, SkjermetDataBolkRequestDTO(personidenter))
+    fun erEgenAnsatt(personidenter: List<String>): Map<String, Boolean> = postForEntity(egenAnsattBulkUri, SkjermetDataBolkRequestDTO(personidenter))
 
     companion object {
 

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/EgenAnsattRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/EgenAnsattRestClient.kt
@@ -17,8 +17,11 @@ class EgenAnsattRestClient(@Value("\${EGEN_ANSATT_URL}") private val uri: URI,
     private val egenAnsattUri: URI = UriUtil.uri(uri, "skjermet")
 
     data class SkjermetDataRequestDTO(val personident: String)
+    data class SkjermetDataBolkRequestDTO(val personidenter: List<String>)
 
-    fun erEgenAnsatt(fnr: String): Boolean = postForEntity(egenAnsattUri, SkjermetDataRequestDTO(fnr))
+    fun erEgenAnsatt(personIdent: String): Boolean = postForEntity(egenAnsattUri, SkjermetDataRequestDTO(personIdent))
+
+    fun erEgenAnsatt(personidenter: List<String>): Map<String, Boolean> = postForEntity(egenAnsattUri, SkjermetDataBolkRequestDTO(personidenter))
 
     companion object {
 

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/EgenAnsattRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/EgenAnsattRestClient.kt
@@ -18,11 +18,11 @@ class EgenAnsattRestClient(@Value("\${EGEN_ANSATT_URL}") private val uri: URI,
     private val egenAnsattBulkUri: URI = UriUtil.uri(uri, "skjermetBulk")
 
     data class SkjermetDataRequestDTO(val personident: String)
-    data class SkjermetDataBolkRequestDTO(val personidenter: List<String>)
+    data class SkjermetDataBolkRequestDTO(val personidenter: Set<String>)
 
     fun erEgenAnsatt(personIdent: String): Boolean = postForEntity(egenAnsattUri, SkjermetDataRequestDTO(personIdent))
 
-    fun erEgenAnsatt(personidenter: List<String>): Map<String, Boolean> = postForEntity(egenAnsattBulkUri, SkjermetDataBolkRequestDTO(personidenter))
+    fun erEgenAnsatt(personidenter: Set<String>): Map<String, Boolean> = postForEntity(egenAnsattBulkUri, SkjermetDataBolkRequestDTO(personidenter))
 
     companion object {
 

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/PdlRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/PdlRestClient.kt
@@ -7,7 +7,22 @@ import no.nav.familie.integrasjoner.felles.OppslagException
 import no.nav.familie.integrasjoner.felles.Tema
 import no.nav.familie.integrasjoner.felles.graphqlCompatible
 import no.nav.familie.integrasjoner.personopplysning.PdlNotFoundException
-import no.nav.familie.integrasjoner.personopplysning.internal.*
+import no.nav.familie.integrasjoner.personopplysning.PdlRequestException
+import no.nav.familie.integrasjoner.personopplysning.internal.Familierelasjon
+import no.nav.familie.integrasjoner.personopplysning.internal.PdlBolkResponse
+import no.nav.familie.integrasjoner.personopplysning.internal.PdlHentIdenter
+import no.nav.familie.integrasjoner.personopplysning.internal.PdlIdent
+import no.nav.familie.integrasjoner.personopplysning.internal.PdlIdentRequest
+import no.nav.familie.integrasjoner.personopplysning.internal.PdlIdentRequestVariables
+import no.nav.familie.integrasjoner.personopplysning.internal.PdlPerson
+import no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonBolkRequest
+import no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonBolkRequestVariables
+import no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonMedRelasjonerOgAdressebeskyttelse
+import no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonRequest
+import no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonRequestVariables
+import no.nav.familie.integrasjoner.personopplysning.internal.PdlResponse
+import no.nav.familie.integrasjoner.personopplysning.internal.Person
+import no.nav.familie.integrasjoner.personopplysning.internal.Personident
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
@@ -93,26 +108,50 @@ class PdlRestClient(@Value("\${PDL_URL}") pdlBaseUrl: URI,
                 throw pdlOppslagException(feilmelding = "Feil ved oppslag på person: ${response.errorMessages()}",
                                           personIdent = ident)
             }
-
             return response.data.hentIdenter.identer
         } catch (e: OppslagException) {
             throw e
-        } catch(e: Exception) {
+        } catch (e: Exception) {
             throw pdlOppslagException(ident, error = e)
         }
+    }
 
+    fun hentPersonMedRelasjonerOgAdressebeskyttelse(identer: List<String>,
+                                                    tema: Tema): Map<String, PdlPersonMedRelasjonerOgAdressebeskyttelse> {
+        val request = PdlPersonBolkRequest(variables = PdlPersonBolkRequestVariables(identer),
+                                           query = HENT_PERSON_RELASJONER_ADRESSEBESKYTTELSE)
+        val response = postForEntity<PdlBolkResponse<PdlPersonMedRelasjonerOgAdressebeskyttelse>>(pdlUri,
+                                                                                                  request,
+                                                                                                  httpHeaders(tema.name))
+        return feilsjekkOgReturnerData(response)
+    }
+
+    private inline fun <reified T : Any> feilsjekkOgReturnerData(pdlResponse: PdlBolkResponse<T>): Map<String, T> {
+        if (pdlResponse.data == null) {
+            secureLogger.error("Data fra pdl er null ved bolkoppslag av ${T::class} fra PDL: ${pdlResponse.errorMessages()}")
+            throw PdlRequestException("Data er null fra PDL -  ${T::class}. Se secure logg for detaljer.")
+        }
+
+        val feil = pdlResponse.data.personBolk.filter { it.code != "ok" }.map { it.ident to it.code }.toMap()
+        if (feil.isNotEmpty()) {
+            secureLogger.error("Feil ved henting av ${T::class} fra PDL: $feil")
+            throw PdlRequestException("Feil ved henting av ${T::class} fra PDL. Se secure logg for detaljer.")
+        }
+        return pdlResponse.data.personBolk.associateBy({ it.ident }, { it.person!! })
     }
 
     fun hentGjeldendeAktørId(ident: String, tema: Tema): String {
         val pdlIdenter = hentIdenter(ident, "AKTORID", tema, false)
         return pdlIdenter.firstOrNull()?.ident
-                ?: throw pdlOppslagException(feilmelding = "Kunne ikke finne aktørId for personIdent=$ident i PDL. ", personIdent = ident)
+               ?: throw pdlOppslagException(feilmelding = "Kunne ikke finne aktørId for personIdent=$ident i PDL. ",
+                                            personIdent = ident)
     }
 
     fun hentGjeldendePersonident(ident: String, tema: Tema): String {
         val pdlIdenter = hentIdenter(ident, "FOLKEREGISTERIDENT", tema, false)
         return pdlIdenter.firstOrNull()?.ident
-                ?: throw pdlOppslagException(feilmelding = "Kunne ikke finne personIdent for aktørId=$ident i PDL. ", personIdent = ident)
+               ?: throw pdlOppslagException(feilmelding = "Kunne ikke finne personIdent for aktørId=$ident i PDL. ",
+                                            personIdent = ident)
     }
 
 
@@ -144,6 +183,7 @@ class PdlRestClient(@Value("\${PDL_URL}") pdlBaseUrl: URI,
 
         private const val PATH_GRAPHQL = "graphql"
         private val HENT_IDENTER_QUERY = hentGraphqlQuery("hentIdenter")
+        private val HENT_PERSON_RELASJONER_ADRESSEBESKYTTELSE = hentGraphqlQuery("hentpersoner-relasjoner-adressebeskyttelse")
     }
 }
 

--- a/src/main/java/no/nav/familie/integrasjoner/client/soap/PersonSoapClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/soap/PersonSoapClient.kt
@@ -24,7 +24,7 @@ class PersonSoapClient(private val port: PersonV3) : AbstractSoapClient("personV
     private val secureLogger = LoggerFactory.getLogger("secureLogger")
 
     @Retryable(value = [OppslagException::class], maxAttempts = 3, backoff = Backoff(delay = 4000))
-    fun hentPersonResponse(request: HentPersonRequest?): HentPersonResponse {
+    fun hentPersonResponse(request: HentPersonRequest): HentPersonResponse {
         return try {
             port.hentPerson(request)
         } catch (e: Exception) {
@@ -75,7 +75,7 @@ class PersonSoapClient(private val port: PersonV3) : AbstractSoapClient("personV
      * @throws HentPersonhistorikkPersonIkkeFunnet      når bruker ikke finnes
      */
     @Retryable(value = [OppslagException::class], maxAttempts = 3, backoff = Backoff(delay = 4000))
-    fun hentPersonhistorikkResponse(request: HentPersonhistorikkRequest?): HentPersonhistorikkResponse {
+    fun hentPersonhistorikkResponse(request: HentPersonhistorikkRequest): HentPersonhistorikkResponse {
         return try {
             executeMedMetrics { port.hentPersonhistorikk(request) }
         } catch (e: Exception) {

--- a/src/main/java/no/nav/familie/integrasjoner/config/CacheConfig.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/config/CacheConfig.kt
@@ -21,7 +21,7 @@ class CacheConfig {
                     .newBuilder()
                     .initialCapacity(100)
                     .maximumSize(1000)
-                    .expireAfterWrite(1, TimeUnit.HOURS)
+                    .expireAfterWrite(2, TimeUnit.HOURS)
                     .recordStats().build<Any, Any>().asMap()
             return ConcurrentMapCache(name, concurrentMap, true)
         }

--- a/src/main/java/no/nav/familie/integrasjoner/config/TilgangConfig.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/config/TilgangConfig.kt
@@ -6,4 +6,4 @@ import org.springframework.boot.context.properties.ConstructorBinding
 
 @ConfigurationProperties("no.nav.security.jwt.tilgang")
 @ConstructorBinding
-class TilgangConfig(val grupper: MutableMap<String, AdRolle>)
+class TilgangConfig(val grupper: Map<String, AdRolle>)

--- a/src/main/java/no/nav/familie/integrasjoner/egenansatt/EgenAnsattService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/egenansatt/EgenAnsattService.kt
@@ -1,8 +1,6 @@
 package no.nav.familie.integrasjoner.egenansatt
 
 import no.nav.familie.integrasjoner.client.rest.EgenAnsattRestClient
-import no.nav.familie.integrasjoner.dokarkiv.DokarkivController
-import org.slf4j.LoggerFactory
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 
@@ -10,5 +8,7 @@ import org.springframework.stereotype.Service
 class EgenAnsattService(private val egenAnsattRestClient: EgenAnsattRestClient) {
 
     @Cacheable("erEgenAnsatt")
-    fun erEgenAnsatt(fnr: String): Boolean = egenAnsattRestClient.erEgenAnsatt(fnr)
+    fun erEgenAnsatt(personIdent: String): Boolean = egenAnsattRestClient.erEgenAnsatt(personIdent)
+
+    fun erEgenAnsatt(personIdenter: List<String>): Map<String, Boolean> = egenAnsattRestClient.erEgenAnsatt(personIdenter)
 }

--- a/src/main/java/no/nav/familie/integrasjoner/egenansatt/EgenAnsattService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/egenansatt/EgenAnsattService.kt
@@ -10,5 +10,5 @@ class EgenAnsattService(private val egenAnsattRestClient: EgenAnsattRestClient) 
     @Cacheable("erEgenAnsatt")
     fun erEgenAnsatt(personIdent: String): Boolean = egenAnsattRestClient.erEgenAnsatt(personIdent)
 
-    fun erEgenAnsatt(personIdenter: List<String>): Map<String, Boolean> = egenAnsattRestClient.erEgenAnsatt(personIdenter)
+    fun erEgenAnsatt(personIdenter: Set<String>): Map<String, Boolean> = egenAnsattRestClient.erEgenAnsatt(personIdenter)
 }

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerService.kt
@@ -85,7 +85,7 @@ class PersonopplysningerService(private val personSoapClient: PersonSoapClient,
         val sivilstandIdenter = hovedperson.sivilstand.mapNotNull { it.relatertVedSivilstand }.distinct()
         val fullmaktIdenter = hovedperson.fullmakt.map { it.motpartsPersonident }.distinct()
 
-        val tilknyttedeIdenter = (sivilstandIdenter + fullmaktIdenter + barnIdenter).distinct()
+        val tilknyttedeIdenter = (barnIdenter + sivilstandIdenter + fullmaktIdenter).distinct()
         val tilknyttedeIdenterData = hentPersonMedRelasjonerOgAdressebeskyttelse(tilknyttedeIdenter, tema)
 
         val barnOpplysninger = tilknyttedeIdenterData.filter { (ident, _) -> barnIdenter.contains(ident) }

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlPersonBolkRequest.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlPersonBolkRequest.kt
@@ -1,0 +1,5 @@
+package no.nav.familie.integrasjoner.personopplysning.internal
+
+data class PdlPersonBolkRequest(val variables: PdlPersonBolkRequestVariables,
+                                val query: String)
+data class PdlPersonBolkRequestVariables(val identer: List<String>)

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlResponse.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlResponse.kt
@@ -30,10 +30,10 @@ data class PdlBolkResponse<T>(val data: PersonBolk<T>?, val errors: List<PdlErro
 }
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class PdlPersonMedRelasjonerOgAdressebeskyttelse(val familierelasjoner: List<PdlFamilierelasjon> = emptyList(),
-                                                      val sivilstand: List<Sivilstand>,
-                                                      val fullmakt: List<Fullmakt>,
-                                                      val adressebeskyttelse: List<Adressebeskyttelse>)
+    data class PdlPersonMedRelasjonerOgAdressebeskyttelse(val familierelasjoner: List<PdlFamilierelasjon>,
+                                                          val sivilstand: List<Sivilstand>,
+                                                          val fullmakt: List<Fullmakt>,
+                                                          val adressebeskyttelse: List<Adressebeskyttelse>)
 
 data class PdlPerson(val person: PdlPersonData?)
 

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlResponse.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlResponse.kt
@@ -51,7 +51,7 @@ data class PdlFødselsDato(val foedselsdato: String?)
 data class PdlError(val message: String,
                     val extensions: PdlExtensions?)
 
-data class PdlExtensions(val code: String) {
+data class PdlExtensions(val code: String?) {
     fun notFound() = code == "not_found"
 }
 

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlResponse.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlResponse.kt
@@ -20,6 +20,19 @@ data class PdlResponse<T>(val data: T,
     }
 }
 
+data class PersonDataBolk<T>(val ident: String, val code: String, val person: T?)
+data class PersonBolk<T>(val personBolk: List<PersonDataBolk<T>>)
+data class PdlBolkResponse<T>(val data: PersonBolk<T>?, val errors: List<PdlError>?) {
+
+    fun errorMessages(): String {
+        return errors?.joinToString { it -> it.message } ?: ""
+    }
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class PdlPersonMedRelasjonerOgAdressebeskyttelse(val familierelasjoner: List<PdlFamilierelasjon> = emptyList(),
+                                                      val adressebeskyttelse: List<Adressebeskyttelse>)
+
 data class PdlPerson(val person: PdlPersonData?)
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlResponse.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlResponse.kt
@@ -31,6 +31,8 @@ data class PdlBolkResponse<T>(val data: PersonBolk<T>?, val errors: List<PdlErro
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class PdlPersonMedRelasjonerOgAdressebeskyttelse(val familierelasjoner: List<PdlFamilierelasjon> = emptyList(),
+                                                      val sivilstand: List<Sivilstand>,
+                                                      val fullmakt: List<Fullmakt>,
                                                       val adressebeskyttelse: List<Adressebeskyttelse>)
 
 data class PdlPerson(val person: PdlPersonData?)
@@ -52,6 +54,7 @@ data class PdlError(val message: String,
                     val extensions: PdlExtensions?)
 
 data class PdlExtensions(val code: String?) {
+
     fun notFound() = code == "not_found"
 }
 
@@ -82,9 +85,11 @@ data class Adressebeskyttelse(
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class Sivilstand(
-        val type: SIVILSTAND
-)
+data class Sivilstand(val type: SIVILSTAND,
+                      val relatertVedSivilstand: String?)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Fullmakt(val motpartsPersonident: String)
 
 enum class KJØNN {
     MANN,

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PersonMedRelasjoner.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PersonMedRelasjoner.kt
@@ -1,0 +1,12 @@
+package no.nav.familie.integrasjoner.personopplysning.internal
+
+data class PersonMedRelasjoner(
+        val personIdent: String,
+        val adressebeskyttelse: ADRESSEBESKYTTELSEGRADERING?,
+        val sivilstand: List<PersonMedAdresseBeskyttelse>,
+        val fullmakt: List<PersonMedAdresseBeskyttelse>,
+        val barn: List<PersonMedAdresseBeskyttelse>,
+        val barnsForeldrer: List<PersonMedAdresseBeskyttelse>)
+
+data class PersonMedAdresseBeskyttelse(val personIdent: String,
+                                       val adressebeskyttelse: ADRESSEBESKYTTELSEGRADERING?)

--- a/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollService.kt
@@ -69,9 +69,8 @@ class CachedTilgangskontrollService(private val egenAnsattService: EgenAnsattSer
      * Trenger kun å sjekke personen og barnets andre foreldrer for om de er ansatt
      */
     private fun erEgenAnsatt(personMedRelasjoner: PersonMedRelasjoner): Boolean {
-        val relevanteIdenterÅSjekkeEgenAnsattFor =
-                setOf(personMedRelasjoner.personIdent) + personMedRelasjoner.barnsForeldrer.map { it.personIdent }
-        return egenAnsattService.erEgenAnsatt(relevanteIdenterÅSjekkeEgenAnsattFor).any { it.value }
+        val relevanteIdenter = setOf(personMedRelasjoner.personIdent) + personMedRelasjoner.barnsForeldrer.map { it.personIdent }
+        return egenAnsattService.erEgenAnsatt(relevanteIdenter).any { it.value }
     }
 
     private fun høyesteGraderingen(personUtvidet: PersonMedRelasjoner): ADRESSEBESKYTTELSEGRADERING? {

--- a/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollService.kt
@@ -49,6 +49,7 @@ class CachedTilgangskontrollService(private val egenAnsattService: EgenAnsattSer
                condition = "#jwtToken.subject != null")
     fun sjekkTilgangTilPersonMedRelasjoner(personIdent: String, jwtToken: JwtToken, tema: Tema): Tilgang {
         val personMedRelasjoner = personopplysningerService.hentPersonMedRelasjoner(personIdent, tema)
+        secureLogger.info("Sjekker tilgang til {}", personMedRelasjoner)
 
         val tilgang = when (høyesteGraderingen(personMedRelasjoner)) {
             FORTROLIG -> hentTilgangForRolle(tilgangConfig.grupper["kode7"], jwtToken, personIdent)

--- a/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollService.kt
@@ -9,6 +9,7 @@ import no.nav.familie.integrasjoner.personopplysning.internal.ADRESSEBESKYTTELSE
 import no.nav.familie.integrasjoner.personopplysning.internal.ADRESSEBESKYTTELSEGRADERING.FORTROLIG
 import no.nav.familie.integrasjoner.personopplysning.internal.ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG
 import no.nav.familie.integrasjoner.personopplysning.internal.ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG_UTLAND
+import no.nav.familie.integrasjoner.personopplysning.internal.PersonMedRelasjoner
 import no.nav.familie.integrasjoner.tilgangskontroll.domene.AdRolle
 import no.nav.familie.kontrakter.felles.tilgangskontroll.Tilgang
 import no.nav.security.token.support.core.jwt.JwtToken
@@ -43,37 +44,41 @@ class CachedTilgangskontrollService(private val egenAnsattService: EgenAnsattSer
         }
     }
 
-    @Cacheable(cacheNames = ["TILGANG_TIL_FAMILIE"],
+    @Cacheable(cacheNames = ["TILGANG_TIL_PERSON_MED_RELASJONER"],
                key = "#jwtToken.subject.concat(#personIdent)",
                condition = "#jwtToken.subject != null")
-    fun sjekkTilgangTilFamilie(personIdent: String, jwtToken: JwtToken, tema: Tema): Tilgang {
+    fun sjekkTilgangTilPersonMedRelasjoner(personIdent: String, jwtToken: JwtToken, tema: Tema): Tilgang {
         val personMedRelasjoner = personopplysningerService.hentPersonMedRelasjoner(personIdent, tema)
-        val alleIdenter =
-                listOf(personIdent) + personMedRelasjoner.barn.map { it.personIdent } + personMedRelasjoner.barnsForeldrer.map { it.personIdent }
 
         val tilgang = when (høyesteGraderingen(personMedRelasjoner)) {
             FORTROLIG -> hentTilgangForRolle(tilgangConfig.grupper["kode7"], jwtToken, personIdent)
             STRENGT_FORTROLIG, STRENGT_FORTROLIG_UTLAND ->
-                hentTilgangForRolle(
-                        tilgangConfig.grupper["kode6"],
-                        jwtToken,
-                        personIdent)
+                hentTilgangForRolle(tilgangConfig.grupper["kode6"], jwtToken, personIdent)
             else -> Tilgang(harTilgang = true)
         }
         if (!tilgang.harTilgang) {
             return tilgang
         }
-        if (egenAnsattService.erEgenAnsatt(alleIdenter).any { it.value }) {
+        if (erEgenAnsatt(personMedRelasjoner)) {
             return hentTilgangForRolle(tilgangConfig.grupper["utvidetTilgang"], jwtToken, personIdent)
         }
         return Tilgang(harTilgang = true)
     }
 
-    // TODO uklart om man kan hente ut høyeste graderingen eller om man må sjekke flere
-    private fun høyesteGraderingen(personMedRelasjoner: PersonopplysningerService.PersonMedFamilieCache): ADRESSEBESKYTTELSEGRADERING? {
-        val adressebeskyttelser = (setOf(personMedRelasjoner.adressebeskyttelse) +
-                                   personMedRelasjoner.barn.map { it.adressebeskyttelse } +
-                                   personMedRelasjoner.barnsForeldrer.map { it.adressebeskyttelse }).filterNotNull()
+    /**
+     * Trenger kun å sjekke personen og barnets andre foreldrer for om de er ansatt
+     */
+    private fun erEgenAnsatt(personMedRelasjoner: PersonMedRelasjoner): Boolean {
+        val relevanteIdenterÅSjekkeEgenAnsattFor =
+                setOf(personMedRelasjoner.personIdent) + personMedRelasjoner.barnsForeldrer.map { it.personIdent }
+        return egenAnsattService.erEgenAnsatt(relevanteIdenterÅSjekkeEgenAnsattFor).any { it.value }
+    }
+
+    private fun høyesteGraderingen(personUtvidet: PersonMedRelasjoner): ADRESSEBESKYTTELSEGRADERING? {
+        val adressebeskyttelser =
+                (personUtvidet.adressebeskyttelse?.let { setOf(it) } ?: emptySet<ADRESSEBESKYTTELSEGRADERING>() +
+                 listOf(personUtvidet.sivilstand, personUtvidet.fullmakt, personUtvidet.barn, personUtvidet.barnsForeldrer)
+                         .flatMap { relasjoner -> relasjoner.mapNotNull { it.adressebeskyttelse } })
         return when {
             adressebeskyttelser.contains(STRENGT_FORTROLIG_UTLAND) -> STRENGT_FORTROLIG_UTLAND
             adressebeskyttelser.contains(STRENGT_FORTROLIG) -> STRENGT_FORTROLIG

--- a/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/TilgangskontrollController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/TilgangskontrollController.kt
@@ -36,10 +36,10 @@ class TilgangskontrollController(private val tilgangskontrollService: Tilgangsko
         return tilgangskontrollService.sjekkTilgangTilBrukere(personIdenter, tema)
     }
 
-    @PostMapping(path = ["/familie"])
+    @PostMapping(path = ["/person-med-relasjoner"])
     @ProtectedWithClaims(issuer = "azuread")
-    fun tilgangTilPersonerV3(@RequestBody personIdent: PersonIdent, @RequestHeader(name = "Nav-Tema") tema: Tema): Tilgang {
-        return tilgangskontrollService.sjekkTilgangTilFamilie(personIdent.ident, tema)
+    fun tilgangTilPersonMedRelasjoner(@RequestBody personIdent: PersonIdent, @RequestHeader(name = "Nav-Tema") tema: Tema): Tilgang {
+        return tilgangskontrollService.sjekkTilgangTilPersonMedRelasjoner(personIdent.ident, tema)
     }
 
 }

--- a/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/TilgangskontrollController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/TilgangskontrollController.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.integrasjoner.tilgangskontroll
 
 import no.nav.familie.integrasjoner.felles.Tema
+import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.kontrakter.felles.tilgangskontroll.Tilgang
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.context.annotation.Profile
@@ -34,4 +35,11 @@ class TilgangskontrollController(private val tilgangskontrollService: Tilgangsko
     fun tilgangTilPersoner(@RequestBody personIdenter: List<String>, @RequestHeader(name = "Nav-Tema") tema: Tema): List<Tilgang> {
         return tilgangskontrollService.sjekkTilgangTilBrukere(personIdenter, tema)
     }
+
+    @PostMapping(path = ["/familie"])
+    @ProtectedWithClaims(issuer = "azuread")
+    fun tilgangTilPersonerV3(@RequestBody personIdent: PersonIdent, @RequestHeader(name = "Nav-Tema") tema: Tema): Tilgang {
+        return tilgangskontrollService.sjekkTilgangTilFamilie(personIdent.ident, tema)
+    }
+
 }

--- a/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/TilgangskontrollService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/TilgangskontrollService.kt
@@ -22,9 +22,12 @@ class TilgangskontrollService(private val cachedTilgangskontrollService: CachedT
         return cachedTilgangskontrollService.sjekkTilgang(personIdent, jwtToken, tema)
     }
 
-    fun sjekkTilgangTilFamilie(personIdent: String, tema: Tema): Tilgang {
+    fun sjekkTilgangTilPersonMedRelasjoner(personIdent: String, tema: Tema): Tilgang {
+        if(tema != Tema.ENF) {
+            throw IllegalArgumentException("Har ikke lagt inn støtte for andre enn ENF")
+        }
         val jwtToken = SpringTokenValidationContextHolder().tokenValidationContext.getJwtToken("azuread")
-        return cachedTilgangskontrollService.sjekkTilgangTilFamilie(personIdent, jwtToken, tema)
+        return cachedTilgangskontrollService.sjekkTilgangTilPersonMedRelasjoner(personIdent, jwtToken, tema)
     }
 
 }

--- a/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/TilgangskontrollService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/TilgangskontrollService.kt
@@ -22,4 +22,9 @@ class TilgangskontrollService(private val cachedTilgangskontrollService: CachedT
         return cachedTilgangskontrollService.sjekkTilgang(personIdent, jwtToken, tema)
     }
 
+    fun sjekkTilgangTilFamilie(personIdent: String, tema: Tema): Tilgang {
+        val jwtToken = SpringTokenValidationContextHolder().tokenValidationContext.getJwtToken("azuread")
+        return cachedTilgangskontrollService.sjekkTilgangTilFamilie(personIdent, jwtToken, tema)
+    }
+
 }

--- a/src/main/resources/pdl/hentpersoner-relasjoner-adressebeskyttelse.graphql
+++ b/src/main/resources/pdl/hentpersoner-relasjoner-adressebeskyttelse.graphql
@@ -1,0 +1,11 @@
+query($identer: [ID!]!){
+    personBolk: hentPersonBolk(identer: $identer) {
+        adressebeskyttelse {
+            gradering
+        }
+        familierelasjoner {
+            relatertPersonsIdent
+            relatertPersonsRolle
+        }
+    }
+}

--- a/src/main/resources/pdl/hentpersoner-relasjoner-adressebeskyttelse.graphql
+++ b/src/main/resources/pdl/hentpersoner-relasjoner-adressebeskyttelse.graphql
@@ -1,11 +1,15 @@
 query($identer: [ID!]!){
     personBolk: hentPersonBolk(identer: $identer) {
-        adressebeskyttelse {
-            gradering
-        }
-        familierelasjoner {
-            relatertPersonsIdent
-            relatertPersonsRolle
+        code
+        ident
+        person {
+            adressebeskyttelse {
+                gradering
+            }
+            familierelasjoner {
+                relatertPersonsIdent
+                relatertPersonsRolle
+            }
         }
     }
 }

--- a/src/main/resources/pdl/hentpersoner-relasjoner-adressebeskyttelse.graphql
+++ b/src/main/resources/pdl/hentpersoner-relasjoner-adressebeskyttelse.graphql
@@ -10,6 +10,13 @@ query($identer: [ID!]!){
                 relatertPersonsIdent
                 relatertPersonsRolle
             }
+            sivilstand {
+                type
+                relatertVedSivilstand
+            }
+            fullmakt {
+                motpartsPersonident
+            }
         }
     }
 }

--- a/src/test/java/no/nav/familie/integrasjoner/egenansatt/EgenAnsattServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/egenansatt/EgenAnsattServiceTest.kt
@@ -12,7 +12,7 @@ class EgenAnsattServiceTest {
 
     @Test
     fun `Er egen ansatt`() {
-        every { egenAnsattRestClientMock.erEgenAnsatt(any()) } returns true
+        every { egenAnsattRestClientMock.erEgenAnsatt(any<String>()) } returns true
         assertThat(egenAnsattService.erEgenAnsatt("1")).isTrue
     }
 }

--- a/src/test/java/no/nav/familie/integrasjoner/egenansatt/EgenAnsattTestConfig.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/egenansatt/EgenAnsattTestConfig.kt
@@ -16,7 +16,7 @@ class EgenAnsattTestConfig {
     @Primary
     fun egenAnssattClientMock(): EgenAnsattRestClient {
         val egenAnsattClient: EgenAnsattRestClient = mockk(relaxed = true)
-        every { egenAnsattClient.erEgenAnsatt(any()) } returns true
+        every { egenAnsattClient.erEgenAnsatt(any<String>()) } returns true
         return egenAnsattClient
     }
 }

--- a/src/test/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerServiceTest.kt
@@ -1,8 +1,12 @@
 package no.nav.familie.integrasjoner.personopplysning
 
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import no.nav.familie.integrasjoner.client.rest.PdlRestClient
 import no.nav.familie.integrasjoner.client.soap.PersonSoapClient
 import no.nav.familie.integrasjoner.felles.OppslagException
+import no.nav.familie.integrasjoner.felles.Tema
 import no.nav.familie.integrasjoner.personopplysning.domene.TpsOversetter
 import no.nav.familie.integrasjoner.personopplysning.domene.adresse.AdresseType
 import no.nav.familie.integrasjoner.personopplysning.domene.adresse.TpsAdresseOversetter
@@ -11,15 +15,18 @@ import no.nav.familie.integrasjoner.personopplysning.domene.relasjon.RelasjonsRo
 import no.nav.familie.integrasjoner.personopplysning.domene.relasjon.SivilstandType
 import no.nav.familie.integrasjoner.personopplysning.domene.status.PersonstatusType
 import no.nav.familie.integrasjoner.personopplysning.domene.tilhørighet.Landkode
+import no.nav.familie.integrasjoner.personopplysning.internal.Adressebeskyttelse
+import no.nav.familie.integrasjoner.personopplysning.internal.FAMILIERELASJONSROLLE
+import no.nav.familie.integrasjoner.personopplysning.internal.Fullmakt
+import no.nav.familie.integrasjoner.personopplysning.internal.PdlFamilierelasjon
+import no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonMedRelasjonerOgAdressebeskyttelse
+import no.nav.familie.integrasjoner.personopplysning.internal.Sivilstand
+import no.nav.familie.kontrakter.felles.personopplysning.SIVILSTAND
 import no.nav.familie.kontrakter.ks.søknad.testdata.SøknadTestdata
-import no.nav.tjeneste.virksomhet.person.v3.meldinger.HentPersonRequest
-import no.nav.tjeneste.virksomhet.person.v3.meldinger.HentPersonhistorikkRequest
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Before
 import org.junit.Test
-import org.mockito.ArgumentMatchers
-import org.mockito.Mockito
-import org.mockito.Mockito.mock
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 
@@ -28,40 +35,39 @@ class PersonopplysningerServiceTest {
     private lateinit var personSoapClient: PersonSoapClient
     private lateinit var personopplysningerService: PersonopplysningerService
 
+    private val pdlRestClient = mockk<PdlRestClient>()
+
     @Before
     fun setUp() {
         personSoapClient = PersonopplysningerTestConfig().personConsumerMock()
         personopplysningerService = PersonopplysningerService(personSoapClient,
                                                               TpsOversetter(TpsAdresseOversetter()),
-                                                              mock(PdlRestClient::class.java))
+                                                              pdlRestClient)
     }
 
     @Test
     fun personhistorikkInfoSkalGiFeilVedUgyldigAktørId() {
-        Mockito.`when`(personSoapClient.hentPersonhistorikkResponse(
-                ArgumentMatchers.any(HentPersonhistorikkRequest::class.java)))
-                .thenThrow(OppslagException("feil", "feil", OppslagException.Level.MEDIUM))
-        Assertions.assertThatThrownBy {
+        every { personSoapClient.hentPersonhistorikkResponse(any()) } throws
+                OppslagException("feil", "feil", OppslagException.Level.MEDIUM)
+        assertThatThrownBy {
             personopplysningerService.hentHistorikkFor(PERSONIDENT, FOM, TOM)
         }.isInstanceOf(OppslagException::class.java)
     }
 
     @Test
     fun personHistorikkSkalGiFeilVedSikkerhetsbegrensning() {
-        Mockito.`when`(personSoapClient.hentPersonhistorikkResponse(
-                ArgumentMatchers.any(HentPersonhistorikkRequest::class.java)))
-                .thenThrow(OppslagException("feil", "feil", OppslagException.Level.MEDIUM))
-        Assertions.assertThatThrownBy {
+        every { personSoapClient.hentPersonhistorikkResponse(any()) } throws
+                OppslagException("feil", "feil", OppslagException.Level.MEDIUM)
+        assertThatThrownBy {
             personopplysningerService.hentHistorikkFor(PERSONIDENT, FOM, TOM)
         }.isInstanceOf(OppslagException::class.java)
     }
 
     @Test
     fun personinfoSkalGiFeilVedUgyldigAktørId() {
-        Mockito.`when`(personSoapClient.hentPersonResponse(
-                ArgumentMatchers.any(HentPersonRequest::class.java)))
-                .thenThrow(OppslagException("feil", "feil", OppslagException.Level.MEDIUM))
-        Assertions.assertThatThrownBy {
+        every { personSoapClient.hentPersonResponse(any()) } throws
+                OppslagException("feil", "feil", OppslagException.Level.MEDIUM)
+        assertThatThrownBy {
             personopplysningerService.hentPersoninfoFor(PERSONIDENT)
         }
                 .isInstanceOf(OppslagException::class.java)
@@ -69,67 +75,95 @@ class PersonopplysningerServiceTest {
 
     @Test
     fun personinfoSkalGiFeilVedSikkerhetsbegrensning() {
-        Mockito.`when`(personSoapClient.hentPersonResponse(
-                ArgumentMatchers.any(HentPersonRequest::class.java)))
-                .thenThrow(OppslagException("feil", "feil", OppslagException.Level.MEDIUM))
-        Assertions.assertThatThrownBy {
+        every { personSoapClient.hentPersonResponse(any()) } throws
+                OppslagException("feil", "feil", OppslagException.Level.MEDIUM)
+        assertThatThrownBy {
             personopplysningerService.hentPersoninfoFor(PERSONIDENT)
         }.isInstanceOf(OppslagException::class.java)
     }
 
     @Test
     fun skalKonvertereResponsTilPersonInfo() {
-        val response =
-                personopplysningerService.hentPersoninfoFor(PERSONIDENT)
+        val response = personopplysningerService.hentPersoninfoFor(PERSONIDENT)
         val forventetFødselsdato = LocalDate.parse("1990-01-01")
-        val barn =
-                response.familierelasjoner.find { p: Familierelasjon -> p.relasjonsrolle == RelasjonsRolleType.BARN }
-        val ektefelle =
-                response.familierelasjoner.find { p: Familierelasjon -> p.relasjonsrolle == RelasjonsRolleType.EKTE }
-        Assertions.assertThat(response.personIdent.id)
-                .isEqualTo(PERSONIDENT)
-        Assertions.assertThat(response.statsborgerskap.erNorge()).isTrue()
-        Assertions.assertThat(response.sivilstand).isEqualTo(SivilstandType.GIFT)
-        Assertions.assertThat(response.alder).isEqualTo(ChronoUnit.YEARS.between(forventetFødselsdato, LocalDate.now()))
-        Assertions.assertThat(response.adresseInfoList).hasSize(1)
-        Assertions.assertThat(response.personstatus).isEqualTo(PersonstatusType.BOSA)
-        Assertions.assertThat(response.geografiskTilknytning).isEqualTo("0315")
-        Assertions.assertThat(response.fødselsdato).isEqualTo(forventetFødselsdato)
-        Assertions.assertThat(response.dødsdato).isNull()
-        Assertions.assertThat(response.diskresjonskode).isNull()
-        Assertions.assertThat(response.adresseLandkode).isEqualTo("NOR")
-        Assertions.assertThat(response.familierelasjoner).hasSize(2)
-        Assertions.assertThat(barn).isNotNull
-        Assertions.assertThat(barn!!.harSammeBosted).isTrue()
-        Assertions.assertThat(ektefelle).isNotNull
-        Assertions.assertThat(ektefelle!!.harSammeBosted).isTrue()
+        val barn = response.familierelasjoner.find { p: Familierelasjon -> p.relasjonsrolle == RelasjonsRolleType.BARN }
+        val ektefelle = response.familierelasjoner.find { p: Familierelasjon -> p.relasjonsrolle == RelasjonsRolleType.EKTE }
+        assertThat(response.personIdent.id).isEqualTo(PERSONIDENT)
+        assertThat(response.statsborgerskap.erNorge()).isTrue()
+        assertThat(response.sivilstand).isEqualTo(SivilstandType.GIFT)
+        assertThat(response.alder).isEqualTo(ChronoUnit.YEARS.between(forventetFødselsdato, LocalDate.now()))
+        assertThat(response.adresseInfoList).hasSize(1)
+        assertThat(response.personstatus).isEqualTo(PersonstatusType.BOSA)
+        assertThat(response.geografiskTilknytning).isEqualTo("0315")
+        assertThat(response.fødselsdato).isEqualTo(forventetFødselsdato)
+        assertThat(response.dødsdato).isNull()
+        assertThat(response.diskresjonskode).isNull()
+        assertThat(response.adresseLandkode).isEqualTo("NOR")
+        assertThat(response.familierelasjoner).hasSize(2)
+        assertThat(barn).isNotNull
+        assertThat(barn!!.harSammeBosted).isTrue()
+        assertThat(ektefelle).isNotNull
+        assertThat(ektefelle!!.harSammeBosted).isTrue()
     }
 
     @Test
     fun skalKonvertereResponsTilPersonhistorikkInfo() {
-        val response =
-                personopplysningerService.hentHistorikkFor(PERSONIDENT, FOM, TOM)
+        val response = personopplysningerService.hentHistorikkFor(PERSONIDENT, FOM, TOM)
 
-        Assertions.assertThat(response.personIdent.id).isEqualTo(PERSONIDENT)
-        Assertions.assertThat(response.statsborgerskaphistorikk).hasSize(1)
-        Assertions.assertThat(response.personstatushistorikk).hasSize(1)
-        Assertions.assertThat(response.adressehistorikk).hasSize(2)
-        Assertions.assertThat(response.statsborgerskaphistorikk[0].tilhørendeLand).isEqualTo(Landkode.NORGE)
-        Assertions.assertThat(response.statsborgerskaphistorikk[0].periode.fom).isEqualTo(FOM)
-        Assertions.assertThat(response.personstatushistorikk[0].personstatus).isEqualTo(PersonstatusType.BOSA)
-        Assertions.assertThat(response.personstatushistorikk[0].periode.tom).isEqualTo(TOM)
-        Assertions.assertThat(response.adressehistorikk[0].adresse.adresseType).isEqualTo(AdresseType.BOSTEDSADRESSE)
-        Assertions.assertThat(response.adressehistorikk[0].adresse.land).isEqualTo(Landkode.NORGE.kode)
-        Assertions.assertThat(response.adressehistorikk[0].adresse.adresselinje1).isEqualTo("Sannergata 2")
-        Assertions.assertThat(response.adressehistorikk[0].adresse.postnummer).isEqualTo("0560")
-        Assertions.assertThat(response.adressehistorikk[0].adresse.poststed).isEqualTo("OSLO")
-        Assertions.assertThat(response.adressehistorikk[1].adresse.adresseType)
+        assertThat(response.personIdent.id).isEqualTo(PERSONIDENT)
+        assertThat(response.statsborgerskaphistorikk).hasSize(1)
+        assertThat(response.personstatushistorikk).hasSize(1)
+        assertThat(response.adressehistorikk).hasSize(2)
+        assertThat(response.statsborgerskaphistorikk[0].tilhørendeLand).isEqualTo(Landkode.NORGE)
+        assertThat(response.statsborgerskaphistorikk[0].periode.fom).isEqualTo(FOM)
+        assertThat(response.personstatushistorikk[0].personstatus).isEqualTo(PersonstatusType.BOSA)
+        assertThat(response.personstatushistorikk[0].periode.tom).isEqualTo(TOM)
+        assertThat(response.adressehistorikk[0].adresse.adresseType).isEqualTo(AdresseType.BOSTEDSADRESSE)
+        assertThat(response.adressehistorikk[0].adresse.land).isEqualTo(Landkode.NORGE.kode)
+        assertThat(response.adressehistorikk[0].adresse.adresselinje1).isEqualTo("Sannergata 2")
+        assertThat(response.adressehistorikk[0].adresse.postnummer).isEqualTo("0560")
+        assertThat(response.adressehistorikk[0].adresse.poststed).isEqualTo("OSLO")
+        assertThat(response.adressehistorikk[1].adresse.adresseType)
                 .isEqualTo(AdresseType.MIDLERTIDIG_POSTADRESSE_UTLAND)
-        Assertions.assertThat(response.adressehistorikk[1].adresse.land).isEqualTo("SWE")
-        Assertions.assertThat(response.adressehistorikk[1].adresse.adresselinje1).isEqualTo("TEST 1")
+        assertThat(response.adressehistorikk[1].adresse.land).isEqualTo("SWE")
+        assertThat(response.adressehistorikk[1].adresse.adresselinje1).isEqualTo("TEST 1")
     }
 
+    @Test
+    fun `hentPersonMedRelasjoner skal kalle på pdl 3 ganger, hovedpersonen, relasjonene og barnets andre forelder`() {
+        val hovedPerson = "1" to lagPdlPersonMedRelasjoner(familierelasjoner = listOf(PdlFamilierelasjon("2",
+                                                                                                         FAMILIERELASJONSROLLE.BARN)),
+                                                           sivilstand = listOf(Sivilstand(SIVILSTAND.GIFT, "3")),
+                                                           fullmakt = listOf(Fullmakt("4")))
+        val barn = lagPdlPersonMedRelasjoner(familierelasjoner = listOf(PdlFamilierelasjon("22",
+                                                                                           FAMILIERELASJONSROLLE.FAR)))
+        every { pdlRestClient.hentPersonMedRelasjonerOgAdressebeskyttelse(any(), any()) } answers {
+            firstArg<List<String>>().map { it to if (it == "2") barn else lagPdlPersonMedRelasjoner() }.toMap()
+        }
+        every { pdlRestClient.hentPersonMedRelasjonerOgAdressebeskyttelse(listOf("1"), any()) } returns mapOf(hovedPerson)
+
+        val hentPersonMedRelasjoner = personopplysningerService.hentPersonMedRelasjoner("1", Tema.ENF)
+
+        assertThat(hentPersonMedRelasjoner.barn.single().personIdent).isEqualTo("2")
+        assertThat(hentPersonMedRelasjoner.barnsForeldrer.single().personIdent).isEqualTo("22")
+        assertThat(hentPersonMedRelasjoner.sivilstand.single().personIdent).isEqualTo("3")
+        assertThat(hentPersonMedRelasjoner.fullmakt.single().personIdent).isEqualTo("4")
+
+        verify(exactly = 1) {
+            pdlRestClient.hentPersonMedRelasjonerOgAdressebeskyttelse(listOf("1"), any())
+            pdlRestClient.hentPersonMedRelasjonerOgAdressebeskyttelse(listOf("2", "3", "4"), any())
+            pdlRestClient.hentPersonMedRelasjonerOgAdressebeskyttelse(listOf("22"), any())
+        }
+    }
+
+    private fun lagPdlPersonMedRelasjoner(familierelasjoner: List<PdlFamilierelasjon> = emptyList(),
+                                          sivilstand: List<Sivilstand> = emptyList(),
+                                          fullmakt: List<Fullmakt> = emptyList(),
+                                          adressebeskyttelse: List<Adressebeskyttelse> = emptyList()) =
+            PdlPersonMedRelasjonerOgAdressebeskyttelse(familierelasjoner, sivilstand, fullmakt, adressebeskyttelse)
+
     companion object {
+
         private const val PERSONIDENT = SøknadTestdata.farPersonident
         private val TOM = LocalDate.now()
         private val FOM = TOM.minusYears(5)

--- a/src/test/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollServiceTest.kt
@@ -1,0 +1,127 @@
+package no.nav.familie.integrasjoner.tilgangskontroll
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.integrasjoner.config.TilgangConfig
+import no.nav.familie.integrasjoner.egenansatt.EgenAnsattService
+import no.nav.familie.integrasjoner.felles.Tema
+import no.nav.familie.integrasjoner.personopplysning.PersonopplysningerService
+import no.nav.familie.integrasjoner.personopplysning.internal.ADRESSEBESKYTTELSEGRADERING
+import no.nav.familie.integrasjoner.personopplysning.internal.PersonMedAdresseBeskyttelse
+import no.nav.familie.integrasjoner.personopplysning.internal.PersonMedRelasjoner
+import no.nav.familie.integrasjoner.tilgangskontroll.domene.AdRolle
+import no.nav.security.token.support.core.jwt.JwtToken
+import no.nav.security.token.support.core.jwt.JwtTokenClaims
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class CachedTilgangskontrollServiceTest {
+
+    private val egenAnsattService = mockk<EgenAnsattService>()
+    private val personopplysningerService = mockk<PersonopplysningerService>()
+    private val kode7Id = "6"
+    private val kode6Id = "7"
+
+    private val tilgangConfig = TilgangConfig(mapOf("kode7" to AdRolle(kode7Id, ""),
+                                                    "kode6" to AdRolle(kode6Id, "")))
+    private val cachedTilgangskontrollService = CachedTilgangskontrollService(egenAnsattService,
+                                                                              personopplysningerService,
+                                                                              tilgangConfig)
+
+    private val jwtToken = mockk<JwtToken>(relaxed = true)
+    private val jwtTokenClaims = mockk<JwtTokenClaims>()
+
+    @BeforeEach
+    internal fun setUp() {
+        every { jwtToken.jwtTokenClaims } returns jwtTokenClaims
+        every { jwtTokenClaims.get("preferred_username") }.returns(listOf("bob"))
+        every { jwtTokenClaims.getAsList(any()) }.returns(emptyList())
+        every { egenAnsattService.erEgenAnsatt(any<Set<String>>()) } answers
+                { (firstArg() as Set<String>).map { it to false }.toMap() }
+    }
+
+    private fun mockHarKode7() {
+        every { jwtTokenClaims.getAsList(any()) }.returns(listOf(kode7Id))
+    }
+
+    private fun mockHarKode6() {
+        every { jwtTokenClaims.getAsList(any()) }.returns(listOf(kode6Id))
+    }
+
+    @Test
+    internal fun `har tilgang når det ikke finnes noen adressebeskyttelser`() {
+        every { personopplysningerService.hentPersonMedRelasjoner(any(), Tema.ENF) } returns lagPersonMedRelasjoner()
+        assertThat(sjekkTilgangTilPersonMedRelasjoner()).isTrue
+    }
+
+    @Test
+    internal fun `har ikke tilgang når søkeren er STRENGT_FORTROLIG og saksbehandler har kode7`() {
+        mockHarKode7()
+        every { personopplysningerService.hentPersonMedRelasjoner(any(), Tema.ENF) } returns
+                lagPersonMedRelasjoner(ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG)
+        assertThat(sjekkTilgangTilPersonMedRelasjoner()).isFalse
+    }
+
+    @Test
+    internal fun `har tilgang når søkeren er STRENGT_FORTROLIG og saksbehandler har kode6`() {
+        mockHarKode6()
+        every { personopplysningerService.hentPersonMedRelasjoner(any(), Tema.ENF) } returns
+                lagPersonMedRelasjoner(ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG)
+        assertThat(sjekkTilgangTilPersonMedRelasjoner()).isTrue
+    }
+
+    @Test
+    internal fun `har ikke tilgang når det finnes adressebeskyttelse for søkeren`() {
+        every { personopplysningerService.hentPersonMedRelasjoner(any(), Tema.ENF) } returns
+                lagPersonMedRelasjoner(adressebeskyttelse = ADRESSEBESKYTTELSEGRADERING.FORTROLIG)
+        assertThat(sjekkTilgangTilPersonMedRelasjoner()).isFalse
+    }
+
+    @Test
+    internal fun `har ikke tilgang når sivilstand inneholder FORTROLIG`() {
+        every { personopplysningerService.hentPersonMedRelasjoner(any(), Tema.ENF) } returns
+                lagPersonMedRelasjoner(sivilstand = ADRESSEBESKYTTELSEGRADERING.FORTROLIG)
+        assertThat(sjekkTilgangTilPersonMedRelasjoner()).isFalse
+    }
+
+    @Test
+    internal fun `har ikke tilgang når fullmakt inneholder FORTROLIG`() {
+        every { personopplysningerService.hentPersonMedRelasjoner(any(), Tema.ENF) } returns
+                lagPersonMedRelasjoner(fullmakt = ADRESSEBESKYTTELSEGRADERING.FORTROLIG)
+        assertThat(sjekkTilgangTilPersonMedRelasjoner()).isFalse
+    }
+
+    @Test
+    internal fun `har ikke tilgang når barn inneholder FORTROLIG`() {
+        every { personopplysningerService.hentPersonMedRelasjoner(any(), Tema.ENF) } returns
+                lagPersonMedRelasjoner(barn = ADRESSEBESKYTTELSEGRADERING.FORTROLIG)
+        assertThat(sjekkTilgangTilPersonMedRelasjoner()).isFalse
+    }
+
+    @Test
+    internal fun `har ikke tilgang når barnsForeldrer inneholder FORTROLIG`() {
+        every { personopplysningerService.hentPersonMedRelasjoner(any(), Tema.ENF) } returns
+                lagPersonMedRelasjoner(barnsForeldrer = ADRESSEBESKYTTELSEGRADERING.FORTROLIG)
+        assertThat(sjekkTilgangTilPersonMedRelasjoner()).isFalse
+    }
+
+    private fun sjekkTilgangTilPersonMedRelasjoner() =
+            cachedTilgangskontrollService.sjekkTilgangTilPersonMedRelasjoner("", jwtToken, Tema.ENF).harTilgang
+
+    private fun lagPersonMedRelasjoner(adressebeskyttelse: ADRESSEBESKYTTELSEGRADERING? = null,
+                                       sivilstand: ADRESSEBESKYTTELSEGRADERING? = null,
+                                       fullmakt: ADRESSEBESKYTTELSEGRADERING? = null,
+                                       barn: ADRESSEBESKYTTELSEGRADERING? = null,
+                                       barnsForeldrer: ADRESSEBESKYTTELSEGRADERING? = null): PersonMedRelasjoner {
+        return PersonMedRelasjoner(personIdent = "",
+                                   adressebeskyttelse = adressebeskyttelse,
+                                   sivilstand = lagPersonMedBeskyttelse(sivilstand, "sivilstand"),
+                                   fullmakt = lagPersonMedBeskyttelse(fullmakt, "fullmakt"),
+                                   barn = lagPersonMedBeskyttelse(barn, "barn"),
+                                   barnsForeldrer = lagPersonMedBeskyttelse(barnsForeldrer, "barnsForeldrer"))
+    }
+
+    private fun lagPersonMedBeskyttelse(sivilstand: ADRESSEBESKYTTELSEGRADERING?, personIdent: String) =
+            sivilstand?.let { listOf(PersonMedAdresseBeskyttelse(personIdent, it)) } ?: emptyList()
+}

--- a/src/test/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollServiceTest.kt
@@ -38,7 +38,7 @@ internal class CachedTilgangskontrollServiceTest {
         every { jwtTokenClaims.get("preferred_username") }.returns(listOf("bob"))
         every { jwtTokenClaims.getAsList(any()) }.returns(emptyList())
         every { egenAnsattService.erEgenAnsatt(any<Set<String>>()) } answers
-                { (firstArg() as Set<String>).map { it to false }.toMap() }
+                { firstArg<Set<String>>().map { it to false }.toMap() }
     }
 
     private fun mockHarKode7() {

--- a/src/test/java/no/nav/familie/integrasjoner/tilgangskontroll/TilgangskontrollServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/tilgangskontroll/TilgangskontrollServiceTest.kt
@@ -31,7 +31,7 @@ class TilgangskontrollServiceTest {
 
     @Test
     fun `tilgang til egen ansatt gir ikke tilgang hvis saksbehandler mangler rollen`() {
-        every { egenAnsattService.erEgenAnsatt(any()) }
+        every { egenAnsattService.erEgenAnsatt(any<String>()) }
                 .returns(true)
         every { tilgangConfig.grupper["utvidetTilgang"] }
                 .returns(AdRolle("8796", "NAV-Ansatt"))
@@ -49,7 +49,7 @@ class TilgangskontrollServiceTest {
 
     @Test
     fun `tilgang til egen ansatt gir tilgang hvis saksbehandler har rollen`() {
-        every { egenAnsattService.erEgenAnsatt(any()) }
+        every { egenAnsattService.erEgenAnsatt(any<String>()) }
                 .returns(true)
         every { tilgangConfig.grupper["utvidetTilgang"] }
                 .returns(AdRolle("8796", "NAV-Ansatt"))
@@ -67,7 +67,7 @@ class TilgangskontrollServiceTest {
 
     @Test
     fun `tilgang til egen ansatt gir ok hvis søker ikke er egen ansatt`() {
-        every { egenAnsattService.erEgenAnsatt(any()) }
+        every { egenAnsattService.erEgenAnsatt(any<String>()) }
                 .returns(false)
         every { tilgangConfig.grupper["utvidetTilgang"] }
                 .returns(AdRolle("8796", "NAV-Ansatt"))
@@ -81,7 +81,7 @@ class TilgangskontrollServiceTest {
 
     @Test
     fun `hvis kode6 har ikke saksbehandler uten rollen tilgang`() {
-        every { egenAnsattService.erEgenAnsatt(any()) }
+        every { egenAnsattService.erEgenAnsatt(any<String>()) }
                 .returns(false)
         every { tilgangConfig.grupper["kode6"] }
                 .returns(AdRolle("8796", "Strengt fortrolig adresse"))
@@ -101,7 +101,7 @@ class TilgangskontrollServiceTest {
 
     @Test
     fun `hvis kode7 har ikke saksbehandler uten rollen tilgang`() {
-        every { egenAnsattService.erEgenAnsatt(any()) }
+        every { egenAnsattService.erEgenAnsatt(any<String>()) }
                 .returns(false)
         every { tilgangConfig.grupper["kode7"] }
                 .returns(AdRolle("8796", "Fortrolig adresse"))
@@ -121,7 +121,7 @@ class TilgangskontrollServiceTest {
 
     @Test
     fun `hvis kode6 har saksbehandler med rollen tilgang`() {
-        every { egenAnsattService.erEgenAnsatt(any()) }
+        every { egenAnsattService.erEgenAnsatt(any<String>()) }
                 .returns(false)
         every { saksbehandler.jwtTokenClaims }
                 .returns(jwtTokenClaims)
@@ -141,7 +141,7 @@ class TilgangskontrollServiceTest {
 
     @Test
     fun `hvis kode7 har saksbehandler med rollen tilgang`() {
-        every { egenAnsattService.erEgenAnsatt(any()) }
+        every { egenAnsattService.erEgenAnsatt(any<String>()) }
                 .returns(false)
         every { saksbehandler.jwtTokenClaims }
                 .returns(jwtTokenClaims)


### PR DESCRIPTION
EF ønsker å sjekke tilgang til "utvidet person", tar gjerne innspill på bruk av ord i denne PR
Pga ytelse så er dette lagt her, for å unngå unødvendig mange kall fra GCP -> fss(pdl) og i stedet gjøre ett kall som kaller pdl og egenAnsatt. Får en response på ca 100ms denne måten.

Årsaken til att den tidligere var langsam er flere.
Vi måtte finne alle disse identene først før vi sendte de til integrasjon, så er ikke tilgang/personer helt optimal då den gjør ett kall per ident til PDL og ett kall til egenAnsatt, i stedet for å bruke bolkoppslag.

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-4139