### PR TITLE
Håndter at person-objektet i PdlPersonMedAdressebeskyttelse kan være null

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerService.kt
@@ -92,7 +92,7 @@ class PersonopplysningerService(private val personSoapClient: PersonSoapClient,
     }
 
     fun hentAdressebeskyttelse(personIdent: String, tema: Tema): Adressebeskyttelse {
-        return pdlRestClient.hentAdressebeskyttelse(personIdent, tema).person.adressebeskyttelse.firstOrNull()
+        return pdlRestClient.hentAdressebeskyttelse(personIdent, tema).adressebeskyttelse.firstOrNull()
                ?: Adressebeskyttelse(gradering = ADRESSEBESKYTTELSEGRADERING.UGRADERT)
     }
 

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlResponse.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlResponse.kt
@@ -29,7 +29,7 @@ data class PdlBolkResponse<T>(val data: PersonBolk<T>?, val errors: List<PdlErro
     }
 }
 
-data class PdlPersonMedAdressebeskyttelse(val person: PdlAdressebeskyttelse)
+data class PdlPersonMedAdressebeskyttelse(val person: PdlAdressebeskyttelse?)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class PdlAdressebeskyttelse(val adressebeskyttelse: List<Adressebeskyttelse>)

--- a/src/test/java/no/nav/familie/integrasjoner/personopplysning/PdlGraphqlTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/personopplysning/PdlGraphqlTest.kt
@@ -80,7 +80,7 @@ class PdlGraphqlTest {
     @Test
     fun testPdlAdressebeskyttelse() {
         val resp: PdlResponse<PdlPersonMedAdressebeskyttelse> = mapper.readValue(File(getFile("pdl/pdlAdressebeskyttelseResponse.json")))
-        assertThat(resp.data.person.adressebeskyttelse).hasSize(1)
+        assertThat(resp.data.person?.adressebeskyttelse).hasSize(1)
     }
 
     @Test


### PR DESCRIPTION
Knyttet til denne favro-oppgaven: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8850

Har et par tilfeller hvor vi får feilmeldingen: 
```
Caused by: org.springframework.web.client.RestClientException: Error while extracting response for type [no.nav.familie.integrasjoner.personopplysning.internal.PdlResponse<no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonMedAdressebeskyttelse>] and content type [application/json]; nested exception is org.springframework.http.converter.HttpMessageNotReadableException: JSON parse error: Instantiation of [simple type, class no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonMedAdressebeskyttelse] value failed for JSON property person due to missing (therefore NULL) value for creator parameter person which is a non-nullable type; nested exception is com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException: Instantiation of [simple type, class no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonMedAdressebeskyttelse] value failed for JSON property person due to missing (therefore NULL) value for creator parameter person which is a non-nullable type
 at [Source: (org.springframework.util.StreamUtils$NonClosingInputStream); line: 1, column: 323] (through reference chain: no.nav.familie.integrasjoner.personopplysning.internal.PdlResponse["data"]->no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonMedAdressebeskyttelse["person"])
```

Dvs. feltet person i PdlPersonMedAdressebeskyttelse er null når koden sier at person ikke er nullable. Tillater derfor at person-objektet i PdlPersonMedAdressebeskyttelse kan være null.

Gjør i tillegg litt refaktorering.
