### PR TITLE
Sette riktig tema på forside-request til Førstesidegenereator-API

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivService.kt
@@ -82,7 +82,7 @@ class DokarkivService(
 
         // førsteside
         arkiverDokumentRequest.førsteside?.also {
-            val bytes = førstesideGeneratorService.genererForside(it, arkiverDokumentRequest.fnr)
+            val bytes = førstesideGeneratorService.genererForside(it, arkiverDokumentRequest.fnr, metadata.tema)
             dokumenter += ArkivDokument(
                 brevkode = metadata.brevkode,
                 dokumentKategori = metadata.dokumentKategori,

--- a/src/main/java/no/nav/familie/integrasjoner/førstesidegenerator/FørstesideGeneratorService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/førstesidegenerator/FørstesideGeneratorService.kt
@@ -55,7 +55,7 @@ class FørstesideGeneratorService(private val førstesidegeneratorClient: Først
         return førstesidegeneratorClient.genererFørsteside(postFørstesideRequest).førsteside
     }
 
-    fun genererForside(førsteside: Førsteside, brukerId: String): ByteArray {
+    fun genererForside(førsteside: Førsteside, brukerId: String, tema: Tema): ByteArray {
         val postFørstesideRequest =
             PostFørstesideRequest(
                 språkkode = førsteside.språkkode,
@@ -71,7 +71,7 @@ class FørstesideGeneratorService(private val førstesidegeneratorClient: Først
                 ),
                 navSkjemaId = førsteside.navSkjemaId, // NAV 33.00-07
                 førstesidetype = Førstesidetype.ETTERSENDELSE,
-                tema = Tema.BAR.name,
+                tema = tema.name,
                 // "Søknad om barnetrygd ved fødsel - NAV 33.00-07,
                 // Ettersendelse til søknad om barnetrygd ved fødsel - NAV 33.00-07",
                 overskriftstittel = førsteside.overskriftstittel,

--- a/src/test/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivServiceTest.kt
@@ -145,7 +145,7 @@ class DokarkivServiceTest {
     fun `skal generere førsteside hvis førsteside er med i request`() {
         val slot = slot<OpprettJournalpostRequest>()
 
-        every { førstesideGeneratorService.genererForside(any<Førsteside>(), any()) }
+        every { førstesideGeneratorService.genererForside(any<Førsteside>(), any(), any()) }
             .answers { PDF_DOK }
 
         every { dokarkivRestClient.lagJournalpost(capture(slot), any()) }
@@ -195,7 +195,7 @@ class DokarkivServiceTest {
     fun `skal ikke generere førsteside hvis førsteside mangler i request`() {
         val slot = slot<OpprettJournalpostRequest>()
 
-        every { førstesideGeneratorService.genererForside(any<Førsteside>(), any()) }
+        every { førstesideGeneratorService.genererForside(any<Førsteside>(), any(), any()) }
             .answers { PDF_DOK }
 
         every { dokarkivRestClient.lagJournalpost(capture(slot), any()) }


### PR DESCRIPTION
Tidligere var tema hardkodet til `Tema.BAR.name`. Bruker nå tema som er spesifisert på Metadata-fil til dokumenttypen.