### PR TITLE
Pdl sts til azuread

### DIFF
--- a/.github/workflows/integrasjonsTest.yml
+++ b/.github/workflows/integrasjonsTest.yml
@@ -27,4 +27,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_PROJECTKEY: ${{ secrets.SONAR_PROJECTKEY }}
           SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}
-        run: mvn verify sonar:sonar --settings .m2/maven-settings.xml --file pom.xml
+        run: mvn verify --settings .m2/maven-settings.xml --file pom.xml
+        #run: mvn verify sonar:sonar --settings .m2/maven-settings.xml --file pom.xml

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/PdlClientCredentialRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/PdlClientCredentialRestClient.kt
@@ -1,0 +1,58 @@
+package no.nav.familie.integrasjoner.client.rest
+
+import no.nav.familie.http.client.AbstractRestClient
+import no.nav.familie.http.util.UriUtil
+import no.nav.familie.integrasjoner.personopplysning.PdlRequestException
+import no.nav.familie.integrasjoner.personopplysning.internal.PdlBolkResponse
+import no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonBolkRequest
+import no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonBolkRequestVariables
+import no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonMedRelasjonerOgAdressebeskyttelse
+import no.nav.familie.kontrakter.felles.Tema
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestOperations
+import java.net.URI
+
+/**
+ * hentPersonBolk støtter ikke on-behalf-of token,
+ * denne burde kun brukes for oppslag, og ikke for utlevering av data fra tjenesten
+ */
+@Service
+class PdlClientCredentialRestClient(@Value("\${PDL_URL}") pdlBaseUrl: URI,
+                                    @Qualifier("clientCredential") private val restTemplate: RestOperations)
+    : AbstractRestClient(restTemplate, "pdl.personinfo.cc") {
+
+    private val pdlUri = UriUtil.uri(pdlBaseUrl, PATH_GRAPHQL)
+
+    fun hentPersonMedRelasjonerOgAdressebeskyttelse(identer: List<String>,
+                                                    tema: Tema): Map<String, PdlPersonMedRelasjonerOgAdressebeskyttelse> {
+        val request = PdlPersonBolkRequest(variables = PdlPersonBolkRequestVariables(identer),
+                                           query = HENT_PERSON_RELASJONER_ADRESSEBESKYTTELSE)
+        val response = postForEntity<PdlBolkResponse<PdlPersonMedRelasjonerOgAdressebeskyttelse>>(pdlUri,
+                                                                                                  request,
+                                                                                                  pdlHttpHeaders(tema))
+        return feilsjekkOgReturnerData(response)
+    }
+
+    private inline fun <reified T : Any> feilsjekkOgReturnerData(pdlResponse: PdlBolkResponse<T>): Map<String, T> {
+        if (pdlResponse.data == null) {
+            secureLogger.error("Data fra pdl er null ved bolkoppslag av ${T::class} fra PDL: ${pdlResponse.errorMessages()}")
+            throw PdlRequestException("Data er null fra PDL -  ${T::class}. Se secure logg for detaljer.")
+        }
+
+        val feil = pdlResponse.data.personBolk.filter { it.code != "ok" }.map { it.ident to it.code }.toMap()
+        if (feil.isNotEmpty()) {
+            secureLogger.error("Feil ved henting av ${T::class} fra PDL: $feil")
+            throw PdlRequestException("Feil ved henting av ${T::class} fra PDL. Se secure logg for detaljer.")
+        }
+        return pdlResponse.data.personBolk.associateBy({ it.ident }, { it.person!! })
+    }
+
+    companion object {
+
+        private const val PATH_GRAPHQL = "graphql"
+        private val HENT_PERSON_RELASJONER_ADRESSEBESKYTTELSE = hentPdlGraphqlQuery("hentpersoner-relasjoner-adressebeskyttelse")
+    }
+}
+

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/PdlRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/PdlRestClient.kt
@@ -10,18 +10,13 @@ import no.nav.familie.integrasjoner.geografisktilknytning.PdlGeografiskTilknytni
 import no.nav.familie.integrasjoner.geografisktilknytning.PdlGeografiskTilknytningVariables
 import no.nav.familie.integrasjoner.geografisktilknytning.PdlHentGeografiskTilknytning
 import no.nav.familie.integrasjoner.personopplysning.PdlNotFoundException
