### PR TITLE
Minimer datainnhenting ved sjekk av tilgang. Dette for å unngå mappingfeil på personen man henter.

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerService.kt
@@ -9,6 +9,8 @@ import no.nav.familie.integrasjoner.personopplysning.domene.PersonIdent
 import no.nav.familie.integrasjoner.personopplysning.domene.PersonhistorikkInfo
 import no.nav.familie.integrasjoner.personopplysning.domene.Personinfo
 import no.nav.familie.integrasjoner.personopplysning.domene.TpsOversetter
+import no.nav.familie.integrasjoner.personopplysning.internal.ADRESSEBESKYTTELSEGRADERING
+import no.nav.familie.integrasjoner.personopplysning.internal.Adressebeskyttelse
 import no.nav.familie.integrasjoner.personopplysning.internal.FORELDERBARNRELASJONROLLE
 import no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonMedRelasjonerOgAdressebeskyttelse
 import no.nav.familie.integrasjoner.personopplysning.internal.Person
@@ -96,6 +98,12 @@ class PersonopplysningerService(private val personSoapClient: PersonSoapClient,
                                    fullmakt = mapPersonMedRelasjoner(fullmaktIdenter, tilknyttedeIdenterData),
                                    barn = mapPersonMedRelasjoner(barnIdenter, tilknyttedeIdenterData),
                                    barnsForeldrer = barnsForeldrer)
+    }
+
+    @Cacheable(cacheNames = ["ADRESSEBESKYTTELSE"], key = "#personIdent + #tema", condition = "#personIdent != null")
+    fun hentAdressebeskyttelse(personIdent: String, tema: Tema): Adressebeskyttelse {
+        return pdlRestClient.hentAdressebeskyttelse(personIdent, tema).person?.adressebeskyttelse?.firstOrNull()
+               ?: Adressebeskyttelse(gradering = ADRESSEBESKYTTELSEGRADERING.UGRADERT)
     }
 
     private fun hentBarnsForeldrer(barnOpplysninger: Map<String, PdlPersonMedRelasjonerOgAdressebeskyttelse>,

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerService.kt
@@ -100,9 +100,8 @@ class PersonopplysningerService(private val personSoapClient: PersonSoapClient,
                                    barnsForeldrer = barnsForeldrer)
     }
 
-    @Cacheable(cacheNames = ["ADRESSEBESKYTTELSE"], key = "#personIdent + #tema", condition = "#personIdent != null")
     fun hentAdressebeskyttelse(personIdent: String, tema: Tema): Adressebeskyttelse {
-        return pdlRestClient.hentAdressebeskyttelse(personIdent, tema).person?.adressebeskyttelse?.firstOrNull()
+        return pdlRestClient.hentAdressebeskyttelse(personIdent, tema).person.adressebeskyttelse.firstOrNull()
                ?: Adressebeskyttelse(gradering = ADRESSEBESKYTTELSEGRADERING.UGRADERT)
     }
 

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlResponse.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlResponse.kt
@@ -29,6 +29,11 @@ data class PdlBolkResponse<T>(val data: PersonBolk<T>?, val errors: List<PdlErro
     }
 }
 
