### PR TITLE
nav-kontor returnerer null hvis geografiskTilknytningKode ikke finnes…

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/arbeidsfordeling/ArbeidsfordelingController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/arbeidsfordeling/ArbeidsfordelingController.kt
@@ -57,7 +57,7 @@ class ArbeidsfordelingController(private val service: ArbeidsfordelingService) {
     @PostMapping("/nav-kontor/{tema}")
     fun hentLokaltNavKontor(@PathVariable(name = "tema") tema: Tema,
                             @RequestBody personIdent: PersonIdent)
-            : ResponseEntity<Ressurs<NavKontorEnhet>> {
+            : ResponseEntity<Ressurs<NavKontorEnhet?>> {
         return ResponseEntity.ok(success(service.finnLokaltNavKontor(personIdent.ident, tema)))
     }
 

--- a/src/main/java/no/nav/familie/integrasjoner/arbeidsfordeling/ArbeidsfordelingService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/arbeidsfordeling/ArbeidsfordelingService.kt
@@ -44,17 +44,16 @@ class ArbeidsfordelingService(
     }
 
     @Improvement("Må ta høyde for om personIdent har diskresjonskode eller skjerming/er egen ansatt. Nå krasjer den for de med kode 6")
-    fun finnLokaltNavKontor(personIdent: String, tema: Tema): NavKontorEnhet {
+    fun finnLokaltNavKontor(personIdent: String, tema: Tema): NavKontorEnhet? {
         val geografiskTilknytning = pdlRestClient.hentGeografiskTilknytning(personIdent, tema)
 
         val geografiskTilknytningKode: String? = utledGeografiskTilknytningKode(geografiskTilknytning)
         if (geografiskTilknytningKode == null) {
             secureLogger.info("Fant ikke geografiskTilknytningKode=$geografiskTilknytning for personIdent=$personIdent")
-            error("Kan ikke utlede lokalt navkontor når det ikke finnes en geografisk tilknytning til personen")
+            return null
         }
 
         return restClient.hentEnhet(geografiskTilknytningKode)
-
     }
 
     fun hentNavKontor(enhetsId: String): NavKontorEnhet {
@@ -66,7 +65,7 @@ class ArbeidsfordelingService(
             return when (it.gtType) {
                 GeografiskTilknytningType.BYDEL -> it.gtBydel
                 GeografiskTilknytningType.KOMMUNE -> it.gtKommune
-                GeografiskTilknytningType.UTLAND -> it.gtLand
+                GeografiskTilknytningType.UTLAND -> null
                 GeografiskTilknytningType.UDEFINERT -> null
             }
         }

--- a/src/test/java/no/nav/familie/integrasjoner/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
@@ -16,9 +16,9 @@ import no.nav.familie.integrasjoner.personopplysning.internal.PersonMedAdresseBe
 import no.nav.familie.integrasjoner.personopplysning.internal.PersonMedRelasjoner
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.arbeidsfordeling.Enhet
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager
 
 internal class ArbeidsfordelingServiceTest {
@@ -59,14 +59,14 @@ internal class ArbeidsfordelingServiceTest {
     }
 
     @Test
-    fun `skal kaste feil ved geografisk tilknytning ikke definert`() {
+    fun `skal returnere null når geografisk tilknytning ikke definert`() {
 
         every {
             pdlRestClient.hentGeografiskTilknytning(ident,
                                                     any())
-        } returns GeografiskTilknytningDto(GeografiskTilknytningType.UDEFINERT, null, null, null)
+        } returns GeografiskTilknytningDto(GeografiskTilknytningType.UDEFINERT, null, null, "Land")
 
-        assertThrows<IllegalStateException> { arbeidsfordelingService.finnLokaltNavKontor(ident, Tema.ENF) }
+        assertThat(arbeidsfordelingService.finnLokaltNavKontor(ident, Tema.ENF)).isNull()
     }
 
     @Test


### PR DESCRIPTION
…, eks når en person flyttet til utlandet

Alternativet er også å sjekke for 404 fra norg2, og då returnere null

* https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8324
* https://github.com/navikt/familie-ef-sak-frontend/pull/1014
* https://github.com/navikt/familie-ef-sak/pull/1299