-import no.nav.familie.integrasjoner.personopplysning.PdlRequestException
 import no.nav.familie.integrasjoner.personopplysning.internal.Familierelasjon
-import no.nav.familie.integrasjoner.personopplysning.internal.PdlBolkResponse
 import no.nav.familie.integrasjoner.personopplysning.internal.PdlHentIdenter
 import no.nav.familie.integrasjoner.personopplysning.internal.PdlIdent
 import no.nav.familie.integrasjoner.personopplysning.internal.PdlIdentRequest
 import no.nav.familie.integrasjoner.personopplysning.internal.PdlIdentRequestVariables
 import no.nav.familie.integrasjoner.personopplysning.internal.PdlPerson
-import no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonBolkRequest
-import no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonBolkRequestVariables
 import no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonMedAdressebeskyttelse
-import no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonMedRelasjonerOgAdressebeskyttelse
 import no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonRequest
 import no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonRequestVariables
 import no.nav.familie.integrasjoner.personopplysning.internal.PdlResponse
@@ -50,7 +45,7 @@ class PdlRestClient(@Value("\${PDL_URL}") pdlBaseUrl: URI,
 
         val response: PdlResponse<PdlPersonMedAdressebeskyttelse> = postForEntity(pdlUri,
                                                                                   pdlAdressebeskyttelseRequest,
-                                                                                  httpHeaders(tema))
+                                                                                  pdlHttpHeaders(tema))
 
         return feilsjekkOgReturnerData(response, personIdent)
     }
