### PR TITLE
Håndter unauthorized-feil ved henting av adressebeskyttelse fra PDL

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/PdlRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/PdlRestClient.kt
@@ -10,6 +10,7 @@ import no.nav.familie.integrasjoner.geografisktilknytning.PdlGeografiskTilknytni
 import no.nav.familie.integrasjoner.geografisktilknytning.PdlGeografiskTilknytningVariables
 import no.nav.familie.integrasjoner.geografisktilknytning.PdlHentGeografiskTilknytning
 import no.nav.familie.integrasjoner.personopplysning.PdlNotFoundException
+import no.nav.familie.integrasjoner.personopplysning.PdlUnauthorizedException
 import no.nav.familie.integrasjoner.personopplysning.internal.Familierelasjon
 import no.nav.familie.integrasjoner.personopplysning.internal.PdlAdressebeskyttelse
 import no.nav.familie.integrasjoner.personopplysning.internal.PdlHentIdenter
@@ -115,6 +116,10 @@ class PdlRestClient(@Value("\${PDL_URL}") pdlBaseUrl: URI,
             if (pdlResponse.harNotFoundFeil()) {
                 secureLogger.info("Finner ikke person for ident=$personIdent i PDL")
                 throw PdlNotFoundException()
+            }
+            if (pdlResponse.harUnauthorizedFeil()) {
+                secureLogger.info("Har ikke tilgang til person med ident=$personIdent i PDL")
+                throw PdlUnauthorizedException()
             }
             throw pdlOppslagException(feilmelding = "Feil ved oppslag på person: ${pdlResponse.errorMessages()}. Se secureLogs for mer info.",
                                       personIdent = personIdent)

--- a/src/main/java/no/nav/familie/integrasjoner/config/ApiExceptionHandler.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/config/ApiExceptionHandler.kt
@@ -2,6 +2,7 @@ package no.nav.familie.integrasjoner.config
 
 import no.nav.familie.integrasjoner.felles.OppslagException
 import no.nav.familie.integrasjoner.personopplysning.PdlNotFoundException
+import no.nav.familie.integrasjoner.personopplysning.PdlUnauthorizedException
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.Ressurs.Companion.failure
 import no.nav.security.token.support.client.core.OAuth2ClientException
@@ -94,6 +95,11 @@ class ApiExceptionHandler {
     fun handleThrowable(feil: PdlNotFoundException): ResponseEntity<Ressurs<Nothing>> {
         logger.info("Finner ikke personen i PDL")
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(failure(frontendFeilmelding = "Finner ikke personen"))
+    }
+
+    @ExceptionHandler(PdlUnauthorizedException::class)
+    fun handleThrowable(feil: PdlUnauthorizedException): ResponseEntity<Ressurs<Nothing>> {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(failure(frontendFeilmelding = "Har ikke tilgang til å slå opp personen i PDL"))
     }
 
     @ExceptionHandler(OppslagException::class)

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/PdlRequestException.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/PdlRequestException.kt
@@ -3,3 +3,5 @@ package no.nav.familie.integrasjoner.personopplysning
 open class PdlRequestException(melding: String? = null) : Exception(melding)
 
 class PdlNotFoundException: PdlRequestException()
+
+class PdlUnauthorizedException: PdlRequestException()

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlResponse.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlResponse.kt
@@ -18,6 +18,10 @@ data class PdlResponse<T>(val data: T,
     fun harNotFoundFeil(): Boolean {
         return errors?.any { it.extensions?.notFound() == true } ?: false
     }
+
+    fun harUnauthorizedFeil(): Boolean {
+        return errors?.any { it.extensions?.unauthorized() == true } ?: false
+    }
 }
 
 data class PersonDataBolk<T>(val ident: String, val code: String, val person: T?)
@@ -61,6 +65,8 @@ data class PdlError(val message: String,
 data class PdlExtensions(val code: String?) {
 
     fun notFound() = code == "not_found"
+
+    fun unauthorized() = code == "unauthorized"
 }
 
 

--- a/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollService.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.integrasjoner.tilgangskontroll
 
-import no.nav.familie.integrasjoner.client.rest.PersonInfoQuery
 import no.nav.familie.integrasjoner.config.TilgangConfig
 import no.nav.familie.integrasjoner.egenansatt.EgenAnsattService
 import no.nav.familie.integrasjoner.personopplysning.PdlUnauthorizedException
@@ -29,7 +28,7 @@ class CachedTilgangskontrollService(private val egenAnsattService: EgenAnsattSer
     fun sjekkTilgang(personIdent: String, jwtToken: JwtToken, tema: Tema): Tilgang {
         return try {
             val adressebeskyttelse = personopplysningerService.hentAdressebeskyttelse(personIdent, tema).gradering
-            sjekTilgang(adressebeskyttelse, jwtToken, personIdent) { egenAnsattService.erEgenAnsatt(personIdent) }
+            hentTilgang(adressebeskyttelse, jwtToken, personIdent) { egenAnsattService.erEgenAnsatt(personIdent) }
         } catch (pdlUnauthorizedException: PdlUnauthorizedException) {
             Tilgang(harTilgang = false)
         }
@@ -43,10 +42,10 @@ class CachedTilgangskontrollService(private val egenAnsattService: EgenAnsattSer
         secureLogger.info("Sjekker tilgang til {}", personMedRelasjoner)
 
         val høyesteGraderingen = TilgangskontrollUtil.høyesteGraderingen(personMedRelasjoner)
-        return sjekTilgang(høyesteGraderingen, jwtToken, personIdent) { erEgenAnsatt(personMedRelasjoner) }
+        return hentTilgang(høyesteGraderingen, jwtToken, personIdent) { erEgenAnsatt(personMedRelasjoner) }
     }
 
-    private fun sjekTilgang(adressebeskyttelsegradering: ADRESSEBESKYTTELSEGRADERING?,
+    private fun hentTilgang(adressebeskyttelsegradering: ADRESSEBESKYTTELSEGRADERING?,
                             jwtToken: JwtToken,
                             personIdent: String,
                             egenAnsattSjekk: () -> Boolean): Tilgang {


### PR DESCRIPTION
Hvis saksbehandler ikke har de rette tilgangene til å hente adressebeskyttelse får man unauthorized-feil: https://pdldocs-navno.msappproxy.net/ekstern/index.html#tilgangsfeil.

I stedet for at det kastes feil, ønsker vi å håndtere dette tilfellet ved å sende tilbake et Tilgangs-objekt med harTilgang=false.