### PR TITLE
Oppdaterer kontrakter uten annotasjon på FinnOppgaveRequest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <springdoc.version>1.6.14</springdoc.version>
         <common-java-modules.version>2.2022.11.16_15.18-421ec713e2a0</common-java-modules.version>
         <felles.version>1.20221202080911_bcf8f33</felles.version>
-        <kontrakt.version>2.0_20221229093739_c660777</kontrakt.version>
+        <kontrakt.version>2.0_20230112095049_2b9ddd6</kontrakt.version>
         <cxf.version>3.5.4</cxf.version>
         <token-validation-spring.version>2.1.9</token-validation-spring.version>
         <tjenestespesifikasjoner.version>2610.9b6de22</tjenestespesifikasjoner.version>

--- a/src/main/java/no/nav/familie/integrasjoner/client/QueryParamUtil.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/QueryParamUtil.kt
@@ -1,0 +1,25 @@
+package no.nav.familie.integrasjoner.client
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.familie.kontrakter.felles.objectMapper
+import org.springframework.util.LinkedMultiValueMap
+
+object QueryParamUtil {
+
+    fun toQueryParams(any: Any): LinkedMultiValueMap<String, String> {
+        val writeValueAsString = objectMapper.writeValueAsString(any)
+        val readValue: LinkedHashMap<String, Any?> = objectMapper.readValue(writeValueAsString)
+        val queryParams = LinkedMultiValueMap<String, String>()
+        readValue.filterNot { it.value == null }
+            .filterNot { it.value is List<*> && (it.value as List<*>).isEmpty() }
+            .forEach {
+                if (it.value is List<*>) {
+                    val liste = (it.value as List<*>).map { elem -> elem.toString() }
+                    queryParams.addAll(it.key, liste)
+                } else {
+                    queryParams.add(it.key, it.value.toString())
+                }
+            }
+        return queryParams
+    }
+}

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/OppgaveRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/OppgaveRestClient.kt
@@ -3,6 +3,7 @@ package no.nav.familie.integrasjoner.client.rest
 import io.micrometer.core.instrument.Metrics
 import no.nav.familie.http.client.AbstractPingableRestClient
 import no.nav.familie.http.util.UriUtil
+import no.nav.familie.integrasjoner.client.QueryParamUtil.toQueryParams
 import no.nav.familie.integrasjoner.felles.OppslagException
 import no.nav.familie.integrasjoner.oppgave.OppgaveByttEnhet
 import no.nav.familie.integrasjoner.oppgave.domene.OppgaveRequest
@@ -63,14 +64,14 @@ class OppgaveRestClient(
     fun buildOppgaveRequestUri(oppgaveRequest: OppgaveRequest): URI =
         UriComponentsBuilder.fromUri(oppgaveBaseUrl)
             .path(PATH_OPPGAVE)
-            .queryParams(oppgaveRequest.toQueryParams())
+            .queryParams(toQueryParams(oppgaveRequest))
             .build()
             .toUri()
 
     fun buildMappeRequestUri(mappeRequest: FinnMappeRequest) =
         UriComponentsBuilder.fromUri(oppgaveBaseUrl)
             .path(PATH_MAPPE)
-            .queryParams(mappeRequest.toQueryParams())
+            .queryParams(toQueryParams(mappeRequest))
             .build()
             .toUri()
 

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/domene/OppgaveRequest.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/domene/OppgaveRequest.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.integrasjoner.oppgave.domene
 
-import no.nav.familie.kontrakter.felles.abstraction.QueryObject
 import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveRequest
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -32,7 +31,7 @@ data class OppgaveRequest(
     val aktivDatoTom: LocalDate?,
     val mappeId: Long?,
     val aktoerId: String?
-) : QueryObject()
+)
 
 fun FinnOppgaveRequest.toDto() =
     OppgaveRequest(

--- a/src/test/java/no/nav/familie/integrasjoner/client/QueryParamUtilTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/client/QueryParamUtilTest.kt
@@ -1,0 +1,30 @@
+package no.nav.familie.integrasjoner.client
+
+import no.nav.familie.integrasjoner.client.QueryParamUtil.toQueryParams
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+import org.springframework.util.LinkedMultiValueMap
+
+internal class QueryParamUtilTest {
+
+    @Test
+    fun `toQueryParams ivaretar lister som lister`() {
+        val queryParams: LinkedMultiValueMap<String, String> = toQueryParams(Testdata())
+
+        assertEquals(listOf("1", "2", "3", "4", "5"), queryParams["list"])
+    }
+
+    @Test
+    fun `toQueryParams filtrerer vekk tomme lister`() {
+        val queryParams: LinkedMultiValueMap<String, String> = toQueryParams(Testdata(list = listOf()))
+
+        assertFalse { queryParams.containsKey("list") }
+    }
+
+    data class Testdata(
+        val int: Int = 5,
+        val string: String = "Fem",
+        val list: List<Int> = listOf(1, 2, 3, 4, 5)
+    )
+}


### PR DESCRIPTION
Flytter toQueryParams to integrasjoner då den brukes for oppgaverequest

Koblet til:
* https://github.com/navikt/familie-felles/pull/664
* https://github.com/navikt/familie-kontrakter/pull/684