@@ -62,7 +57,7 @@ class PdlRestClient(@Value("\${PDL_URL}") pdlBaseUrl: URI,
         try {
             val response = postForEntity<PdlResponse<PdlPerson>>(pdlUri,
                                                                  pdlPersonRequest,
-                                                                 httpHeaders(tema))
+                                                                 pdlHttpHeaders(tema))
             if (!response.harFeil()) {
                 return Result.runCatching {
                     val familierelasjoner: Set<Familierelasjon> =
@@ -114,7 +109,7 @@ class PdlRestClient(@Value("\${PDL_URL}") pdlBaseUrl: URI,
         try {
             val response = postForEntity<PdlResponse<PdlHentIdenter>>(pdlUri,
                                                                       pdlPersonRequest,
-                                                                      httpHeaders(tema))
+                                                                      pdlHttpHeaders(tema))
             if (response.harFeil() || response.data.hentIdenter == null) {
                 if (response.harNotFoundFeil()) {
                     secureLogger.info("Finner ikke ident med gruppe=$gruppe for ident=$ident i PDL")
@@ -129,30 +124,6 @@ class PdlRestClient(@Value("\${PDL_URL}") pdlBaseUrl: URI,
         } catch (e: Exception) {
             throw pdlOppslagException(ident, error = e)
         }
-    }
-
-    fun hentPersonMedRelasjonerOgAdressebeskyttelse(identer: List<String>,
-                                                    tema: Tema): Map<String, PdlPersonMedRelasjonerOgAdressebeskyttelse> {
-        val request = PdlPersonBolkRequest(variables = PdlPersonBolkRequestVariables(identer),
-                                           query = HENT_PERSON_RELASJONER_ADRESSEBESKYTTELSE)
-        val response = postForEntity<PdlBolkResponse<PdlPersonMedRelasjonerOgAdressebeskyttelse>>(pdlUri,
-                                                                                                  request,
-                                                                                                  httpHeaders(tema))
-        return feilsjekkOgReturnerData(response)
-    }
-
-    private inline fun <reified T : Any> feilsjekkOgReturnerData(pdlResponse: PdlBolkResponse<T>): Map<String, T> {
-        if (pdlResponse.data == null) {
-            secureLogger.error("Data fra pdl er null ved bolkoppslag av ${T::class} fra PDL: ${pdlResponse.errorMessages()}")
-            throw PdlRequestException("Data er null fra PDL -  ${T::class}. Se secure logg for detaljer.")
-        }
-
-        val feil = pdlResponse.data.personBolk.filter { it.code != "ok" }.map { it.ident to it.code }.toMap()
-        if (feil.isNotEmpty()) {
-            secureLogger.error("Feil ved henting av ${T::class} fra PDL: $feil")
-            throw PdlRequestException("Feil ved henting av ${T::class} fra PDL. Se secure logg for detaljer.")
-        }
-        return pdlResponse.data.personBolk.associateBy({ it.ident }, { it.person!! })
     }
 
     private inline fun <reified T : Any> feilsjekkOgReturnerData(pdlResponse: PdlResponse<T>, personIdent: String): T {
@@ -185,7 +156,7 @@ class PdlRestClient(@Value("\${PDL_URL}") pdlBaseUrl: URI,
         try {
             val response: PdlResponse<PdlHentGeografiskTilknytning> = postForEntity(pdlUri,
                                                                                     pdlGeografiskTilknytningRequest,
-                                                                                    httpHeaders(tema))
+                                                                                    pdlHttpHeaders(tema))
 
             if (response.harFeil()) {
                 if (response.harNotFoundFeil()) {
@@ -203,15 +174,6 @@ class PdlRestClient(@Value("\${PDL_URL}") pdlBaseUrl: URI,
                 is PdlNotFoundException -> throw e
                 else -> throw pdlOppslagException(personIdent, error = e)
             }
-        }
-    }
-
-
-    private fun httpHeaders(tema: Tema): HttpHeaders {
-        return HttpHeaders().apply {
-            contentType = MediaType.APPLICATION_JSON
-            accept = listOf(MediaType.APPLICATION_JSON)
-            add("Tema", tema.name)
         }
     }
 
@@ -233,19 +195,27 @@ class PdlRestClient(@Value("\${PDL_URL}") pdlBaseUrl: URI,
     companion object {
 
         private const val PATH_GRAPHQL = "graphql"
-        private val HENT_IDENTER_QUERY = hentGraphqlQuery("hentIdenter")
+        private val HENT_IDENTER_QUERY = hentPdlGraphqlQuery("hentIdenter")
         private val HENT_GEOGRAFISK_TILKNYTNING_QUERY = graphqlQuery("/pdl/geografisk_tilknytning.graphql")
         private val HENT_ADRESSEBESKYTTELSE_QUERY = graphqlQuery("/pdl/adressebeskyttelse.graphql")
-        private val HENT_PERSON_RELASJONER_ADRESSEBESKYTTELSE = hentGraphqlQuery("hentpersoner-relasjoner-adressebeskyttelse")
+        private val HENT_PERSON_RELASJONER_ADRESSEBESKYTTELSE = hentPdlGraphqlQuery("hentpersoner-relasjoner-adressebeskyttelse")
     }
 }
 
 enum class PersonInfoQuery(val graphQL: String) {
-    ENKEL(hentGraphqlQuery("hentperson-enkel")),
-    MED_RELASJONER(hentGraphqlQuery("hentperson-med-relasjoner"))
+    ENKEL(hentPdlGraphqlQuery("hentperson-enkel")),
+    MED_RELASJONER(hentPdlGraphqlQuery("hentperson-med-relasjoner"))
 }
 
-private fun hentGraphqlQuery(pdlResource: String): String {
+fun hentPdlGraphqlQuery(pdlResource: String): String {
     return PersonInfoQuery::class.java.getResource("/pdl/$pdlResource.graphql").readText().graphqlCompatible()
+}
+
+fun pdlHttpHeaders(tema: Tema): HttpHeaders {
+    return HttpHeaders().apply {
+        contentType = MediaType.APPLICATION_JSON
+        accept = listOf(MediaType.APPLICATION_JSON)
+        add("Tema", tema.name)
+    }
 }
 

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/PdlRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/PdlRestClient.kt
@@ -1,12 +1,14 @@
 package no.nav.familie.integrasjoner.client.rest
 
 import no.nav.familie.http.client.AbstractRestClient
-import no.nav.familie.http.sts.StsRestClient
 import no.nav.familie.http.util.UriUtil
 import no.nav.familie.integrasjoner.felles.OppslagException
 import no.nav.familie.integrasjoner.felles.graphqlCompatible
 import no.nav.familie.integrasjoner.felles.graphqlQuery
-import no.nav.familie.integrasjoner.geografisktilknytning.*
+import no.nav.familie.integrasjoner.geografisktilknytning.GeografiskTilknytningDto
+import no.nav.familie.integrasjoner.geografisktilknytning.PdlGeografiskTilknytningRequest
+import no.nav.familie.integrasjoner.geografisktilknytning.PdlGeografiskTilknytningVariables
+import no.nav.familie.integrasjoner.geografisktilknytning.PdlHentGeografiskTilknytning
 import no.nav.familie.integrasjoner.personopplysning.PdlNotFoundException
 import no.nav.familie.integrasjoner.personopplysning.PdlRequestException
 import no.nav.familie.integrasjoner.personopplysning.internal.Familierelasjon
@@ -16,9 +18,9 @@ import no.nav.familie.integrasjoner.personopplysning.internal.PdlIdent
 import no.nav.familie.integrasjoner.personopplysning.internal.PdlIdentRequest
 import no.nav.familie.integrasjoner.personopplysning.internal.PdlIdentRequestVariables
 import no.nav.familie.integrasjoner.personopplysning.internal.PdlPerson
-import no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonMedAdressebeskyttelse
 import no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonBolkRequest
 import no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonBolkRequestVariables
+import no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonMedAdressebeskyttelse
 import no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonMedRelasjonerOgAdressebeskyttelse
 import no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonRequest
 import no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonRequestVariables
@@ -37,8 +39,7 @@ import java.net.URI
 
 @Service
 class PdlRestClient(@Value("\${PDL_URL}") pdlBaseUrl: URI,
-                    @Qualifier("sts") val restTemplate: RestOperations,
-                    private val stsRestClient: StsRestClient)
+                    @Qualifier("jwtBearer") private val restTemplate: RestOperations)
     : AbstractRestClient(restTemplate, "pdl.personinfo") {
 
     private val pdlUri = UriUtil.uri(pdlBaseUrl, PATH_GRAPHQL)
@@ -210,7 +211,6 @@ class PdlRestClient(@Value("\${PDL_URL}") pdlBaseUrl: URI,
         return HttpHeaders().apply {
             contentType = MediaType.APPLICATION_JSON
             accept = listOf(MediaType.APPLICATION_JSON)
-            add("Nav-Consumer-Token", "Bearer ${stsRestClient.systemOIDCToken}")
             add("Tema", tema.name)
         }
     }

--- a/src/main/java/no/nav/familie/integrasjoner/config/RestTemplateConfig.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/config/RestTemplateConfig.kt
@@ -20,7 +20,8 @@ import org.springframework.web.client.RestTemplate
 @Import(ConsumerIdClientInterceptor::class,
         BearerTokenClientInterceptor::class,
         StsBearerTokenClientInterceptor::class,
-        BearerTokenWithSTSFallbackClientInterceptor::class)
+        BearerTokenWithSTSFallbackClientInterceptor::class,
+        BearerTokenClientCredentialsClientInterceptor::class)
 class RestTemplateConfig(
         private val environment: Environment
 ) {

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerService.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.integrasjoner.personopplysning
 
+import no.nav.familie.integrasjoner.client.rest.PdlClientCredentialRestClient
 import no.nav.familie.integrasjoner.client.rest.PdlRestClient
 import no.nav.familie.integrasjoner.client.rest.PersonInfoQuery
 import no.nav.familie.integrasjoner.client.soap.PersonSoapClient
@@ -34,7 +35,8 @@ import no.nav.tjeneste.virksomhet.person.v3.informasjon.PersonIdent as TpsPerson
 @ApplicationScope
 class PersonopplysningerService(private val personSoapClient: PersonSoapClient,
                                 private val oversetter: TpsOversetter,
-                                private val pdlRestClient: PdlRestClient) {
+                                private val pdlRestClient: PdlRestClient,
+                                private val pdlClientCredentialRestClient: PdlClientCredentialRestClient) {
 
     @Deprecated("Tps er markert for utfasing. PDL er master.")
     fun hentHistorikkFor(personIdent: String, fom: LocalDate, tom: LocalDate): PersonhistorikkInfo {
@@ -119,7 +121,7 @@ class PersonopplysningerService(private val personSoapClient: PersonSoapClient,
     private fun hentPersonMedRelasjonerOgAdressebeskyttelse(personIdenter: List<String>,
                                                             tema: Tema): Map<String, PdlPersonMedRelasjonerOgAdressebeskyttelse> {
         if (personIdenter.isEmpty()) return emptyMap()
-        return pdlRestClient.hentPersonMedRelasjonerOgAdressebeskyttelse(personIdenter, tema)
+        return pdlClientCredentialRestClient.hentPersonMedRelasjonerOgAdressebeskyttelse(personIdenter, tema)
     }
 
     companion object {

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -86,6 +86,24 @@ no.nav.security.jwt:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
+      pdl:
+        resource-url: ${PDL_URL}
+        token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+        grant-type: client_credentials
+        scope: api://dev-fss.pdl.pdl-api/.default
+        authentication:
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
+          client-auth-method: client_secret_basic
+      pdl-onbehalf-of:
+        resource-url: ${PDL_URL}
+        token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+        grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
+        scope: api://dev-fss.pdl.pdl-api/.default
+        authentication:
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
+          client-auth-method: client_secret_basic
 
 
 AAD_GRAPH_API_URI: https://graph.microsoft.com/v1.0/

--- a/src/main/resources/application-e2e.yml
+++ b/src/main/resources/application-e2e.yml
@@ -86,6 +86,24 @@ no.nav.security.jwt:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
+      pdl:
+        resource-url: ${PDL_URL}
+        token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+        grant-type: client_credentials
+        scope: api://dev-fss.pdl.pdl-api/.default
+        authentication:
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
+          client-auth-method: client_secret_basic
+      pdl-onbehalf-of:
+        resource-url: ${PDL_URL}
+        token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+        grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
+        scope: api://dev-fss.pdl.pdl-api/.default
+        authentication:
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
+          client-auth-method: client_secret_basic
 
 AZURE_APP_CLIENT_ID: ${INTEGRASJONER_CLIENT_ID}
 AZURE_APP_CLIENT_SECRET: ${INTEGRASJONER_CLIENT_SECRET}

--- a/src/main/resources/application-integrasjonstest.yaml
+++ b/src/main/resources/application-integrasjonstest.yaml
@@ -86,6 +86,24 @@ no.nav.security.jwt:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
+      pdl:
+        resource-url: ${PDL_URL}
+        token-endpoint-url: https://login.microsoftonline.com/navq.onmicrosoft.com/oauth2/v2.0/token
+        grant-type: client_credentials
+        scope: api://dev-fss.pdl.pdl-api/.default
+        authentication:
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
+          client-auth-method: client_secret_basic
+      pdl-onbehalf-of:
+        resource-url: ${PDL_URL}
+        token-endpoint-url: https://login.microsoftonline.com/navq.onmicrosoft.com/oauth2/v2.0/token
+        grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
+        scope: api://dev-fss.pdl.pdl-api/.default
+        authentication:
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
+          client-auth-method: client_secret_basic
 
 
 SFTP_HOST: localhost

--- a/src/main/resources/application-preprod-q1.yaml
+++ b/src/main/resources/application-preprod-q1.yaml
@@ -87,8 +87,27 @@ no.nav.security.jwt:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
+      pdl:
+        resource-url: ${PDL_URL}
+        token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+        grant-type: client_credentials
+        scope: ${PDL_SCOPE}
+        authentication:
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
+          client-auth-method: client_secret_basic
+      pdl-onbehalf-of:
+        resource-url: ${PDL_URL}
+        token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+        grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
+        scope: ${PDL_SCOPE}
+        authentication:
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
+          client-auth-method: client_secret_basic
 
 DOKARKIV_SCOPE: api://dev-fss.teamdokumenthandtering.dokarkiv-q1/.default
+PDL_SCOPE: api://dev-fss.pdl.pdl-api-q1/.default
 
 AAD_GRAPH_API_URI: https://graph.microsoft.com/v1.0/
 SECURITYTOKENSERVICE_URL: https://sts-q2.preprod.local/SecurityTokenServiceProvider/

--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -87,11 +87,30 @@ no.nav.security.jwt:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
+      pdl:
+        resource-url: ${PDL_URL}
+        token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+        grant-type: client_credentials
+        scope: ${PDL_SCOPE}
+        authentication:
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
+          client-auth-method: client_secret_basic
+      pdl-onbehalf-of:
+        resource-url: ${PDL_URL}
+        token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+        grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
+        scope: ${PDL_SCOPE}
+        authentication:
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
+          client-auth-method: client_secret_basic
 
 INTEGRASJONER_CLIENT_ID: ${AZURE_APP_CLIENT_ID}
 CLIENT_SECRET: ${AZURE_APP_CLIENT_SECRET}
 INFOTRYGD_KS_SCOPE: ${INFOTRYGD_KS_SCOPE}
 DOKARKIV_SCOPE: api://dev-fss.teamdokumenthandtering.dokarkiv/.default
+PDL_SCOPE: api://dev-fss.pdl.pdl-api/.default
 
 AAD_GRAPH_API_URI: https://graph.microsoft.com/v1.0/
 SECURITYTOKENSERVICE_URL: https://sts-q2.preprod.local/SecurityTokenServiceProvider/

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -87,11 +87,30 @@ no.nav.security.jwt:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
+      pdl:
+        resource-url: ${PDL_URL}
+        token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+        grant-type: client_credentials
+        scope: ${PDL_SCOPE}
+        authentication:
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
+          client-auth-method: client_secret_basic
+      pdl-onbehalf-of:
+        resource-url: ${PDL_URL}
+        token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+        grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
+        scope: ${PDL_SCOPE}
+        authentication:
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
+          client-auth-method: client_secret_basic
 
 INTEGRASJONER_CLIENT_ID: ${AZURE_APP_CLIENT_ID}
 CLIENT_SECRET: ${AZURE_APP_CLIENT_SECRET}
 INFOTRYGD_KS_SCOPE: ${INFOTRYGD_KS_SCOPE}
 DOKARKIV_SCOPE: api://prod-fss.teamdokumenthandtering.dokarkiv/.default
+PDL_SCOPE: api://prod-fss.pdl.pdl-api/.default
 
 AAD_GRAPH_API_URI: https://graph.microsoft.com/v1.0/
 SECURITYTOKENSERVICE_URL: https://sts.adeo.no/SecurityTokenServiceProvider/

--- a/src/test/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerControllerTest.kt
@@ -31,7 +31,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.web.util.UriComponentsBuilder
 import kotlin.test.assertNull
 
-@ActiveProfiles("integrasjonstest", "mock-personopplysninger", "mock-sts")
+@ActiveProfiles("integrasjonstest", "mock-personopplysninger", "mock-oauth")
 @ExtendWith(MockServerExtension::class)
 @MockServerSettings(ports = [OppslagSpringRunnerTest.MOCK_SERVER_PORT])
 class PersonopplysningerControllerTest(val client: ClientAndServer) : OppslagSpringRunnerTest() {

--- a/src/test/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerServiceTest.kt
@@ -3,6 +3,7 @@ package no.nav.familie.integrasjoner.personopplysning
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import no.nav.familie.integrasjoner.client.rest.PdlClientCredentialRestClient
 import no.nav.familie.integrasjoner.client.rest.PdlRestClient
 import no.nav.familie.integrasjoner.client.soap.PersonSoapClient
 import no.nav.familie.integrasjoner.felles.OppslagException
@@ -36,13 +37,15 @@ class PersonopplysningerServiceTest {
     private lateinit var personopplysningerService: PersonopplysningerService
 
     private val pdlRestClient = mockk<PdlRestClient>()
+    private val pdlClientCredentialRestClient = mockk<PdlClientCredentialRestClient>()
 
     @BeforeEach
     fun setUp() {
         personSoapClient = PersonopplysningerTestConfig().personConsumerMock()
         personopplysningerService = PersonopplysningerService(personSoapClient,
                                                               TpsOversetter(TpsAdresseOversetter()),
-                                                              pdlRestClient)
+                                                              pdlRestClient,
+                                                              pdlClientCredentialRestClient)
     }
 
     @Test
@@ -138,10 +141,10 @@ class PersonopplysningerServiceTest {
                                           fullmakt = listOf(Fullmakt("4")))
         val barn = lagPdlPersonMedRelasjoner(familierelasjoner = listOf(PdlForelderBarnRelasjon("22",
                                                                                                 FORELDERBARNRELASJONROLLE.FAR)))
-        every { pdlRestClient.hentPersonMedRelasjonerOgAdressebeskyttelse(any(), any()) } answers {
+        every { pdlClientCredentialRestClient.hentPersonMedRelasjonerOgAdressebeskyttelse(any(), any()) } answers {
             firstArg<List<String>>().map { it to if (it == "2") barn else lagPdlPersonMedRelasjoner() }.toMap()
         }
-        every { pdlRestClient.hentPersonMedRelasjonerOgAdressebeskyttelse(listOf("1"), any()) } returns mapOf(hovedPerson)
+        every { pdlClientCredentialRestClient.hentPersonMedRelasjonerOgAdressebeskyttelse(listOf("1"), any()) } returns mapOf(hovedPerson)
 
         val hentPersonMedRelasjoner = personopplysningerService.hentPersonMedRelasjoner("1", Tema.ENF)
 
@@ -151,9 +154,9 @@ class PersonopplysningerServiceTest {
         assertThat(hentPersonMedRelasjoner.fullmakt.single().personIdent).isEqualTo("4")
 
         verify(exactly = 1) {
-            pdlRestClient.hentPersonMedRelasjonerOgAdressebeskyttelse(listOf("1"), any())
-            pdlRestClient.hentPersonMedRelasjonerOgAdressebeskyttelse(listOf("2", "3", "4"), any())
-            pdlRestClient.hentPersonMedRelasjonerOgAdressebeskyttelse(listOf("22"), any())
+            pdlClientCredentialRestClient.hentPersonMedRelasjonerOgAdressebeskyttelse(listOf("1"), any())
+            pdlClientCredentialRestClient.hentPersonMedRelasjonerOgAdressebeskyttelse(listOf("2", "3", "4"), any())
+            pdlClientCredentialRestClient.hentPersonMedRelasjonerOgAdressebeskyttelse(listOf("22"), any())
         }
     }
 


### PR DESCRIPTION
Splitter opp PDLClient med kun client_credentials-kall for kall som kun har støtte for det.
`PdlClientCredentialRestClient` bruker `hentPersonBolk` som kun støtter client_credential

For å sikre tilgangsstyringen på uthenting av informasjon så burde vi skru av uthenting av personinformasjon fra integrasjoner, eller legge til tilgangssjekk på controllers som henter ut personinfo.