### PR TITLE
Tea-9958_fjern_ba_mottak

### DIFF
--- a/app-preprod.teamfamilie.q1.yaml
+++ b/app-preprod.teamfamilie.q1.yaml
@@ -55,7 +55,6 @@ spec:
           cluster: dev-gcp
         - application: familie-tilbake-lokal
           cluster: dev-gcp
-        - application: familie-ba-mottak
         - application: familie-baks-mottak
           cluster: dev-gcp
         - application: familie-ef-mottak

--- a/app-preprod.teamfamilie.yaml
+++ b/app-preprod.teamfamilie.yaml
@@ -54,7 +54,6 @@ spec:
         - application: familie-tilbake-lokal
           cluster: dev-gcp
         - application: familie-ks-mottak
-        - application: familie-ba-mottak
         - application: familie-baks-mottak
           cluster: dev-gcp
         - application: familie-ef-mottak

--- a/app-prod.teamfamilie.yaml
+++ b/app-prod.teamfamilie.yaml
@@ -57,7 +57,6 @@ spec:
         - application: familie-tilbake
           cluster: prod-gcp
         - application: familie-ks-mottak
-        - application: familie-ba-mottak
         - application: familie-baks-mottak
           cluster: prod-gcp
         - application: familie-ef-mottak


### PR DESCRIPTION
Vi fjerner familie-ba-mottak(fss) da familie-baks-mottak(gcp) har tatt over.