### PR TITLE
Bumpet kontrakter og lagt til nye metadata for ulike vedtakstyper i BA.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <springfox.version>3.0.0</springfox.version>
         <common-java-modules.version>1.2019.11.06-15.14-6ca860e6cead</common-java-modules.version>
         <felles.version>1.20210419103325_d044927</felles.version>
-        <kontrakt.version>2.0_20210427110428_c65325b</kontrakt.version>
+        <kontrakt.version>2.0_20210429153055_d1e5881</kontrakt.version>
         <cxf.version>3.3.4</cxf.version>
         <token-validation-spring.version>1.3.3</token-validation-spring.version>
         <tjenestespesifikasjoner.version>1.2021.02.22-10.45-4201aaea72fb</tjenestespesifikasjoner.version>

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivService.kt
@@ -64,7 +64,8 @@ class DokarkivService(private val dokarkivRestClient: DokarkivRestClient,
     private fun mapTilOpprettJournalpostRequest(arkiverDokumentRequest: ArkiverDokumentRequest): OpprettJournalpostRequest {
 
         val dokarkivBruker = DokarkivBruker(BrukerIdType.FNR, arkiverDokumentRequest.fnr)
-        val metadata = dokarkivMetadata.getMetadata(arkiverDokumentRequest.hoveddokumentvarianter[0])
+        val hoveddokument = arkiverDokumentRequest.hoveddokumentvarianter[0]
+        val metadata = dokarkivMetadata.getMetadata(hoveddokument)
         val avsenderMottaker = arkiverDokumentRequest.avsenderMottaker ?: arkiverDokumentRequest.fnr.let {
             val navn = hentNavnForFnr(fnr = arkiverDokumentRequest.fnr, behandlingstema = metadata.tema)
             AvsenderMottaker(it, BrukerIdType.FNR, navn)
@@ -91,7 +92,7 @@ class DokarkivService(private val dokarkivRestClient: DokarkivRestClient,
         return OpprettJournalpostRequest(journalpostType = metadata.journalpostType,
                                          behandlingstema = metadata.behandlingstema?.value,
                                          kanal = metadata.kanal,
-                                         tittel = metadata.tittel,
+                                         tittel = hoveddokument.tittel ?: metadata.tittel,
                                          tema = metadata.tema.name,
                                          avsenderMottaker = avsenderMottaker,
                                          bruker = dokarkivBruker,

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdVedtakAvslagMetadata.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdVedtakAvslagMetadata.kt
@@ -1,0 +1,23 @@
+package no.nav.familie.integrasjoner.dokarkiv.metadata
+
+import no.nav.familie.integrasjoner.dokarkiv.client.domene.JournalpostType
+import no.nav.familie.kontrakter.felles.Behandlingstema
+import no.nav.familie.kontrakter.felles.Fagsystem
+import no.nav.familie.kontrakter.felles.Tema
+import no.nav.familie.kontrakter.felles.dokarkiv.Dokumenttype
+import org.springframework.stereotype.Component
+
+@Component
+object BarnetrygdVedtakAvslagMetadata : Dokumentmetadata {
+
+    override val journalpostType: JournalpostType = JournalpostType.UTGAAENDE
+    override val fagsakSystem: Fagsystem = Fagsystem.BA
+    override val tema: Tema = Tema.BAR
+    override val behandlingstema: Behandlingstema = Behandlingstema.Barnetrygd
+    override val kanal: String? = null
+    override val dokumenttype: Dokumenttype = Dokumenttype.BARNETRYGD_VEDTAK_AVSLAG
+    override val tittel: String = "Vedtak om avslag på barnetrygd"
+    override val brevkode: String = "BAA1"
+    override val dokumentKategori: Dokumentkategori = Dokumentkategori.VB
+
+}

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdVedtakInnvilgetMetadata.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdVedtakInnvilgetMetadata.kt
@@ -1,0 +1,23 @@
+package no.nav.familie.integrasjoner.dokarkiv.metadata
+
+import no.nav.familie.integrasjoner.dokarkiv.client.domene.JournalpostType
+import no.nav.familie.kontrakter.felles.Behandlingstema
+import no.nav.familie.kontrakter.felles.Fagsystem
+import no.nav.familie.kontrakter.felles.Tema
+import no.nav.familie.kontrakter.felles.dokarkiv.Dokumenttype
+import org.springframework.stereotype.Component
+
+@Component
+object BarnetrygdVedtakInnvilgetMetadata : Dokumentmetadata {
+
+    override val journalpostType: JournalpostType = JournalpostType.UTGAAENDE
+    override val fagsakSystem: Fagsystem = Fagsystem.BA
+    override val tema: Tema = Tema.BAR
+    override val behandlingstema: Behandlingstema = Behandlingstema.Barnetrygd
+    override val kanal: String? = null
+    override val dokumenttype: Dokumenttype = Dokumenttype.BARNETRYGD_VEDTAK_INNVILGELSE
+    override val tittel: String = "Vedtak om innvilgelse av barnetrygd"
+    override val brevkode: String = "BAA1"
+    override val dokumentKategori: Dokumentkategori = Dokumentkategori.VB
+
+}


### PR DESCRIPTION
Det skal differensieres på vedtakstype for barnetrygd i dokarkiv. Innfører derfor spesifikke metadata for hhv avslag og innvilgelse.

Ref. https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-4485