### PR TITLE
Ikke automatisk deploy dependabot-brancher

### DIFF
--- a/.github/workflows/deploy-preprod.yml
+++ b/.github/workflows/deploy-preprod.yml
@@ -1,7 +1,10 @@
 name: Build-Deploy-Preprod
 on:
-  pull_request:
   workflow_dispatch:
+  pull_request:
+    branches-ignore:
+      - 'dependabot/**'
+
 env:
   IMAGE: docker.pkg.github.com/${{ github.repository }}/familie-integrasjoner:${{ github.sha }}
 jobs:


### PR DESCRIPTION
Ref https://nav-it.slack.com/archives/CJN0STWB0/p1620725112236500 : Kan vi gjøre dette i stedet for å lukke pr'ene? Synes man mister litt oversikt. Så kan man likevel opprette kort om det er noe man ønsker flere skal bistå med.