### PR TITLE
Oppdater beskrivelse på oppgave ved fordeling og tilbakestilling

### DIFF
--- a/app-preprod.teamfamilie.q1.yaml
+++ b/app-preprod.teamfamilie.q1.yaml
@@ -40,6 +40,8 @@ spec:
           - id: "01166863-22f1-4e16-9785-d7a05a22df74"  # 0000-GA-Enslig-Forsorger-Beslutter
           - id: "ee5e0b5e-454c-4612-b931-1fe363df7c2c"  # 0000-GA-Enslig-Forsorger-Saksbehandler
           - id: "19dcbfde-4cdb-4c64-a1ea-ac9802b03339"  # 0000-GA-Enslig-Forsorger-Veileder
+        extra:
+          - "NAVident"
   accessPolicy:
     inbound:
       rules:

--- a/app-preprod.teamfamilie.yaml
+++ b/app-preprod.teamfamilie.yaml
@@ -40,6 +40,8 @@ spec:
           - id: "01166863-22f1-4e16-9785-d7a05a22df74"  # 0000-GA-Enslig-Forsorger-Beslutter
           - id: "ee5e0b5e-454c-4612-b931-1fe363df7c2c"  # 0000-GA-Enslig-Forsorger-Saksbehandler
           - id: "19dcbfde-4cdb-4c64-a1ea-ac9802b03339"  # 0000-GA-Enslig-Forsorger-Veileder
+        extra:
+          - "NAVident"
   accessPolicy:
     inbound:
       rules:

--- a/app-prod.teamfamilie.yaml
+++ b/app-prod.teamfamilie.yaml
@@ -45,6 +45,9 @@ spec:
           - id: "5fcc0e1d-a4c2-49f0-93dc-27c9fea41e54"  # 0000-GA-Enslig-Forsorger-Beslutter
           - id: "e40090eb-c2fb-400e-b412-e9084019a73b"  # 0000-GA-Kontantstotte
           - id: "54cd86b8-2e23-48b2-8852-b05b5827bb0f"  # 0000-GA-Kontantstotte-Veileder
+        extra:
+          - "NAVident"
+
   accessPolicy:
     inbound:
       rules:

--- a/src/main/java/no/nav/familie/integrasjoner/felles/DatoFormat.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/felles/DatoFormat.kt
@@ -1,0 +1,6 @@
+import java.time.format.DateTimeFormatter
+
+object DatoFormat {
+
+    val GOSYS_DATE_TIME = DateTimeFormatter.ofPattern("yyyy.MM.dd' 'HH:mm")
+}

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
@@ -146,7 +146,7 @@ class OppgaveService constructor(
         val formatertDato = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy.MM.dd' 'HH:mm"))
 
         val prefix = "--- $formatertDato $saksbehandlerNavn ($innloggetSaksbehandlerIdent) ---\n"
-        val endring = """Oppgave er flyttet fra ${oppgave.tilordnetRessurs ?: "<ingen>"} til ${nySaksbehandlerIdent ?: "<ingen>"}"""
+        val endring = "Oppgave er flyttet fra ${oppgave.tilordnetRessurs ?: "<ingen>"} til ${nySaksbehandlerIdent ?: "<ingen>"}"
 
         val nåværendeBeskrivelse = if (oppgave.beskrivelse != null) {
             "\n\n${oppgave.beskrivelse}"

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
@@ -136,7 +136,6 @@ class OppgaveService constructor(
         )
         oppgaveRestClient.oppdaterOppgave(oppdatertOppgaveDto)
 
-
         return oppgaveId
     }
 
@@ -146,11 +145,8 @@ class OppgaveService constructor(
             LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME)
         } ${SikkerhetsContext.hentSaksbehandlerNavn(strict = true)} ($innloggetSaksbehandler) ---"
 
