### PR TITLE
Ikke autotrigg pr-deploy når det kun er pom-endringer

### DIFF
--- a/.github/workflows/deploy-preprod-q1.yml
+++ b/.github/workflows/deploy-preprod-q1.yml
@@ -2,8 +2,11 @@ name: Build-Deploy-Preprod-Q1
 on:
   workflow_dispatch:
   pull_request:
-    branches-ignore:
-      - 'dependabot/**'
+    paths-ignore:
+      - 'pom.xml'
+      - '**.md'
+      - '.gitignore'
+
 concurrency: q1
 env:
   IMAGE: docker.pkg.github.com/${{ github.repository }}/familie-integrasjoner-q1:${{ github.sha }}

--- a/.github/workflows/deploy-preprod.yml
+++ b/.github/workflows/deploy-preprod.yml
@@ -2,8 +2,11 @@ name: Build-Deploy-Preprod
 on:
   workflow_dispatch:
   pull_request:
-    branches-ignore:
-      - 'dependabot/**'
+    paths-ignore:
+      - 'pom.xml'
+      - '**.md'
+      - '.gitignore'
+
 concurrency: preprod
 env:
   IMAGE: docker.pkg.github.com/${{ github.repository }}/familie-integrasjoner:${{ github.sha }}


### PR DESCRIPTION
Branches/branches-ignore funka ikke siden den bruker target og det gir ikke så mye mening for oss. 
Foreslår derfor paths hvor man ignorerer pom.xml, som vil si at man manuelt må trigge kjøring av pr'er som _kun_ inneholder endring der (eller i listede paths).
https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths