### PR TITLE
Skal sjekke om en persons ektefelle eller tidligere ektefelle også er…

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollService.kt
@@ -61,6 +61,7 @@ class CachedTilgangskontrollService(
             FORTROLIG -> hentTilgangForRolle(tilgangConfig.grupper["kode7"], jwtToken, personIdent)
             STRENGT_FORTROLIG, STRENGT_FORTROLIG_UTLAND ->
                 hentTilgangForRolle(tilgangConfig.grupper["kode6"], jwtToken, personIdent)
+
             else -> Tilgang(harTilgang = true)
         }
         if (!tilgang.harTilgang) {
@@ -76,7 +77,10 @@ class CachedTilgangskontrollService(
      * Trenger kun å sjekke personen og barnets andre foreldrer for om de er ansatt
      */
     private fun erEgenAnsatt(personMedRelasjoner: PersonMedRelasjoner): Boolean {
-        val relevanteIdenter = setOf(personMedRelasjoner.personIdent) + personMedRelasjoner.barnsForeldrer.map { it.personIdent }
+        val relevanteIdenter = setOf(personMedRelasjoner.personIdent) +
+            personMedRelasjoner.sivilstand.map { it.personIdent } +
+            personMedRelasjoner.barnsForeldrer.map { it.personIdent }
+
         return egenAnsattService.erEgenAnsatt(relevanteIdenter).any { it.value }
     }
 

--- a/src/test/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollServiceTest.kt
@@ -139,6 +139,16 @@ internal class CachedTilgangskontrollServiceTest {
         assertThat(sjekkTilgangTilPersonMedRelasjoner()).isFalse
     }
 
+    @Test
+    internal fun `har ikke tilgang når sivilstand er egenansatt`() {
+        every { personopplysningerService.hentPersonMedRelasjoner(any(), Tema.ENF) } returns
+            lagPersonMedRelasjoner(sivilstand = ADRESSEBESKYTTELSEGRADERING.UGRADERT)
+        every { egenAnsattService.erEgenAnsatt(any<Set<String>>()) } answers {
+            firstArg<Set<String>>().associateWith { it == "sivilstand" }
+        }
+        assertThat(sjekkTilgangTilPersonMedRelasjoner()).isFalse
+    }
+
     private fun sjekkTilgangTilPersonMedRelasjoner() =
         cachedTilgangskontrollService.sjekkTilgangTilPersonMedRelasjoner("", jwtToken, Tema.ENF).harTilgang
 


### PR DESCRIPTION
… egenansatt i tilgangskontrollen. Hvis ikke vil dette fanges opp ved uthenting av personopplysninger og feile med en dårlig feilmelding til brukeren