### PR TITLE
Vil legge til exception responseBodyAsString i data ved feil mot brev…

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/dokdist/DokdistController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokdist/DokdistController.kt
@@ -24,7 +24,13 @@ class DokdistController(private val dokdistService: DokdistService) {
     @ExceptionHandler(HttpClientErrorException::class)
     fun handleHttpClientException(e: HttpClientErrorException): ResponseEntity<Ressurs<Any>> {
         secureLogger.warn("Feil ved distribusjon: ${e.message}")
-        return ResponseEntity.status(e.rawStatusCode).body(Ressurs.failure(e.message, error = e))
+        val ressurs: Ressurs<Any> = Ressurs(
+            data = e.responseBodyAsString,
+            status = Ressurs.Status.FEILET,
+            melding = e.message.toString(),
+            stacktrace = e.stackTraceToString()
+        )
+        return ResponseEntity.status(e.rawStatusCode).body(ressurs)
     }
 
     @PostMapping("v1")
@@ -35,6 +41,7 @@ class DokdistController(private val dokdistService: DokdistService) {
     }
 
     companion object {
+
         private val secureLogger = LoggerFactory.getLogger("secureLogger")
     }
 }

--- a/src/main/java/no/nav/familie/integrasjoner/dokdist/DokdistController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokdist/DokdistController.kt
@@ -27,7 +27,7 @@ class DokdistController(private val dokdistService: DokdistService) {
         val ressurs: Ressurs<Any> = Ressurs(
             data = e.responseBodyAsString,
             status = Ressurs.Status.FEILET,
-            melding = e.message.toString(),
+            melding = e.message ?: "Uventet feil status=${e.rawStatusCode}",
             stacktrace = e.stackTraceToString()
         )
         return ResponseEntity.status(e.rawStatusCode).body(ressurs)


### PR DESCRIPTION
…distribusjon (spesielt med tanke på 409 feil hvor bestillingsId returneres i body)

Se dokdist:
https://github.com/navikt/dokdistfordeling/blob/2330e5a59f40d2d560608fbad727ca0dc65b590e/rdist002/src/main/java/no/nav/dokdistfordeling/DistribuerJournalpostController.java#L71


