### PR TITLE
Feature/oppdaterte dokumenttitler

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivService.kt
@@ -25,6 +25,7 @@ import no.nav.familie.kontrakter.felles.dokarkiv.Sak
 import no.nav.familie.kontrakter.felles.dokarkiv.v2.ArkiverDokumentRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.v2.Dokument
 import no.nav.familie.kontrakter.felles.dokarkiv.v2.Filtype
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import no.nav.familie.kontrakter.felles.arkivering.ArkiverDokumentRequest as DeprecatedArkiverDokumentRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.ArkiverDokumentRequest as DeprecatedArkiverDokumentRequest2
@@ -89,6 +90,7 @@ class DokarkivService(private val dokarkivRestClient: DokarkivRestClient,
                                                                                    filnavn = "førsteside.pdf")))
         }
 
+        LOG.info("Journalfører fagsak ${sak.fagsakId} med tittel ${hoveddokument.tittel ?: metadata.tittel}")
         return OpprettJournalpostRequest(journalpostType = metadata.journalpostType,
                                          behandlingstema = metadata.behandlingstema?.value,
                                          kanal = metadata.kanal,
@@ -270,4 +272,7 @@ class DokarkivService(private val dokarkivRestClient: DokarkivRestClient,
         dokarkivLogiskVedleggRestClient.slettLogiskVedlegg(dokumentInfoId, logiskVedleggId)
     }
 
+    companion object {
+        private val LOG = LoggerFactory.getLogger(DokarkivService::class.java)
+    }
 }

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivService.kt
@@ -90,7 +90,7 @@ class DokarkivService(private val dokarkivRestClient: DokarkivRestClient,
                                                                                    filnavn = "førsteside.pdf")))
         }
 
-        LOG.info("Journalfører fagsak ${sak.fagsakId} med tittel ${hoveddokument.tittel ?: metadata.tittel}")
+        LOG.info("Journalfører fagsak ${sak?.fagsakId} med tittel ${hoveddokument.tittel ?: metadata.tittel}")
         return OpprettJournalpostRequest(journalpostType = metadata.journalpostType,
                                          behandlingstema = metadata.behandlingstema?.value,
                                          kanal = metadata.kanal,

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdHenleggelseMetadata.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdHenleggelseMetadata.kt
@@ -16,7 +16,7 @@ object BarnetrygdHenleggelseMetadata : Dokumentmetadata {
     override val behandlingstema: Behandlingstema? = null
     override val kanal: String? = null
     override val dokumenttype: Dokumenttype = Dokumenttype.BARNETRYGD_HENLEGGE_TRUKKET_SØKNAD
-    override val tittel: String = "Brev for bekreftelse av trukket søknad"
+    override val tittel: String = "Informasjon om henleggelse - barnetrygd"
     override val brevkode: String = "henlegge-trukket-soknad"
     override val dokumentKategori: Dokumentkategori = Dokumentkategori.B
 }

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdInnhenteOpplysningerMetadata.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdInnhenteOpplysningerMetadata.kt
@@ -16,7 +16,7 @@ object BarnetrygdInnhenteOpplysningerMetadata : Dokumentmetadata {
     override val behandlingstema: Behandlingstema? = null
     override val kanal: String? = null
     override val dokumenttype: Dokumenttype = Dokumenttype.BARNETRYGD_INNHENTE_OPPLYSNINGER
-    override val tittel: String = "Brev for innhenting av opplysninger"
+    override val tittel: String = "Innhenting av opplysninger - barnetrygd"
     override val brevkode: String = "innhente-opplysninger"
     override val dokumentKategori: Dokumentkategori = Dokumentkategori.B
 

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdOpphørMetadata.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdOpphørMetadata.kt
@@ -16,7 +16,7 @@ object BarnetrygdOpphørMetadata : Dokumentmetadata {
     override val behandlingstema: Behandlingstema? = null
     override val kanal: String? = null
     override val dokumenttype: Dokumenttype = Dokumenttype.BARNETRYGD_OPPHØR
-    override val tittel: String = "Vedtak om opphør av barnetrygd"
+    override val tittel: String = "Vedtak om opphørt barnetrygd"
     override val brevkode: String = "opphor"
     override val dokumentKategori: Dokumentkategori = Dokumentkategori.B
 }

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdVarselOmRevurderingMetadata.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdVarselOmRevurderingMetadata.kt
@@ -16,7 +16,7 @@ object BarnetrygdVarselOmRevurderingMetadata : Dokumentmetadata {
     override val behandlingstema: Behandlingstema? = null
     override val kanal: String? = null
     override val dokumenttype: Dokumenttype = Dokumenttype.BARNETRYGD_VARSEL_OM_REVURDERING
-    override val tittel: String = "Brev for varsel om revurdering"
+    override val tittel: String = "Varsel om revurdering - barnetrygd"
     override val brevkode: String = "varsel-om-revurdering"
     override val dokumentKategori: Dokumentkategori = Dokumentkategori.B
 }

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdVedtakAvslagMetadata.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdVedtakAvslagMetadata.kt
@@ -16,7 +16,7 @@ object BarnetrygdVedtakAvslagMetadata : Dokumentmetadata {
     override val behandlingstema: Behandlingstema = Behandlingstema.Barnetrygd
     override val kanal: String? = null
     override val dokumenttype: Dokumenttype = Dokumenttype.BARNETRYGD_VEDTAK_AVSLAG
-    override val tittel: String = "Vedtak om avslag på barnetrygd"
+    override val tittel: String = "Vedtak om avslag - barnetrygd"
     override val brevkode: String = "BAA1"
     override val dokumentKategori: Dokumentkategori = Dokumentkategori.VB
 

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdVedtakInnvilgetMetadata.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdVedtakInnvilgetMetadata.kt
@@ -16,7 +16,7 @@ object BarnetrygdVedtakInnvilgetMetadata : Dokumentmetadata {
     override val behandlingstema: Behandlingstema = Behandlingstema.Barnetrygd
     override val kanal: String? = null
     override val dokumenttype: Dokumenttype = Dokumenttype.BARNETRYGD_VEDTAK_INNVILGELSE
-    override val tittel: String = "Vedtak om innvilgelse av barnetrygd"
+    override val tittel: String = "Vedtak om barnetrygd"
     override val brevkode: String = "BAA1"
     override val dokumentKategori: Dokumentkategori = Dokumentkategori.VB
 


### PR DESCRIPTION
Oppdaterer dokumenttitler ihht https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-4636. Dette gjelder da kun de titlene som gjelder tilfellene vi har metadata-klasser for. For øvrige case så vil titlene overstyres fra ba-sak ved at tittel sendes med i requesten.