### PR TITLE
Legger til behandlingsnummer mot PDL då de ønsker mer fingranulert in…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,9 +21,9 @@
         <changelist>-SNAPSHOT</changelist>
         <java.version>17</java.version>
         <springdoc.version>2.1.0</springdoc.version>
-        <felles.version>2.20230210162649_a258d57-SPRING_BOOT_3</felles.version>
-        <kontrakt.version>3.0_20230404163639_edb8619-JAKARTA</kontrakt.version>
-        <token-validation-spring.version>3.0.10</token-validation-spring.version>
+        <felles.version>2.20230508082643_6b28bd8</felles.version>
+        <kontrakt.version>3.0_20230509152247_36d24db</kontrakt.version>
+        <token-validation-spring.version>3.0.12</token-validation-spring.version>
         <kotlin.version>1.8.20</kotlin.version>
 
         <mock-server.version>5.15.0</mock-server.version>

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/PdlClientCredentialRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/PdlClientCredentialRestClient.kt
@@ -54,6 +54,10 @@ class PdlClientCredentialRestClient(
             secureLogger.error("Feil ved henting av ${T::class} fra PDL: $feil")
             throw PdlRequestException("Feil ved henting av ${T::class} fra PDL. Se secure logg for detaljer.")
         }
+        if (pdlResponse.harAdvarsel()) {
+            log.warn("Advarsel ved henting av ${T::class} fra PDL. Se securelogs for detaljer.")
+            secureLogger.warn("Advarsel ved henting av ${T::class} fra PDL: ${pdlResponse.extensions?.warnings}")
+        }
         return pdlResponse.data.personBolk.associateBy({ it.ident }, { it.person!! })
     }
 

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/PdlRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/PdlRestClient.kt
@@ -141,6 +141,10 @@ class PdlRestClient(
                 personIdent = personIdent,
             )
         }
+        if (pdlResponse.harAdvarsel()) {
+            log.warn("Advarsel ved henting av ${DATA::class} fra PDL. Se securelogs for detaljer.")
+            secureLogger.warn("Advarsel ved henting av ${DATA::class} fra PDL: ${pdlResponse.extensions?.warnings}")
+        }
         val data = dataMapper.invoke(pdlResponse.data)
             ?: throw pdlOppslagException(
                 feilmelding = "Feil ved oppslag på person. Objekt mangler på responsen fra PDL. Se secureLogs for mer info.",
@@ -228,7 +232,6 @@ class PdlRestClient(
         private val HENT_IDENTER_QUERY = hentPdlGraphqlQuery("hentIdenter")
         private val HENT_GEOGRAFISK_TILKNYTNING_QUERY = graphqlQuery("/pdl/geografisk_tilknytning.graphql")
         private val HENT_ADRESSEBESKYTTELSE_QUERY = graphqlQuery("/pdl/adressebeskyttelse.graphql")
-        private val HENT_PERSON_RELASJONER_ADRESSEBESKYTTELSE = hentPdlGraphqlQuery("hentpersoner-relasjoner-adressebeskyttelse")
     }
 }
 
@@ -246,5 +249,6 @@ fun pdlHttpHeaders(tema: Tema): HttpHeaders {
         contentType = MediaType.APPLICATION_JSON
         accept = listOf(MediaType.APPLICATION_JSON)
         add("Tema", tema.name)
+        add("behandlingsnummer", tema.behandlingsnummer)
     }
 }

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlResponse.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlResponse.kt
@@ -7,10 +7,15 @@ import no.nav.familie.kontrakter.felles.personopplysning.SIVILSTAND
 data class PdlResponse<T>(
     val data: T,
     val errors: List<PdlError>?,
+    val extensions: PdlExtensions?,
 ) {
 
     fun harFeil(): Boolean {
         return errors != null && errors.isNotEmpty()
+    }
+
+    fun harAdvarsel(): Boolean {
+        return !extensions?.warnings.isNullOrEmpty()
     }
 
     fun errorMessages(): String {
@@ -28,10 +33,18 @@ data class PdlResponse<T>(
 
 data class PersonDataBolk<T>(val ident: String, val code: String, val person: T?)
 data class PersonBolk<T>(val personBolk: List<PersonDataBolk<T>>)
-data class PdlBolkResponse<T>(val data: PersonBolk<T>?, val errors: List<PdlError>?) {
+data class PdlBolkResponse<T>(
+    val data: PersonBolk<T>?,
+    val errors: List<PdlError>?,
+    val extensions: PdlExtensions?,
+) {
 
     fun errorMessages(): String {
         return errors?.joinToString { it -> it.message } ?: ""
+    }
+
+    fun harAdvarsel(): Boolean {
+        return !extensions?.warnings.isNullOrEmpty()
     }
 }
 
@@ -67,15 +80,19 @@ data class PdlFødselsDato(val foedselsdato: String?)
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class PdlError(
     val message: String,
-    val extensions: PdlExtensions?,
+    val extensions: PdlErrorExtensions?,
 )
 
-data class PdlExtensions(val code: String?) {
+data class PdlErrorExtensions(val code: String?) {
 
     fun notFound() = code == "not_found"
 
     fun unauthorized() = code == "unauthorized"
 }
+
+data class PdlExtensions(val warnings: List<PdlWarning>?)
+
+data class PdlWarning(val details: Any?, val id: String?, val message: String?, val query: String?)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class PdlNavn(


### PR DESCRIPTION
…formasjon om hvem det er som spør, og kan då gi varsel på om man ikke har hjemmel til gitt opplysning


https://github.com/navikt/familie-ba-sak/pull/3582

Kopiert inn fra PR i BA
Favrokort: [NAV-12403](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12403)

Dersom man henter ut noe fra pdl sendes det med en warning i extensions-objektet i responsen fordi behandlingsnummer ikke blir sendt med i header. Denne PR'en legger til denne headeren. Dette nummeret er knyttet opp mot [behandlingskatalogen](https://behandlingskatalog.nais.adeo.no/process/purpose/BARNETRYGD/9f5fa38c-c6d3-415f-967e-9f961ab8413d). Da får man også en warning dersom man mangler noen opplysningstyper i behandlingskatalogen.

Det er også lagt til at vi logger dersom man får denne warningen.

Til info: opplysningstypene som manglet for barnetrygd er nå lagt til i behandlingskatalogen også.