### PR TITLE
Org i preprod må bruke q1 for å få gyldig tss identer

### DIFF
--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -113,7 +113,7 @@ DOKARKIV_SCOPE: api://dev-fss.teamdokumenthandtering.dokarkiv/.default
 PDL_SCOPE: api://dev-fss.pdl.pdl-api/.default
 
 AAD_GRAPH_API_URI: https://graph.microsoft.com/v1.0/
-ORGANISASJON_URL: https://ereg-services.dev.intern.nav.no
+ORGANISASJON_URL: https://ereg-services-q1.dev.intern.nav.no
 DOKARKIV_V1_URL: https://dokarkiv-q2.dev.intern.nav.no
 MEDL2_URL: https://medlemskap-medl-api.dev.intern.nav.no
 SAF_URL: https://saf-q2.dev.intern.nav.no


### PR DESCRIPTION
Vi i ba er avhengig at org går mot q1, siden TSS kun er med q1 data