-        val endring = if (oppgave.tilordnetRessurs == null) {
-            "Oppgave plukket av ${oppgave.tilordnetRessurs}"
-        } else {
-            "Oppgave er flyttet fra ${oppgave.tilordnetRessurs} til ${nySaksbehandlerIdent ?: "<ingen>"}"
-        }
+        val endring =
+            "Oppgave er flyttet fra ${oppgave.tilordnetRessurs ?: "<ingen>"} til ${nySaksbehandlerIdent ?: "<ingen>"}"
 
         val nåværendeBeskrivelse = oppgave.beskrivelse ?: ""
 

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
@@ -148,9 +148,13 @@ class OppgaveService constructor(
         val endring =
             "Oppgave er flyttet fra ${oppgave.tilordnetRessurs ?: "<ingen>"} til ${nySaksbehandlerIdent ?: "<ingen>"}"
 
-        val nåværendeBeskrivelse = oppgave.beskrivelse ?: ""
+        val nåværendeBeskrivelse = if (oppgave.beskrivelse != null) {
+            "\n\n${oppgave.beskrivelse}"
+        } else {
+            ""
+        }
 
-        return "$prefix \n $endring \n $nåværendeBeskrivelse"
+        return "$prefix \n $endring $nåværendeBeskrivelse"
     }
 
     @Deprecated("Bruk opprettOppgave")

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
@@ -100,7 +100,7 @@ class OppgaveService constructor(
             id = oppgave.id,
             versjon = versjon ?: oppgave.versjon,
             tilordnetRessurs = nySaksbehandlerIdent,
-            beskrivelse = lagOppgaveBeskrivelseFordeling(oppgave = oppgave, nySaksbehandlerIdent = nySaksbehandlerIdent)
+            beskrivelse = lagOppgaveBeskrivelseFordeling(oppgave = oppgave, nySaksbehandlerIdent = nySaksbehandlerIdent),
         )
         oppgaveRestClient.oppdaterOppgave(oppdatertOppgaveDto)
 
@@ -132,7 +132,7 @@ class OppgaveService constructor(
             id = oppgave.id,
             versjon = versjon ?: oppgave.versjon,
             tilordnetRessurs = "",
-            beskrivelse = lagOppgaveBeskrivelseFordeling(oppgave = oppgave)
+            beskrivelse = lagOppgaveBeskrivelseFordeling(oppgave = oppgave),
         )
         oppgaveRestClient.oppdaterOppgave(oppdatertOppgaveDto)
 
@@ -140,13 +140,13 @@ class OppgaveService constructor(
     }
 
     private fun lagOppgaveBeskrivelseFordeling(oppgave: Oppgave, nySaksbehandlerIdent: String? = null): String {
-        val innloggetSaksbehandler = SikkerhetsContext.hentSaksbehandler()
-        val prefix = "--- ${
-            LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME)
-        } ${SikkerhetsContext.hentSaksbehandlerNavn(strict = true)} ($innloggetSaksbehandler) ---"
+        val innloggetSaksbehandlerIdent = SikkerhetsContext.hentSaksbehandler()
+        val saksbehandlerNavn = SikkerhetsContext.hentSaksbehandlerNavn(strict = true)
 
-        val endring =
-            "Oppgave er flyttet fra ${oppgave.tilordnetRessurs ?: "<ingen>"} til ${nySaksbehandlerIdent ?: "<ingen>"}"
+        val formatertDato = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy.MM.dd' 'HH:mm"))
+
+        val prefix = "--- $formatertDato $saksbehandlerNavn ($innloggetSaksbehandlerIdent) ---\n"
+        val endring = """Oppgave er flyttet fra ${oppgave.tilordnetRessurs ?: "<ingen>"} til ${nySaksbehandlerIdent ?: "<ingen>"}"""
 
         val nåværendeBeskrivelse = if (oppgave.beskrivelse != null) {
             "\n\n${oppgave.beskrivelse}"
@@ -154,7 +154,8 @@ class OppgaveService constructor(
             ""
         }
 
-        return "$prefix \n $endring $nåværendeBeskrivelse"
+        return prefix + endring + nåværendeBeskrivelse
+
     }
 
     @Deprecated("Bruk opprettOppgave")

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
@@ -155,7 +155,6 @@ class OppgaveService constructor(
         }
 
         return prefix + endring + nåværendeBeskrivelse
-
     }
 
     @Deprecated("Bruk opprettOppgave")
