### PR TITLE
Fjerner CPU-limit

### DIFF
--- a/app-preprod.teamfamilie.q1.yaml
+++ b/app-preprod.teamfamilie.q1.yaml
@@ -74,11 +74,9 @@ spec:
   replicas:
     min: 2
     max: 2
-    cpuThresholdPercentage: 50
   resources:
     limits:
       memory: 2Gi
-      cpu: 1500m
     requests:
       memory: 1Gi
       cpu: 200m

--- a/app-preprod.teamfamilie.yaml
+++ b/app-preprod.teamfamilie.yaml
@@ -82,11 +82,9 @@ spec:
   replicas:
     min: 2
     max: 2
-    cpuThresholdPercentage: 50
   resources:
     limits:
       memory: 2Gi
-      cpu: 1500m
     requests:
       memory: 1Gi
       cpu: 200m

--- a/app-prod.teamfamilie.yaml
+++ b/app-prod.teamfamilie.yaml
@@ -77,11 +77,9 @@ spec:
   replicas:
     min: 2
     max: 2
-    cpuThresholdPercentage: 50
   resources:
     limits:
       memory: 4Gi
-      cpu: 1500m
     requests:
       memory: 1Gi
       cpu: 200m


### PR DESCRIPTION
Anbefaling fra NAIS om at CPU throttle fjernes fra pod, men beholdes for requests: https://nav-it.slack.com/archives/C01DE3M9YBV/p1680172494569329

Artikkelen som det refereres til i meldingen fra NAIS beskriver hvorfor:
https://home.robusta.dev/blog/stop-using-cpu-limits

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12306)