### PR TITLE
Vil filtrere bort mapper med tema Pensjon og Bidrag. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <springdoc.version>1.6.9</springdoc.version>
         <common-java-modules.version>2.2022.06.30_06.19-0603b0416483</common-java-modules.version>
         <felles.version>1.20220610091149_ae616c5</felles.version>
-        <kontrakt.version>2.0_20220830112448_a88e797</kontrakt.version>
+        <kontrakt.version>2.0_20220831094750_9782fd7</kontrakt.version>
         <cxf.version>3.5.3</cxf.version>
         <token-validation-spring.version>2.1.1</token-validation-spring.version>
         <tjenestespesifikasjoner.version>2594.7c3ac50</tjenestespesifikasjoner.version>

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
@@ -209,6 +209,9 @@ class OppgaveService constructor(
     }
 }
 
+/**
+ * Vil filtrere bort mapper med tema siden disse er spesifikke for andre ytelser enn våre (f.eks Pensjon og Bidrag)
+ **/
 private fun FinnMappeResponseDto.mapperUtenTema(): FinnMappeResponseDto {
     val mapperUtenTema = this.mapper.filter { it.tema.isNullOrBlank() }
     return this.copy(mapper = mapperUtenTema, antallTreffTotalt = mapperUtenTema.size)

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
@@ -193,19 +193,23 @@ class OppgaveService constructor(
     }
 
     fun finnMapper(finnMappeRequest: FinnMappeRequest): FinnMappeResponseDto {
-        return oppgaveRestClient.finnMapper(finnMappeRequest)
-    }
-
-    fun finnMapper(enhetNr: String): List<MappeDto> {
-        val finnMappeRequest = FinnMappeRequest(enhetsnr = enhetNr, limit = 1000)
         val mappeRespons = oppgaveRestClient.finnMapper(finnMappeRequest)
-
         if (mappeRespons.antallTreffTotalt > mappeRespons.mapper.size) {
             logger.error(
                 "Det finnes flere mapper (${mappeRespons.antallTreffTotalt}) " +
                     "enn vi har hentet ut (${mappeRespons.mapper.size}). Sjekk limit. "
             )
         }
-        return mappeRespons.mapper
+        return mappeRespons.mapperUtenTema()
     }
+
+    fun finnMapper(enhetNr: String): List<MappeDto> {
+        val finnMappeRequest = FinnMappeRequest(enhetsnr = enhetNr, limit = 1000)
+        return finnMapper(finnMappeRequest).mapper
+    }
+}
+
+private fun FinnMappeResponseDto.mapperUtenTema(): FinnMappeResponseDto {
+    val mapperUtenTema = this.mapper.filter { it.tema.isNullOrBlank() }
+    return this.copy(mapper = mapperUtenTema, antallTreffTotalt = mapperUtenTema.size)
 }

--- a/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveControllerTest.kt
@@ -72,7 +72,7 @@ class OppgaveControllerTest : OppslagSpringRunnerTest() {
     }
 
     @Test
-    fun `finnMApper med gyldig query returnerer mapper`() {
+    fun `finnMapper med gyldig query returnerer mapper uten tema som skal filtreres bort`() {
 
         stubFor(
             get(GET_MAPPER_URL)
@@ -80,12 +80,23 @@ class OppgaveControllerTest : OppslagSpringRunnerTest() {
                     okJson(
                         objectMapper.writeValueAsString(
                             FinnMappeResponseDto(
-                                5,
+                                3,
                                 listOf(
                                     MappeDto(
                                         1,
-                                        "1",
+                                        "112",
                                         "4489"
+                                    ),
+                                    MappeDto(
+                                        2,
+                                        "132",
+                                        "4489"
+                                    ),
+                                    MappeDto(
+                                        id = 3,
+                                        navn = "123",
+                                        enhetsnr = "4489",
+                                        tema = "PEN"
                                     )
                                 )
                             )
@@ -101,7 +112,7 @@ class OppgaveControllerTest : OppslagSpringRunnerTest() {
                 HttpEntity(null, headers)
             )
 
-        assertThat(response.body?.data?.antallTreffTotalt).isEqualTo(5)
+        assertThat(response.body?.data?.antallTreffTotalt).isEqualTo(2)
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
     }
 

--- a/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveServiceTest.kt
@@ -1,0 +1,57 @@
+package no.nav.familie.integrasjoner.oppgave
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.integrasjoner.client.rest.OppgaveRestClient
+import no.nav.familie.integrasjoner.client.rest.PdlRestClient
+import no.nav.familie.integrasjoner.saksbehandler.SaksbehandlerService
+import no.nav.familie.kontrakter.felles.oppgave.FinnMappeRequest
+import no.nav.familie.kontrakter.felles.oppgave.FinnMappeResponseDto
+import no.nav.familie.kontrakter.felles.oppgave.MappeDto
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class OppgaveServiceTest {
+
+    val oppgaveRestClient = mockk<OppgaveRestClient>()
+    val pdlRestClient = mockk<PdlRestClient>()
+    val saksbehandlerService = mockk<SaksbehandlerService>()
+
+    val oppgaveService = OppgaveService(oppgaveRestClient, pdlRestClient, saksbehandlerService)
+
+    val mapper = listOf(
+        MappeDto(
+            id = 1,
+            navn = "132",
+            enhetsnr = "4483"
+        ),
+        MappeDto(
+            id = 2,
+            navn = "123",
+            enhetsnr = "4483",
+            tema = "PEN"
+        )
+    )
+    val expectedResponse = FinnMappeResponseDto(antallTreffTotalt = 2, mapper = mapper)
+
+    @Test
+    fun `Skal filtrere bort mapper med tema`() {
+        every { oppgaveRestClient.finnMapper(any()) } returns expectedResponse
+        val finnMapper = oppgaveService.finnMapper("4483")
+        assertThat(finnMapper.size).isEqualTo(1)
+        assertThat(finnMapper.first().id).isEqualTo(1)
+    }
+
+    @Test
+    fun `Skal oppdatere antall treff i FinnMappeResponseDto`() {
+        every { oppgaveRestClient.finnMapper(any()) } returns expectedResponse
+        val finnMappeRequest = FinnMappeRequest(
+            tema = listOf(),
+            enhetsnr = "4483",
+            opprettetFom = null,
+            limit = 1000
+        )
+        val response = oppgaveService.finnMapper(finnMappeRequest)
+        assertThat(response.antallTreffTotalt).isEqualTo(1)
+    }
+}


### PR DESCRIPTION
Vil filtrere bort mapper med tema Pensjon og Bidrag. 
Kun generiske mapper uten tema skal returneres fra finnMapper.

Øsnker å fjerne disse - også viktig å ikke hente ut disse mappene når vi skal plassere oppgaver i mapper - risiko for at de havner hos pensjon, eller bidrag: 

![image](https://user-images.githubusercontent.com/53942238/187635524-22cf07bf-4b6e-4525-ac87-85f19b565008.png)

preprod etter deploy:

![image](https://user-images.githubusercontent.com/53942238/187655513-61a1e8d3-7961-4810-820b-2ff328b0ac47.png)

