### PR TITLE
Skal håndtere feil ved fordeling av oppgave

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
@@ -64,28 +64,21 @@ class OppgaveController(private val oppgaveService: OppgaveService) {
         @RequestParam("saksbehandler") saksbehandler: String?,
         @RequestParam("versjon") versjon: Int?,
     ): ResponseEntity<Ressurs<OppgaveResponse>> {
-        Result.runCatching {
-            if (saksbehandler == null) {
-                oppgaveService.tilbakestillFordelingPåOppgave(oppgaveId, versjon)
-            } else {
-                oppgaveService.fordelOppgave(oppgaveId, saksbehandler, versjon)
-            }
-        }.fold(
-            onSuccess = {
-                return ResponseEntity.ok(
-                    success(
-                        OppgaveResponse(oppgaveId = oppgaveId),
-                        if (saksbehandler !== null) {
-                            "Oppgaven ble tildelt saksbehandler $saksbehandler"
-                        } else {
-                            "Fordeling på oppgaven ble tilbakestilt"
-                        },
-                    ),
-                )
-            },
-            onFailure = {
-                return ResponseEntity.badRequest().body(Ressurs.failure(errorMessage = it.message))
-            },
+        if (saksbehandler == null) {
+            oppgaveService.tilbakestillFordelingPåOppgave(oppgaveId, versjon)
+        } else {
+            oppgaveService.fordelOppgave(oppgaveId, saksbehandler, versjon)
+        }
+
+        return ResponseEntity.ok(
+            success(
+                OppgaveResponse(oppgaveId = oppgaveId),
+                if (saksbehandler !== null) {
+                    "Oppgaven ble tildelt saksbehandler $saksbehandler"
+                } else {
+                    "Fordeling på oppgaven ble tilbakestilt"
+                },
+            ),
         )
     }
 
@@ -119,7 +112,7 @@ class OppgaveController(private val oppgaveService: OppgaveService) {
     @PatchMapping(path = ["/{oppgaveId}/ferdigstill"])
     fun ferdigstillOppgave(
         @PathVariable(name = "oppgaveId") oppgaveId: Long,
-        @RequestParam(name = "versjon") versjon: Int?
+        @RequestParam(name = "versjon") versjon: Int?,
     ): ResponseEntity<Ressurs<OppgaveResponse>> {
         oppgaveService.ferdigstill(oppgaveId, versjon)
         return ResponseEntity.ok(success(OppgaveResponse(oppgaveId = oppgaveId), "ferdigstill OK"))

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
@@ -84,7 +84,12 @@ class OppgaveService constructor(
             val oppgave = oppgaveRestClient.finnOppgaveMedId(oppgaveId)
 
             if (oppgave.status === StatusEnum.FERDIGSTILT) {
-                error("Kan ikke fordele oppgave med id $oppgaveId som allerede er ferdigstilt")
+                throw OppslagException(
+                    "Kan ikke fordele oppgave med id $oppgaveId som allerede er ferdigstilt",
+                    "Oppgave.fordel",
+                    Level.LAV,
+                    HttpStatus.BAD_REQUEST,
+                )
             }
             val oppdatertOppgaveDto = oppgave.copy(
                 id = oppgave.id,
@@ -103,7 +108,12 @@ class OppgaveService constructor(
             val oppgave = oppgaveRestClient.finnOppgaveMedId(oppgaveId)
 
             if (oppgave.status === StatusEnum.FERDIGSTILT) {
-                error("Kan ikke tilbakestille fordeling på oppgave med id $oppgaveId som allerede er ferdigstilt")
+                throw OppslagException(
+                    "Kan ikke tilbakestille fordeling på oppgave med id $oppgaveId som allerede er ferdigstilt",
+                    "Oppgave.tilbakestill",
+                    Level.LAV,
+                    HttpStatus.BAD_REQUEST,
+                )
             }
 
             val oppdatertOppgaveDto = oppgave.copy(
@@ -207,7 +217,7 @@ class OppgaveService constructor(
         if (versjon != null && versjon != oppgave.versjon) {
             throw OppslagException(
                 "Oppgave har har feil versjon og kan ikke ferdigstilles. " +
-                        "oppgaveId=${oppgave.id}",
+                    "oppgaveId=${oppgave.id}",
                 "Oppgave.ferdigstill",
                 Level.LAV,
                 HttpStatus.CONFLICT,


### PR DESCRIPTION
Dersom oppgave-api returnerer 409 skal denne feiltypen returneres istedenfor 400 BAD REQUEST