### PR TITLE
PDL endrer relatertPersonsIdent i ForelderBarnRelasjon til nullable, …

### DIFF
--- a/.github/workflows/integrasjonsTest.yml
+++ b/.github/workflows/integrasjonsTest.yml
@@ -27,4 +27,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_PROJECTKEY: ${{ secrets.SONAR_PROJECTKEY }}
           SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}
-        run: mvn verify sonar:sonar --settings .m2/maven-settings.xml --file pom.xml
+        run: mvn verify --settings .m2/maven-settings.xml --file pom.xml
+        #run: mvn verify sonar:sonar --settings .m2/maven-settings.xml --file pom.xml

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerService.kt
@@ -71,7 +71,7 @@ class PersonopplysningerService(private val personSoapClient: PersonSoapClient,
         val hovedperson = hentPersonMedRelasjonerOgAdressebeskyttelse(listOf(personIdent), tema).getOrThrow(personIdent)
         val barnIdenter = hovedperson.forelderBarnRelasjon
                 .filter { it.relatertPersonsRolle == FORELDERBARNRELASJONROLLE.BARN }
-                .map { it.relatertPersonsIdent }
+                .mapNotNull { it.relatertPersonsIdent }
         val sivilstandIdenter = hovedperson.sivilstand.mapNotNull { it.relatertVedSivilstand }.distinct()
         val fullmaktIdenter = hovedperson.fullmakt.map { it.motpartsPersonident }.distinct()
 
@@ -99,7 +99,7 @@ class PersonopplysningerService(private val personSoapClient: PersonSoapClient,
                                    tema: Tema): List<PersonMedAdresseBeskyttelse> {
         val barnsForeldrerIdenter = barnOpplysninger.flatMap { (_, personMedRelasjoner) ->
             personMedRelasjoner.forelderBarnRelasjon.filter { it.relatertPersonsRolle != FORELDERBARNRELASJONROLLE.BARN }
-        }.filter { it.relatertPersonsIdent != personIdent }.map { it.relatertPersonsIdent }.distinct()
+        }.filter { it.relatertPersonsIdent != personIdent }.mapNotNull { it.relatertPersonsIdent }.distinct()
         val barnsForeldrerOpplysninger = hentPersonMedRelasjonerOgAdressebeskyttelse(barnsForeldrerIdenter, tema)
 
         return mapPersonMedRelasjoner(barnsForeldrerIdenter, barnsForeldrerOpplysninger)

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlResponse.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlResponse.kt
@@ -81,7 +81,7 @@ data class PdlNavn(val fornavn: String,
 data class PdlKjoenn(val kjoenn: KJØNN)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class PdlForelderBarnRelasjon(val relatertPersonsIdent: String,
+data class PdlForelderBarnRelasjon(val relatertPersonsIdent: String?,
                                    val relatertPersonsRolle: FORELDERBARNRELASJONROLLE)
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/resources/pdl/pdl-api-schema.graphql
+++ b/src/main/resources/pdl/pdl-api-schema.graphql
@@ -142,7 +142,8 @@ type ForelderBarnRelasjon {
     folkeregistermetadata: Folkeregistermetadata
     metadata: Metadata!
     minRolleForPerson: ForelderBarnRelasjonRolle
-    relatertPersonsIdent: String!
+    relatertPersonUtenFolkeregisteridentifikator: RelatertBiPerson
+    relatertPersonsIdent: String
     relatertPersonsRolle: ForelderBarnRelasjonRolle!
 }
 
@@ -530,6 +531,7 @@ type Query {
     forslagAdresse(parameters: CompletionParameters): AdresseCompletionResult
     hentAdresse(matrikkelId: ID!): KartverketAdresse
     hentGeografiskTilknytning(ident: ID!): GeografiskTilknytning
+    hentGeografiskTilknytningBolk(identer: [ID!]!): [hentGeografiskTilknytningBolkResult!]!
     hentIdenter(grupper: [IdentGruppe!], historikk: Boolean = false, ident: ID!): Identliste
     hentIdenterBolk(grupper: [IdentGruppe!], historikk: Boolean = false, identer: [ID!]!): [HentIdenterBolkResult!]!
     hentPerson(ident: ID!): Person
@@ -686,6 +688,12 @@ type VergemaalEllerFremtidsfullmakt {
     vergeEllerFullmektig: VergeEllerFullmektig!
 }
 
+type hentGeografiskTilknytningBolkResult {
+    code: String!
+    geografiskTilknytning: GeografiskTilknytning
+    ident: String!
+}
+
 enum AdressebeskyttelseGradering {
     FORTROLIG
     STRENGT_FORTROLIG
@@ -776,6 +784,15 @@ enum Sivilstandstype {
     UGIFT
     UOPPGITT
 }
+
+"Format: YYYY-MM-DD (ISO-8601), example: 2017-11-24"
+scalar Date
+
+"Format: YYYY-MM-DDTHH:mm:SS (ISO-8601), example: 2011-12-03T10:15:30"
+scalar DateTime
+
+"Long type"
+scalar Long
 
 input CompletionFieldValue {
     fieldName: String!
@@ -879,13 +896,3 @@ input SearchSorting {
     " Feltnavn ikludert sti til ønsket felt (eksepmel: person.navn.fornavn)"
     fieldName: String!
 }
-
-
-"Format: YYYY-MM-DD (ISO-8601), example: 2017-11-24"
-scalar Date
-
-"Format: YYYY-MM-DDTHH:mm:SS (ISO-8601), example: 2011-12-03T10:15:30"
-scalar DateTime
-
-"Long type"
-scalar Long


### PR DESCRIPTION
…vanligvis hvis ene foreldern bor i utlandet uten norsk ident

Disse filtreres bare bort nå, då de ikke brukes direkte. Hvis det er behov for de får man legge til støtte for det senere.

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8687