@@ -225,7 +224,7 @@ class OppgaveService constructor(
             StatusEnum.FERDIGSTILT -> logger.info("Oppgave er allerede ferdigstilt. oppgaveId=$oppgaveId")
             StatusEnum.FEILREGISTRERT -> throw OppslagException(
                 "Oppgave har status feilregistrert og kan ikke oppdateres. " +
-                        "oppgaveId=$oppgaveId",
+                    "oppgaveId=$oppgaveId",
                 "Oppgave.ferdigstill",
                 Level.MEDIUM,
                 HttpStatus.BAD_REQUEST,
@@ -233,7 +232,7 @@ class OppgaveService constructor(
 
             null -> throw OppslagException(
                 "Oppgave har ingen status og kan ikke oppdateres. " +
-                        "oppgaveId=$oppgaveId",
+                    "oppgaveId=$oppgaveId",
                 "Oppgave.ferdigstill",
                 Level.MEDIUM,
                 HttpStatus.BAD_REQUEST,
@@ -248,7 +247,7 @@ class OppgaveService constructor(
         if (versjon != null && versjon != oppgave.versjon) {
             throw OppslagException(
                 "Oppgave har har feil versjon og kan ikke ferdigstilles. " +
-                        "oppgaveId=${oppgave.id}",
+                    "oppgaveId=${oppgave.id}",
                 "Oppgave.ferdigstill",
                 Level.LAV,
                 HttpStatus.CONFLICT,
@@ -272,7 +271,7 @@ class OppgaveService constructor(
         if (mappeRespons.antallTreffTotalt > mappeRespons.mapper.size) {
             logger.error(
                 "Det finnes flere mapper (${mappeRespons.antallTreffTotalt}) " +
-                        "enn vi har hentet ut (${mappeRespons.mapper.size}). Sjekk limit. ",
+                    "enn vi har hentet ut (${mappeRespons.mapper.size}). Sjekk limit. ",
             )
         }
         return mappeRespons.mapperUtenTema()

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
@@ -139,8 +139,8 @@ class OppgaveService constructor(
     }
 
     private fun lagOppgaveBeskrivelseFordeling(oppgave: Oppgave, nySaksbehandlerIdent: String? = null): String {
-        val innloggetSaksbehandlerIdent = SikkerhetsContext.hentSaksbehandler()
-        val saksbehandlerNavn = SikkerhetsContext.hentSaksbehandlerNavn(strict = true)
+        val innloggetSaksbehandlerIdent = SikkerhetsContext.hentSaksbehandlerEllerSystembruker()
+        val saksbehandlerNavn = SikkerhetsContext.hentSaksbehandlerNavn(strict = false)
 
         val formatertDato = LocalDateTime.now().format(DatoFormat.GOSYS_DATE_TIME)
 

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.integrasjoner.oppgave
 
+import DatoFormat
 import com.fasterxml.jackson.annotation.JsonInclude
 import no.nav.familie.integrasjoner.aktør.AktørService
 import no.nav.familie.integrasjoner.client.rest.OppgaveRestClient
@@ -141,7 +142,7 @@ class OppgaveService constructor(
         val innloggetSaksbehandlerIdent = SikkerhetsContext.hentSaksbehandler()
         val saksbehandlerNavn = SikkerhetsContext.hentSaksbehandlerNavn(strict = true)
 
-        val formatertDato = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy.MM.dd' 'HH:mm"))
+        val formatertDato = LocalDateTime.now().format(DatoFormat.GOSYS_DATE_TIME)
 
         val prefix = "--- $formatertDato $saksbehandlerNavn ($innloggetSaksbehandlerIdent) ---\n"
         val endring = "Oppgave er flyttet fra ${oppgave.tilordnetRessurs ?: "<ingen>"} til ${nySaksbehandlerIdent ?: "<ingen>"}"

--- a/src/main/java/no/nav/familie/integrasjoner/sikkerhet/SikkerhetsContext.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/sikkerhet/SikkerhetsContext.kt
@@ -1,0 +1,38 @@
+package no.nav.familie.integrasjoner.sikkerhet
+
+import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
+
+object SikkerhetsContext {
+
+    private const val SYSTEM_NAVN = "System"
+    const val SYSTEM_FORKORTELSE = "VL"
+
+    fun hentSaksbehandler(): String {
+        val result = hentSaksbehandlerEllerSystembruker()
+
+        if (result == SYSTEM_FORKORTELSE) {
+            error("Finner ikke NAVident i token")
+        }
+        return result
+    }
+
+    fun hentSaksbehandlerEllerSystembruker() =
+        Result.runCatching { SpringTokenValidationContextHolder().tokenValidationContext }
+            .fold(
+                onSuccess = {
+                    it.getClaims("azuread")?.get("NAVident")?.toString() ?: SYSTEM_FORKORTELSE
+                },
+                onFailure = { SYSTEM_FORKORTELSE }
+            )
+
+    fun hentSaksbehandlerNavn(strict: Boolean = false): String {
+        return Result.runCatching { SpringTokenValidationContextHolder().tokenValidationContext }
+            .fold(
+                onSuccess = {
+                    it.getClaims("azuread")?.get("name")?.toString()
+                        ?: if (strict) error("Finner ikke navn i azuread token") else SYSTEM_NAVN
+                },
+                onFailure = { if (strict) error("Finner ikke navn på innlogget bruker") else SYSTEM_NAVN }
+            )
+    }
+}

--- a/src/test/java/no/nav/familie/integrasjoner/OppslagSpringRunnerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/OppslagSpringRunnerTest.kt
@@ -67,17 +67,24 @@ abstract class OppslagSpringRunnerTest {
             return lagToken()
         }
 
-    fun lagToken(subject: String = "subject"): String {
+    fun lagToken(saksbehandler: String = "testbruker", ): String {
         val clientId = UUID.randomUUID().toString()
+        val brukerId  = UUID.randomUUID().toString()
         val issuerId = "azuread"
         return mockOAuth2Server.issueToken(
             issuerId = issuerId,
             clientId = clientId,
             DefaultOAuth2TokenCallback(
                 issuerId = issuerId,
-                subject = subject,
+                subject = brukerId,
                 audience = listOf("aud-localhost"),
-                claims = emptyMap(),
+                claims = mapOf(
+                    "oid" to brukerId,
+                    "azp" to clientId,
+                    "name" to saksbehandler,
+                    "NAVident" to saksbehandler,
+                    "groups" to emptyList<String>()
+                ),
                 expiry = 3600,
             ),
         ).serialize()

--- a/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveControllerTest.kt
@@ -638,11 +638,9 @@ class OppgaveControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `Skal returnere 409 dersom man oppdaterer oppgave med feil versjon`() {
+        stubFor(get("/api/v1/oppgaver/$OPPGAVE_ID").willReturn(okJson(gyldigOppgaveResponse("hentOppgave.json"))))
         stubFor(
             patch(urlEqualTo("/api/v1/oppgaver/$OPPGAVE_ID"))
-                .withRequestBody(
-                    WireMock.equalToJson("""{"id":315488374, "tilordnetRessurs": "test123" ,"versjon":1}"""),
-                )
                 .willReturn(
                     aResponse()
                         .withStatus(409)

--- a/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveControllerTest.kt
@@ -181,7 +181,7 @@ class OppgaveControllerTest : OppslagSpringRunnerTest() {
             .anyMatch {
                 it.contains(
                     "[oppgave][Ingen oppgaver funnet for http://localhost:28085/api/v1/oppgaver" +
-                            "?aktoerId=1234567891011&tema=KON&oppgavetype=BEH_SAK&journalpostId=1&statuskategori=AAPEN]",
+                        "?aktoerId=1234567891011&tema=KON&oppgavetype=BEH_SAK&journalpostId=1&statuskategori=AAPEN]",
                 )
             }
         assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
@@ -208,7 +208,7 @@ class OppgaveControllerTest : OppslagSpringRunnerTest() {
             .anyMatch {
                 it.contains(
                     "Ignorerer oppdatering av oppgave som er ferdigstilt for aktørId=1234567891011 " +
-                            "journalpostId=123456789 oppgaveId=$OPPGAVE_ID",
+                        "journalpostId=123456789 oppgaveId=$OPPGAVE_ID",
                 )
             }
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)

--- a/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveControllerTest.kt
@@ -181,7 +181,7 @@ class OppgaveControllerTest : OppslagSpringRunnerTest() {
             .anyMatch {
                 it.contains(
                     "[oppgave][Ingen oppgaver funnet for http://localhost:28085/api/v1/oppgaver" +
-                        "?aktoerId=1234567891011&tema=KON&oppgavetype=BEH_SAK&journalpostId=1&statuskategori=AAPEN]",
+                            "?aktoerId=1234567891011&tema=KON&oppgavetype=BEH_SAK&journalpostId=1&statuskategori=AAPEN]",
                 )
             }
         assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
@@ -208,7 +208,7 @@ class OppgaveControllerTest : OppslagSpringRunnerTest() {
             .anyMatch {
                 it.contains(
                     "Ignorerer oppdatering av oppgave som er ferdigstilt for aktørId=1234567891011 " +
-                        "journalpostId=123456789 oppgaveId=$OPPGAVE_ID",
+                            "journalpostId=123456789 oppgaveId=$OPPGAVE_ID",
                 )
             }
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)


### PR DESCRIPTION
Når man tildeler eller fristiller en oppgave skal oppgavebeskrivelsen oppdateres med endringen.

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-11462

Basert på tekstene funnet i gosys skal tekstene bli slik: 

Første linje `--- dato tid fornavn etternavn (navident) ---`
Andre linje varierer avhengig av tidligere status og mål: 

- Oppgave plukket første gang: `Oppgave flyttet fra <ingen> til navIdent`
- Oppgave overtatt: `Oppgave flyttet fra navIdent1 til navIdent2`
- Oppgave tilbakestilt: `Oppgave flyttet fra navIdent1 til <ingen>`

Enhet er ikke med slik som i gosys.

**Oppgavebenk EF**
![Skjermbilde 2023-02-21 kl  16 14 08](https://user-images.githubusercontent.com/21220467/220384083-c306d95b-ac60-44c0-b220-3a4ef9675a29.png)

**Gosys** (med ett innslag ekstra)
![Skjermbilde 2023-02-21 kl  16 16 37](https://user-images.githubusercontent.com/21220467/220384669-41ef84dc-4ceb-4979-85d3-45d86b49f744.png)
