### PR TITLE
For endepunkt brukt av KON, så søk kun etter åpen oppgave

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/OppgaveRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/OppgaveRestClient.kt
@@ -41,7 +41,7 @@ class OppgaveRestClient(@Value("\${OPPGAVE_URL}") private val oppgaveBaseUrl: UR
 
     private val logger = LoggerFactory.getLogger(OppgaveRestClient::class.java)
 
-    fun finnOppgave(request: Oppgave): Oppgave {
+    fun finnÅpenBehandleSakOppgave(request: Oppgave): Oppgave {
         request.takeUnless { it.aktoerId == null } ?: error("Finner ikke aktør id på request")
         request.takeUnless {
             it.journalpostId == null
@@ -177,6 +177,7 @@ class OppgaveRestClient(@Value("\${OPPGAVE_URL}") private val oppgaveBaseUrl: UR
                 .queryParam("tema", tema)
                 .queryParam("oppgavetype", OPPGAVE_TYPE)
                 .queryParam("journalpostId", journalpostId)
+                .queryParam("statuskategori", "AAPEN")
                 .build()
                 .toUri()
     }

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
@@ -36,7 +36,7 @@ class OppgaveService constructor(
 
     fun oppdaterOppgave(request: Oppgave): Long {
         val oppgave: Oppgave = if (request.id == null) {
-            oppgaveRestClient.finnOppgave(request)
+            oppgaveRestClient.finnÅpenBehandleSakOppgave(request)
         } else {
             oppgaveRestClient.finnOppgaveMedId(request.id!!)
         }

--- a/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveControllerTest.kt
@@ -144,7 +144,7 @@ class OppgaveControllerTest : OppslagSpringRunnerTest() {
                 .extracting<String, RuntimeException> { obj: ILoggingEvent -> obj.formattedMessage }
                 .anyMatch {
                     it.contains("[oppgave][Ingen oppgaver funnet for http://localhost:28085/api/v1/oppgaver" +
-                                "?aktoerId=1234567891011&tema=KON&oppgavetype=BEH_SAK&journalpostId=1]")
+                                "?aktoerId=1234567891011&tema=KON&oppgavetype=BEH_SAK&journalpostId=1&statuskategori=AAPEN]")
                 }
         assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
     }
@@ -546,7 +546,7 @@ class OppgaveControllerTest : OppslagSpringRunnerTest() {
         private const val OPPDATER_OPPGAVE_URL = "${OPPGAVE_URL}/oppdater"
         private const val OPPGAVE_ID = 315488374L
         private const val GET_OPPGAVER_URL =
-                "/api/v1/oppgaver?aktoerId=1234567891011&tema=KON&oppgavetype=BEH_SAK&journalpostId=1"
+                "/api/v1/oppgaver?aktoerId=1234567891011&tema=KON&oppgavetype=BEH_SAK&journalpostId=1&statuskategori=AAPEN"
         private const val GET_MAPPER_URL =
                 "/api/v1/mapper?enhetsnr=1234567891011&opprettetFom=dcssdf&limit=50"
         private const val GET_OPPGAVE_URL = "/api/v1/oppgaver/$OPPGAVE_ID"

--- a/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveRestClientTestConfig.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveRestClientTestConfig.kt
@@ -52,7 +52,7 @@ class OppgaveRestClientTestConfig {
         } returns FinnOppgaveResponseDto(1, listOf(response))
 
         every {
-            klient.finnOppgave(any())
+            klient.finnÅpenBehandleSakOppgave(any())
         } returns response
 
         every {


### PR DESCRIPTION
Kontantstøtte prøver å oppdatere feilregistrerte oppgaver, siden finn oppgave endepunktet i bruk fra KON returnerer alle oppgaver for en aktør med journalpostId. For å unngå dette så sjekker vi kun for statuskategori AAPEN.
