### PR TITLE
Lagt til callId mot saf og dokarkiv som ble fjernet en gang tidligere.

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivLogiskVedleggRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivLogiskVedleggRestClient.kt
@@ -1,11 +1,13 @@
 package no.nav.familie.integrasjoner.client.rest
 
 import no.nav.familie.http.client.AbstractRestClient
+import no.nav.familie.integrasjoner.felles.MDCOperations
 import no.nav.familie.integrasjoner.felles.OppslagException
 import no.nav.familie.kontrakter.felles.dokarkiv.LogiskVedleggRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.LogiskVedleggResponse
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import org.springframework.web.client.HttpStatusCodeException
@@ -29,7 +31,7 @@ class DokarkivLogiskVedleggRestClient(
             .buildAndExpand(dokumentInfoId)
             .toUri()
         try {
-            return postForEntity(uri, request)
+            return postForEntity(uri, request, headers())
         } catch (e: RuntimeException) {
             val responsebody = if (e is HttpStatusCodeException) e.responseBodyAsString else ""
             val message = "Kan ikke opprette logisk vedlegg for dokumentinfo $dokumentInfoId $responsebody"
@@ -69,7 +71,7 @@ class DokarkivLogiskVedleggRestClient(
         AbstractRestClient(restOperations, "dokarkiv.logiskvedlegg.slett") {
 
         fun slettLogiskVedlegg(uri: URI) {
-            deleteForEntity<String>(uri)
+            deleteForEntity<String>(uri, null, headers())
         }
     }
 
@@ -77,5 +79,13 @@ class DokarkivLogiskVedleggRestClient(
 
         private const val PATH_LOGISKVEDLEGG = "rest/journalpostapi/v1/dokumentInfo/{dokumentInfo}/logiskVedlegg/"
         private const val PATH_SLETT_LOGISK_VEDLEGG = "$PATH_LOGISKVEDLEGG/{logiskVedleggId}"
+
+        private const val NAV_CALL_ID = "Nav-Callid"
+
+        private fun headers(): HttpHeaders {
+            return HttpHeaders().apply {
+                add(NAV_CALL_ID, MDCOperations.getCallId())
+            }
+        }
     }
 }

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivRestClient.kt
@@ -6,6 +6,7 @@ import no.nav.familie.integrasjoner.dokarkiv.client.KanIkkeFerdigstilleJournalpo
 import no.nav.familie.integrasjoner.dokarkiv.client.domene.FerdigstillJournalPost
 import no.nav.familie.integrasjoner.dokarkiv.client.domene.OpprettJournalpostRequest
 import no.nav.familie.integrasjoner.dokarkiv.client.domene.OpprettJournalpostResponse
+import no.nav.familie.integrasjoner.felles.MDCOperations
 import no.nav.familie.integrasjoner.felles.OppslagException
 import no.nav.familie.kontrakter.felles.dokarkiv.OppdaterJournalpostRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.OppdaterJournalpostResponse
@@ -116,11 +117,13 @@ class DokarkivRestClient(
         private const val PATH_JOURNALPOST = "rest/journalpostapi/v1/journalpost"
         private const val QUERY_FERDIGSTILL = "forsoekFerdigstill={boolean}"
         private const val PATH_FERDIGSTILL_JOURNALPOST = "rest/journalpostapi/v1/journalpost/%s/ferdigstill"
+        private const val NAV_CALL_ID = "Nav-Callid"
 
         private val NAVIDENT_REGEX = """^[a-zA-Z]\d{6}$""".toRegex()
 
         fun headers(navIdent: String?): HttpHeaders {
             return HttpHeaders().apply {
+                add(NAV_CALL_ID, MDCOperations.getCallId())
                 if (!navIdent.isNullOrEmpty()) {
                     if (NAVIDENT_REGEX.matches(navIdent)) {
                         add(NavHttpHeaders.NAV_USER_ID.asString(), navIdent)

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/SafHentDokumentRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/SafHentDokumentRestClient.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.integrasjoner.client.rest
 
 import no.nav.familie.http.client.AbstractRestClient
+import no.nav.familie.integrasjoner.felles.MDCOperations
 import no.nav.familie.integrasjoner.journalpost.JournalpostForbiddenException
 import no.nav.familie.integrasjoner.journalpost.JournalpostRestClientException
 import org.springframework.beans.factory.annotation.Qualifier
@@ -30,6 +31,7 @@ class SafHentDokumentRestClient(
     private fun httpHeaders(): HttpHeaders {
         return HttpHeaders().apply {
             accept = listOf(MediaType.ALL)
+            add(NAV_CALL_ID, MDCOperations.getCallId())
         }
     }
 

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/SafRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/SafRestClient.kt
@@ -2,6 +2,7 @@ package no.nav.familie.integrasjoner.client.rest
 
 import no.nav.familie.http.client.AbstractPingableRestClient
 import no.nav.familie.http.util.UriUtil
+import no.nav.familie.integrasjoner.felles.MDCOperations
 import no.nav.familie.integrasjoner.felles.graphqlQuery
 import no.nav.familie.integrasjoner.journalpost.JournalpostForBrukerException
 import no.nav.familie.integrasjoner.journalpost.JournalpostForbiddenException
@@ -103,6 +104,7 @@ class SafRestClient(
         return HttpHeaders().apply {
             contentType = MediaType.APPLICATION_JSON
             accept = listOf(MediaType.APPLICATION_JSON)
+            add(NAV_CALL_ID, MDCOperations.getCallId())
         }
     }
 


### PR DESCRIPTION
Disse bruker en eldre variant av Nav-Callid med litet i

De i saf-klientene ble fjernet en gang, tror det var et misforstand fra min side der jeg tenkte disse allerede settes fra felles, men saf og arkiv bruker en eldre variant med `Callid` som vi ikke setter.
https://nav-it.slack.com/archives/CDBKYSE7Q/p1636627832011100?thread_ts=1636626169.009600&cid=CDBKYSE7Q