### PR TITLE
Endepunkt for å fjerne behandlesAvApplikasjon på en oppgave

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/medlemskap/MedlemskapController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/medlemskap/MedlemskapController.kt
@@ -16,7 +16,7 @@ class MedlemskapController(private val medlemskapService: MedlemskapService) {
 
     @PostMapping("v3")
     fun hentMedlemskapsunntakForIdentEllerAktørIdV3(
-        @RequestBody(required = true) personIdent: PersonIdent
+        @RequestBody(required = true) personIdent: PersonIdent,
     ): Ressurs<Medlemskapsinfo> {
         return Ressurs.success(medlemskapService.hentMedlemskapsunntak(personIdent.ident))
     }

--- a/src/main/java/no/nav/familie/integrasjoner/medlemskap/MedlemskapService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/medlemskap/MedlemskapService.kt
@@ -20,7 +20,7 @@ class MedlemskapService(private val medlRestClient: MedlRestClient) {
                 OppslagException.Level.MEDIUM,
                 HttpStatus.INTERNAL_SERVER_ERROR,
                 e,
-                "Feil ved oppslag av medlemskap ident=$ident"
+                "Feil ved oppslag av medlemskap ident=$ident",
             )
         }
     }

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
@@ -129,7 +129,7 @@ class OppgaveController(private val oppgaveService: OppgaveService) {
         return ResponseEntity.ok().body(success(OppgaveResponse(oppgaveId = oppgaveId), "Oppdatering av oppgave OK"))
     }
 
-    @PatchMapping(path = ["/{oppgaveId}/fjernBehandlesAvApplikasjon"])
+    @PatchMapping(path = ["/{oppgaveId}/fjern-behandles-av-applikasjon"])
     fun fjernBehandlesAvApplikasjon(
         @PathVariable(name = "oppgaveId") oppgaveId: Long,
         @RequestParam(name = "versjon") versjon: Int,

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
@@ -128,4 +128,13 @@ class OppgaveController(private val oppgaveService: OppgaveService) {
         oppgaveService.tilordneEnhet(oppgaveId, enhet, fjernMappeFraOppgave, versjon)
         return ResponseEntity.ok().body(success(OppgaveResponse(oppgaveId = oppgaveId), "Oppdatering av oppgave OK"))
     }
+
+    @PatchMapping(path = ["/{oppgaveId}/fjernBehandlesAvApplikasjon"])
+    fun fjernBehandlesAvApplikasjon(
+        @PathVariable(name = "oppgaveId") oppgaveId: Long,
+        @RequestParam(name = "versjon") versjon: Int,
+    ): ResponseEntity<Ressurs<OppgaveResponse>> {
+        oppgaveService.fjernBehandlesAvApplikasjon(oppgaveId, versjon)
+        return ResponseEntity.ok(success(OppgaveResponse(oppgaveId = oppgaveId), "ferdigstill OK"))
+    }
 }

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
@@ -259,6 +259,10 @@ class OppgaveService constructor(
         val mappeId = if (fjernMappeFraOppgave) null else oppgave.mappeId
         oppgaveRestClient.oppdaterEnhet(OppgaveByttEnhet(oppgaveId, enhet, versjon ?: oppgave.versjon!!, mappeId))
     }
+
+    fun fjernBehandlesAvApplikasjon(oppgaveId: Long, versjon: Int) {
+        oppgaveRestClient.fjernBehandlesAvApplikasjon(OppgaveFjernBehandlesAvApplikasjon(oppgaveId, versjon))
+    }
 }
 
 data class OppgaveByttEnhet(
@@ -266,6 +270,12 @@ data class OppgaveByttEnhet(
     val tildeltEnhetsnr: String,
     val versjon: Int,
     @JsonInclude(JsonInclude.Include.ALWAYS) val mappeId: Long? = null,
+)
+
+data class OppgaveFjernBehandlesAvApplikasjon(
+    val id: Long,
+    val versjon: Int,
+    @JsonInclude(JsonInclude.Include.ALWAYS) val behandlesAvApplikasjon: Long? = null,
 )
 
 /**

--- a/src/main/java/no/nav/familie/integrasjoner/sikkerhet/SikkerhetsContext.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/sikkerhet/SikkerhetsContext.kt
@@ -22,7 +22,7 @@ object SikkerhetsContext {
                 onSuccess = {
                     it.getClaims("azuread")?.get("NAVident")?.toString() ?: SYSTEM_FORKORTELSE
                 },
-                onFailure = { SYSTEM_FORKORTELSE }
+                onFailure = { SYSTEM_FORKORTELSE },
             )
 
     fun hentSaksbehandlerNavn(strict: Boolean = false): String {
@@ -32,7 +32,7 @@ object SikkerhetsContext {
                     it.getClaims("azuread")?.get("name")?.toString()
                         ?: if (strict) error("Finner ikke navn i azuread token") else SYSTEM_NAVN
                 },
-                onFailure = { if (strict) error("Finner ikke navn på innlogget bruker") else SYSTEM_NAVN }
+                onFailure = { if (strict) error("Finner ikke navn på innlogget bruker") else SYSTEM_NAVN },
             )
     }
 }

--- a/src/test/java/no/nav/familie/integrasjoner/OppslagSpringRunnerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/OppslagSpringRunnerTest.kt
@@ -67,9 +67,9 @@ abstract class OppslagSpringRunnerTest {
             return lagToken()
         }
 
-    fun lagToken(saksbehandler: String = "testbruker", ): String {
+    fun lagToken(saksbehandler: String = "testbruker"): String {
         val clientId = UUID.randomUUID().toString()
-        val brukerId  = UUID.randomUUID().toString()
+        val brukerId = UUID.randomUUID().toString()
         val issuerId = "azuread"
         return mockOAuth2Server.issueToken(
             issuerId = issuerId,
@@ -83,7 +83,7 @@ abstract class OppslagSpringRunnerTest {
                     "azp" to clientId,
                     "name" to saksbehandler,
                     "NAVident" to saksbehandler,
-                    "groups" to emptyList<String>()
+                    "groups" to emptyList<String>(),
                 ),
                 expiry = 3600,
             ),

--- a/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveControllerTest.kt
@@ -664,7 +664,7 @@ class OppgaveControllerTest : OppslagSpringRunnerTest() {
 
         val response: ResponseEntity<Ressurs<OppgaveResponse>> =
             restTemplate.exchange(
-                localhost("$OPPGAVE_URL/$OPPGAVE_ID/fjernBehandlesAvApplikasjon?versjon=1"),
+                localhost("$OPPGAVE_URL/$OPPGAVE_ID/fjern-behandles-av-applikasjon?versjon=1"),
                 HttpMethod.PATCH,
                 HttpEntity(oppgave, headers),
             )
@@ -698,7 +698,7 @@ class OppgaveControllerTest : OppslagSpringRunnerTest() {
 
         val response: ResponseEntity<Ressurs<OppgaveResponse>> =
             restTemplate.exchange(
-                localhost("$OPPGAVE_URL/$OPPGAVE_ID/fjernBehandlesAvApplikasjon?versjon=1"),
+                localhost("$OPPGAVE_URL/$OPPGAVE_ID/fjern-behandles-av-applikasjon?versjon=1"),
                 HttpMethod.PATCH,
                 HttpEntity(oppgave, headers),
             )


### PR DESCRIPTION
En del av:
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12200

mulighet til å slette behandlesAvApplikasjon på en oppgave, slik at saksbehandler kan lukke oppgaven fra gosys etter at man har teknisk henlagt den åpne behandlingen