### PR TITLE
Skal kunne sende med versjon til oppgave

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/OppgaveRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/OppgaveRestClient.kt
@@ -129,6 +129,16 @@ class OppgaveRestClient(
                 var feilmelding = "Feil ved oppdatering av oppgave for ${patchDto.id}."
                 if (it is HttpStatusCodeException) {
                     feilmelding += " Response fra oppgave = ${it.responseBodyAsString}"
+
+                    if(it.statusCode == HttpStatus.CONFLICT) {
+                        throw OppslagException(
+                            feilmelding,
+                            "Oppgave.oppdaterOppgave",
+                            OppslagException.Level.LAV,
+                            HttpStatus.CONFLICT,
+                            it,
+                        )
+                    }
                 }
 
                 throw OppslagException(

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
@@ -62,12 +62,13 @@ class OppgaveController(private val oppgaveService: OppgaveService) {
     fun fordelOppgave(
         @PathVariable(name = "oppgaveId") oppgaveId: Long,
         @RequestParam("saksbehandler") saksbehandler: String?,
+        @RequestParam("versjon") versjon: Int?,
     ): ResponseEntity<Ressurs<OppgaveResponse>> {
         Result.runCatching {
             if (saksbehandler == null) {
-                oppgaveService.tilbakestillFordelingPåOppgave(oppgaveId)
+                oppgaveService.tilbakestillFordelingPåOppgave(oppgaveId, versjon)
             } else {
-                oppgaveService.fordelOppgave(oppgaveId, saksbehandler)
+                oppgaveService.fordelOppgave(oppgaveId, saksbehandler, versjon)
             }
         }.fold(
             onSuccess = {
@@ -116,8 +117,11 @@ class OppgaveController(private val oppgaveService: OppgaveService) {
     }
 
     @PatchMapping(path = ["/{oppgaveId}/ferdigstill"])
-    fun ferdigstillOppgave(@PathVariable(name = "oppgaveId") oppgaveId: Long): ResponseEntity<Ressurs<OppgaveResponse>> {
-        oppgaveService.ferdigstill(oppgaveId)
+    fun ferdigstillOppgave(
+        @PathVariable(name = "oppgaveId") oppgaveId: Long,
+        @RequestParam(name = "versjon") versjon: Int?
+    ): ResponseEntity<Ressurs<OppgaveResponse>> {
+        oppgaveService.ferdigstill(oppgaveId, versjon)
         return ResponseEntity.ok(success(OppgaveResponse(oppgaveId = oppgaveId), "ferdigstill OK"))
     }
 
@@ -133,8 +137,11 @@ class OppgaveController(private val oppgaveService: OppgaveService) {
         @Parameter(description = "Settes til true hvis man ønsker å flytte en oppgave uten å ta med seg mappa opp på oppgaven. Noen mapper hører spesifikt til en enhet, og man får da ikke flyttet oppgaven uten at mappen fjernes ")
         @RequestParam(name = "fjernMappeFraOppgave")
         fjernMappeFraOppgave: Boolean,
+        @Parameter(description = "Settes dersom man ønsker å sjekke at oppgaven man har tilgjengelig er riktig versjon.")
+        @RequestParam(name = "versjon")
+        versjon: Int?,
     ): ResponseEntity<Ressurs<OppgaveResponse>> {
-        oppgaveService.tilordneEnhet(oppgaveId, enhet, fjernMappeFraOppgave)
+        oppgaveService.tilordneEnhet(oppgaveId, enhet, fjernMappeFraOppgave, versjon)
         return ResponseEntity.ok().body(success(OppgaveResponse(oppgaveId = oppgaveId), "Oppdatering av oppgave OK"))
     }
 }

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
@@ -137,7 +137,7 @@ class OppgaveController(private val oppgaveService: OppgaveService) {
         @Parameter(description = "Settes til true hvis man ønsker å flytte en oppgave uten å ta med seg mappa opp på oppgaven. Noen mapper hører spesifikt til en enhet, og man får da ikke flyttet oppgaven uten at mappen fjernes ")
         @RequestParam(name = "fjernMappeFraOppgave")
         fjernMappeFraOppgave: Boolean,
-        @Parameter(description = "Settes dersom man ønsker å sjekke at oppgaven man har tilgjengelig er riktig versjon.")
+        @Parameter(description = "Vil feile med 409 Conflict dersom versjonen ikke stemmer overens med oppgavesystemets versjon")
         @RequestParam(name = "versjon")
         versjon: Int?,
     ): ResponseEntity<Ressurs<OppgaveResponse>> {

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
@@ -169,6 +169,8 @@ class OppgaveService constructor(
     fun ferdigstill(oppgaveId: Long, versjon: Int?) {
         val oppgave = oppgaveRestClient.finnOppgaveMedId(oppgaveId)
 
+        validerVersjon(versjon, oppgave)
+
         when (oppgave.status) {
             StatusEnum.OPPRETTET, StatusEnum.AAPNET, StatusEnum.UNDER_BEHANDLING -> {
                 val patchOppgaveDto = oppgave.copy(
@@ -194,6 +196,21 @@ class OppgaveService constructor(
                 "Oppgave.ferdigstill",
                 Level.MEDIUM,
                 HttpStatus.BAD_REQUEST,
+            )
+        }
+    }
+
+    private fun validerVersjon(
+        versjon: Int?,
+        oppgave: Oppgave,
+    ) {
+        if (versjon != null && versjon != oppgave.versjon) {
+            throw OppslagException(
+                "Oppgave har har feil versjon og kan ikke ferdigstilles. " +
+                        "oppgaveId=${oppgave.id}",
+                "Oppgave.ferdigstill",
+                Level.LAV,
+                HttpStatus.CONFLICT,
             )
         }
     }


### PR DESCRIPTION
### Hvorfor er dette nødvendig?
Oppgavesystemet tar i mot versjon (Int) og validerer på denne før endringer på oppgaver gjøres. Når man skal oppdatere oppgaver via integrasjoner kommer man seg rundt dette ved å hente oppgave og sende med eksisterende versjon til oppgavesystemet. 

I ef-sak har vi behov for å kunne sende med versjon på oppgaven man har for å kunne sjekke at dette er den nyeste versjonen før man kan gjøre endringer på oppgaven. 

### Vil det påvirke oss?
Målet er at alle endringer skal være tilbakevirkende, og det er meningen at versjon skal være optional og kun tas hensyn med dersom man aktivt sender den inn. 