### PR TITLE
Roe ved dependabotbrancher og muliggjør trigg av sjekker

### DIFF
--- a/.github/workflows/deploy-preprod-q1.yml
+++ b/.github/workflows/deploy-preprod-q1.yml
@@ -2,16 +2,14 @@ name: Build-Deploy-Preprod-Q1
 on:
   workflow_dispatch:
   pull_request:
-    paths-ignore:
-      - 'pom.xml'
-      - '**.md'
-      - '.gitignore'
+    types: [ opened, synchronize, reopened, ready_for_review ]
 
 concurrency: q1
 env:
   IMAGE: docker.pkg.github.com/${{ github.repository }}/familie-integrasjoner-q1:${{ github.sha }}
 jobs:
   deploy-to-dev:
+    if: github.event.pull_request.draft == false
     name: Build, push and deploy to dev-fss Q1
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-preprod.yml
+++ b/.github/workflows/deploy-preprod.yml
@@ -2,16 +2,14 @@ name: Build-Deploy-Preprod
 on:
   workflow_dispatch:
   pull_request:
-    paths-ignore:
-      - 'pom.xml'
-      - '**.md'
-      - '.gitignore'
+    types: [ opened, synchronize, reopened, ready_for_review ]
 
 concurrency: preprod
 env:
   IMAGE: docker.pkg.github.com/${{ github.repository }}/familie-integrasjoner:${{ github.sha }}
 jobs:
   deploy-to-dev:
+    if: github.event.pull_request.draft == false
     name: Build, push and deploy to dev-fss
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
![Skjermbilde 2021-05-21 kl  14 07 59](https://user-images.githubusercontent.com/5719550/119135343-91b18100-ba3e-11eb-80cc-7d432eb02c53.png)
Det fungerte å stoppe deploy når man synca dependabot-prene, men fikk ikke til å trigge de manuelt som antatt :P Kjører derfor samme variant på som ba-sak som ikke kjører på drafts. Da kan @blommish  og jeg bare sette pr'ene til drafts når vi ikke har tid til å ta de med en gang. 