### PR TITLE
Mer fleksibel oppgavetildeling

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
@@ -4,6 +4,7 @@ import no.nav.familie.integrasjoner.client.rest.OppgaveRestClient
 import no.nav.familie.integrasjoner.client.rest.PdlRestClient
 import no.nav.familie.integrasjoner.felles.OppslagException
 import no.nav.familie.integrasjoner.felles.OppslagException.Level
+import no.nav.familie.integrasjoner.saksbehandler.SaksbehandlerService
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.oppgave.*
 import org.slf4j.LoggerFactory
@@ -13,8 +14,11 @@ import org.springframework.web.context.annotation.ApplicationScope
 import java.time.format.DateTimeFormatter
 
 @Service @ApplicationScope
-class OppgaveService constructor(private val oppgaveRestClient: OppgaveRestClient,
-                                 private val pdlRestClient: PdlRestClient) {
+class OppgaveService constructor(
+        private val oppgaveRestClient: OppgaveRestClient,
+        private val pdlRestClient: PdlRestClient,
+        private val saksbehandlerService: SaksbehandlerService,
+) {
 
     fun finnOppgaver(finnOppgaveRequest: FinnOppgaveRequest): FinnOppgaveResponseDto {
         return oppgaveRestClient.finnOppgaver(finnOppgaveRequest)
@@ -65,7 +69,7 @@ class OppgaveService constructor(private val oppgaveRestClient: OppgaveRestClien
         val oppdatertOppgaveDto = oppgave.copy(
                 id = oppgave.id,
                 versjon = oppgave.versjon,
-                tilordnetRessurs = saksbehandler
+                tilordnetRessurs = saksbehandlerService.hentNavIdent(saksbehandler)
         )
         oppgaveRestClient.oppdaterOppgave(oppdatertOppgaveDto)
         return oppgave.id!!
@@ -128,7 +132,7 @@ class OppgaveService constructor(private val oppgaveRestClient: OppgaveRestClien
                 oppgavetype = request.oppgavetype.value,
                 beskrivelse = request.beskrivelse,
                 behandlingstype = request.behandlingstype,
-                tilordnetRessurs = request.tilordnetRessurs,
+                tilordnetRessurs = request.tilordnetRessurs?.let { saksbehandlerService.hentNavIdent(it) },
                 behandlesAvApplikasjon = request.behandlesAvApplikasjon
         )
 
@@ -172,6 +176,7 @@ class OppgaveService constructor(private val oppgaveRestClient: OppgaveRestClien
     }
 
     companion object {
+
         private val LOG = LoggerFactory.getLogger(OppgaveService::class.java)
     }
 }

--- a/src/main/java/no/nav/familie/integrasjoner/saksbehandler/SaksbehandlerService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/saksbehandler/SaksbehandlerService.kt
@@ -37,8 +37,12 @@ class SaksbehandlerService(private val azureGraphRestClient: AzureGraphRestClien
                              azureAdBruker.surname)
     }
 
+    fun hentNavIdent(saksbehandlerId: String): String =
+            saksbehandlerId.takeIf { it.length == lengdeNavIdent } ?: hentSaksbehandler(saksbehandlerId).navIdent
+
     companion object {
 
         const val ID_VEDTAKSLØSNINGEN = "VL"
     }
+
 }


### PR DESCRIPTION
Ved opprettelse av "behandle underkjent vedtak" oppgave har vi kun mailen til forrige behandler tilgjengelig. Ønsker derfor å gjøre [opprettelse av oppgave](https://github.com/navikt/familie-integrasjoner/compare/feature/oppgavefordeling?expand=1#diff-441aaf9b3e1cc7d404a3f6d591733fa1c05461f1791927d169b2340ac1d661d2L115-L133) mer fleksibel.

Gjorde det samme for [fordel oppgave](https://github.com/navikt/familie-integrasjoner/compare/feature/oppgavefordeling?expand=1#diff-441aaf9b3e1cc7d404a3f6d591733fa1c05461f1791927d169b2340ac1d661d2L59-L71).