### PR TITLE
Setter http status fra exception hvis eksisterer, istede for alltid 500

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivRestClient.kt
@@ -63,10 +63,11 @@ class DokarkivRestClient(@Value("\${DOKARKIV_V1_URL}") private val dokarkivUrl: 
     private fun oppslagExceptionVed(requestType: String, e: RuntimeException, brukerId: String?): Throwable {
         val message = "Feil ved $requestType av journalpost "
         val sensitiveInfo = if (e is HttpStatusCodeException) e.responseBodyAsString else "$message for bruker $brukerId "
+        val httpStatus = if (e is HttpStatusCodeException) e.statusCode else null
         return OppslagException(message,
                                 "Dokarkiv",
                                 OppslagException.Level.MEDIUM,
-                                HttpStatus.INTERNAL_SERVER_ERROR,
+                                httpStatus,
                                 e,
                                 sensitiveInfo)
     }


### PR DESCRIPTION
Ønsker å ikke endre status kode mottatt fra dokarkiv, spesielt for (409 Conflict) ved eksisterende eksternReferanseId
https://github.com/navikt/dokarkiv/blob/e82662f70cfd55502d0eba65c554fa64d7d9925c/journalpost/src/main/java/no/nav/dokarkiv/journalpost/v1/api/opprettjournalpost/OpprettJournalpostRequest.java#L88
