### PR TITLE
Bumper dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.4</version>
     </parent>
 
     <groupId>no.nav.familie.integrasjoner</groupId>
@@ -20,16 +20,16 @@
         <sha1></sha1>
         <changelist>-SNAPSHOT</changelist>
         <java.version>17</java.version>
-        <springdoc.version>1.6.9</springdoc.version>
+        <springdoc.version>1.6.11</springdoc.version>
         <common-java-modules.version>2.2022.06.30_06.19-0603b0416483</common-java-modules.version>
         <felles.version>1.20220610091149_ae616c5</felles.version>
         <kontrakt.version>2.0_20220831094750_9782fd7</kontrakt.version>
         <cxf.version>3.5.3</cxf.version>
-        <token-validation-spring.version>2.1.1</token-validation-spring.version>
+        <token-validation-spring.version>2.1.4</token-validation-spring.version>
         <tjenestespesifikasjoner.version>2594.7c3ac50</tjenestespesifikasjoner.version>
-        <kotlin.version>1.6.10</kotlin.version>
+        <kotlin.version>1.7.10</kotlin.version>
 
-        <mock-server.version>5.13.2</mock-server.version>
+        <mock-server.version>5.14.0</mock-server.version>
 
         <!--suppress UnresolvedMavenProperty  Ligger som secret i github-->
         <sonar.projectKey>${SONAR_PROJECTKEY}</sonar.projectKey>

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
@@ -176,6 +176,14 @@ class OppgaveService constructor(
                 Level.MEDIUM,
                 HttpStatus.BAD_REQUEST
             )
+
+            null -> throw OppslagException(
+                "Oppgave har ingen status og kan ikke oppdateres. " +
+                    "oppgaveId=$oppgaveId",
+                "Oppgave.ferdigstill",
+                Level.MEDIUM,
+                HttpStatus.BAD_REQUEST
+            )
         }
     }
 


### PR DESCRIPTION
Oppdatert en del dependencies, måtte dea utvide `when (oppgave.status) {` med null case, så ta gjerne en titt på om det er fornuftig oppførsel der