+data class PdlPersonMedAdressebeskyttelse(val person: PdlAdressebeskyttelse)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class PdlAdressebeskyttelse(val adressebeskyttelse: List<Adressebeskyttelse>)
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class PdlPersonMedRelasjonerOgAdressebeskyttelse(val forelderBarnRelasjon: List<PdlForelderBarnRelasjon>,
                                                       val sivilstand: List<Sivilstand>,

--- a/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollService.kt
@@ -26,8 +26,7 @@ class CachedTilgangskontrollService(private val egenAnsattService: EgenAnsattSer
                key = "#jwtToken.subject.concat(#personIdent)",
                condition = "#personIdent != null && #jwtToken.subject != null")
     fun sjekkTilgang(personIdent: String, jwtToken: JwtToken, tema: Tema): Tilgang {
-        val personInfo = personopplysningerService.hentPersoninfo(personIdent, tema, PersonInfoQuery.ENKEL)
-        val adressebeskyttelse = personInfo.adressebeskyttelseGradering
+        val adressebeskyttelse = personopplysningerService.hentAdressebeskyttelse(personIdent, tema).gradering
 
         return sjekTilgang(adressebeskyttelse, jwtToken, personIdent) { egenAnsattService.erEgenAnsatt(personIdent) }
     }

--- a/src/main/resources/pdl/adressebeskyttelse.graphql
+++ b/src/main/resources/pdl/adressebeskyttelse.graphql
@@ -1,0 +1,5 @@
+query($ident: ID!) {person: hentPerson(ident: $ident) {
+    adressebeskyttelse {
+        gradering
+    }
+}}

--- a/src/test/java/no/nav/familie/integrasjoner/personopplysning/PdlGraphqlTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/personopplysning/PdlGraphqlTest.kt
@@ -9,6 +9,7 @@ import no.nav.familie.integrasjoner.geografisktilknytning.PdlHentGeografiskTilkn
 import no.nav.familie.integrasjoner.personopplysning.internal.PdlHentIdenter
 import no.nav.familie.integrasjoner.personopplysning.internal.PdlNavn
 import no.nav.familie.integrasjoner.personopplysning.internal.PdlPerson
+import no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonMedAdressebeskyttelse
 import no.nav.familie.integrasjoner.personopplysning.internal.PdlResponse
 import no.nav.familie.kontrakter.felles.personopplysning.SIVILSTAND
 import org.assertj.core.api.Assertions.assertThat
@@ -74,6 +75,12 @@ class PdlGraphqlTest {
     fun testPdlIdenter() {
         val resp: PdlResponse<PdlHentIdenter> = mapper.readValue(File(getFile("pdl/pdlIdenterResponse.json")))
         assertThat(resp.data.hentIdenter!!.identer).hasSize(1)
+    }
+
+    @Test
+    fun testPdlAdressebeskyttelse() {
+        val resp: PdlResponse<PdlPersonMedAdressebeskyttelse> = mapper.readValue(File(getFile("pdl/pdlAdressebeskyttelseResponse.json")))
+        assertThat(resp.data.person.adressebeskyttelse).hasSize(1)
     }
 
     @Test

--- a/src/test/java/no/nav/familie/integrasjoner/tilgangskontroll/TilgangskontrollServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/tilgangskontroll/TilgangskontrollServiceTest.kt
@@ -6,6 +6,7 @@ import no.nav.familie.integrasjoner.config.TilgangConfig
 import no.nav.familie.integrasjoner.egenansatt.EgenAnsattService
 import no.nav.familie.integrasjoner.personopplysning.PersonopplysningerService
 import no.nav.familie.integrasjoner.personopplysning.internal.ADRESSEBESKYTTELSEGRADERING
+import no.nav.familie.integrasjoner.personopplysning.internal.Adressebeskyttelse
 import no.nav.familie.integrasjoner.personopplysning.internal.Person
 import no.nav.familie.integrasjoner.tilgangskontroll.domene.AdRolle
 import no.nav.familie.kontrakter.felles.personopplysning.SIVILSTAND
@@ -55,8 +56,8 @@ class TilgangskontrollServiceTest {
     fun `tilgang til egen ansatt gir tilgang hvis saksbehandler har rollen`() {
         every { egenAnsattService.erEgenAnsatt(any<String>()) }
                 .returns(true)
-        every { personopplysningerService.hentPersoninfo("123", any(), any()) }
-                .returns(personMedAdressebeskyttelse(null))
+        every { personopplysningerService.hentAdressebeskyttelse("123", any()) }
+                .returns(Adressebeskyttelse(ADRESSEBESKYTTELSEGRADERING.UGRADERT))
         every { saksbehandler.jwtTokenClaims }
                 .returns(jwtTokenClaims)
         every { jwtTokenClaims.getAsList(any()) }
@@ -72,8 +73,8 @@ class TilgangskontrollServiceTest {
     fun `tilgang til egen ansatt gir ok hvis søker ikke er egen ansatt`() {
         every { egenAnsattService.erEgenAnsatt(any<String>()) }
                 .returns(false)
-        every { personopplysningerService.hentPersoninfo("123", any(), any()) }
-                .returns(personMedAdressebeskyttelse(null))
+        every { personopplysningerService.hentAdressebeskyttelse("123", any()) }
+                .returns(Adressebeskyttelse(ADRESSEBESKYTTELSEGRADERING.UGRADERT))
 
         assertThat(tilgangskontrollService.sjekkTilgang("123", saksbehandler).harTilgang)
                 .isTrue
@@ -140,8 +141,8 @@ class TilgangskontrollServiceTest {
                 .returns(listOf("bob"))
         every { jwtTokenClaims.getAsList(any()) }
                 .returns(listOf(GRUPPE_TILGANG_7))
-        every { personopplysningerService.hentPersoninfo("123", any(), any()) }
-                .returns(personMedAdressebeskyttelse(ADRESSEBESKYTTELSEGRADERING.FORTROLIG))
+        every { personopplysningerService.hentAdressebeskyttelse("123", any()) }
+                .returns(Adressebeskyttelse(ADRESSEBESKYTTELSEGRADERING.FORTROLIG))
 
         assertThat(tilgangskontrollService.sjekkTilgang("123", saksbehandler).harTilgang)
                 .isTrue

--- a/src/test/resources/pdl/pdlAdressebeskyttelseResponse.json
+++ b/src/test/resources/pdl/pdlAdressebeskyttelseResponse.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "person": {
+      "adressebeskyttelse": [
+        {
+          "gradering": "UGRADERT"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Personer uten fødselsdato feiler i denne flyten og derfor bør vi minimere datainnhentingen.