### PR TITLE
Endre tittel for informasjonsbrev og et par andre slik at vi viser riktig informasjon til brukere

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdInformasjonsbrevDeltBostedMetadata.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdInformasjonsbrevDeltBostedMetadata.kt
@@ -16,7 +16,7 @@ object BarnetrygdInformasjonsbrevDeltBostedMetadata : Dokumentmetadata {
     override val behandlingstema: Behandlingstema? = null
     override val kanal: String? = null
     override val dokumenttype: Dokumenttype = Dokumenttype.BARNETRYGD_INFORMASJONSBREV_DELT_BOSTED
-    override val tittel: String = "Informasjonsbrev delt bosted - barnetrygd"
+    override val tittel: String = "Informasjonsbrev om barnetrygd"
     override val brevkode: String = "informasjonsbrev-delt-bosted"
     override val dokumentKategori: Dokumentkategori = Dokumentkategori.B
 }

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdInformasjonsbrevFødselGenerell.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdInformasjonsbrevFødselGenerell.kt
@@ -16,7 +16,7 @@ object BarnetrygdInformasjonsbrevFødselGenerell : Dokumentmetadata {
     override val behandlingstema: Behandlingstema? = null
     override val kanal: String? = null
     override val dokumenttype: Dokumenttype = Dokumenttype.BARNETRYGD_INFORMASJONSBREV_FØDSEL_GENERELL
-    override val tittel: String = "Informasjonsbrev fødsel generell"
+    override val tittel: String = "Informasjonsbrev om barnetrygd"
     override val brevkode: String = "informasjonsbrev-fodsel-generell"
     override val dokumentKategori: Dokumentkategori = Dokumentkategori.B
 }

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdInformasjonsbrevFødselMindreårigMetadata.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdInformasjonsbrevFødselMindreårigMetadata.kt
@@ -16,7 +16,7 @@ object BarnetrygdInformasjonsbrevFødselMindreårigMetadata : Dokumentmetadata {
     override val behandlingstema: Behandlingstema? = null
     override val kanal: String? = null
     override val dokumenttype: Dokumenttype = Dokumenttype.BARNETRYGD_INFORMASJONSBREV_FØDSEL_MINDREÅRIG
-    override val tittel: String = "Informasjonsbrev fødsel mindreårig"
+    override val tittel: String = "Informasjonsbrev om barnetrygd"
     override val brevkode: String = "informasjonsbrev-fodsel-mindreaarig"
     override val dokumentKategori: Dokumentkategori = Dokumentkategori.B
 }

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdInformasjonsbrevFødselVergemålMetadata.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdInformasjonsbrevFødselVergemålMetadata.kt
@@ -16,7 +16,7 @@ object BarnetrygdInformasjonsbrevFødselVergemålMetadata : Dokumentmetadata {
     override val behandlingstema: Behandlingstema? = null
     override val kanal: String? = null
     override val dokumenttype: Dokumenttype = Dokumenttype.BARNETRYGD_INFORMASJONSBREV_FØDSEL_VERGEMÅL
-    override val tittel: String = "Informasjonsbrev fødsel vergemål"
+    override val tittel: String = "Informasjonsbrev om barnetrygd"
     override val brevkode: String = "informasjonsbrev-fodsel-vergemaal"
     override val dokumentKategori: Dokumentkategori = Dokumentkategori.B
 }

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdInformasjonsbrevKanSøkeEøsMetadata.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdInformasjonsbrevKanSøkeEøsMetadata.kt
@@ -16,7 +16,7 @@ object BarnetrygdInformasjonsbrevKanSøkeEøsMetadata : Dokumentmetadata {
     override val behandlingstema: Behandlingstema? = null
     override val kanal: String? = null
     override val dokumenttype: Dokumenttype = Dokumenttype.BARNETRYGD_INFORMASJONSBREV_KAN_SØKE_EØS
-    override val tittel: String = "Informasjonsbrev kan søke EØS"
+    override val tittel: String = "Informasjonsbrev om barnetrygd"
     override val brevkode: String = "informasjonsbrev-kan-søke-eøs"
     override val dokumentKategori: Dokumentkategori = Dokumentkategori.B
 }

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdInformasjonsbrevKanSøkeMetadata.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdInformasjonsbrevKanSøkeMetadata.kt
@@ -16,7 +16,7 @@ object BarnetrygdInformasjonsbrevKanSøkeMetadata : Dokumentmetadata {
     override val behandlingstema: Behandlingstema? = null
     override val kanal: String? = null
     override val dokumenttype: Dokumenttype = Dokumenttype.BARNETRYGD_INFORMASJONSBREV_KAN_SØKE
-    override val tittel: String = "Informasjonsbrev kan søke"
+    override val tittel: String = "Informasjonsbrev om barnetrygd"
     override val brevkode: String = "informasjonsbrev-kan-soke"
     override val dokumentKategori: Dokumentkategori = Dokumentkategori.B
 }

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdInformasjonsbrevTilForelderMedSelvstendigRettViHarFåttF016KanSøkeOmBarnetrygdMetadata.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdInformasjonsbrevTilForelderMedSelvstendigRettViHarFåttF016KanSøkeOmBarnetrygdMetadata.kt
@@ -16,7 +16,7 @@ object BarnetrygdInformasjonsbrevTilForelderMedSelvstendigRettViHarFåttF016KanS
     override val behandlingstema: Behandlingstema? = null
     override val kanal: String? = null
     override val dokumenttype: Dokumenttype = Dokumenttype.BARNETRYGD_INFORMASJONSBREV_TIL_FORELDER_MED_SELVSTENDIG_RETT_VI_HAR_FÅTT_F016_KAN_SØKE_OM_BARNETRYGD
-    override val tittel: String = "Informasjonsbrev til forelder med selvstendig rett vi har fått F016 - kan søke om barnetrygd"
+    override val tittel: String = "Informasjonsbrev om barnetrygd"
     override val brevkode: String = "informasjonsbrev-til-forelder-f016-søke-barnetrygd"
     override val dokumentKategori: Dokumentkategori = Dokumentkategori.B
 }

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdInformasjonsbrevTilForelderOmfattetNorskLovgivningHarFåttEnSøknadFraAnnenForelderMetadata.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdInformasjonsbrevTilForelderOmfattetNorskLovgivningHarFåttEnSøknadFraAnnenForelderMetadata.kt
@@ -16,7 +16,7 @@ object BarnetrygdInformasjonsbrevTilForelderOmfattetNorskLovgivningHarFåttEnSø
     override val behandlingstema: Behandlingstema? = null
     override val kanal: String? = null
     override val dokumenttype: Dokumenttype = Dokumenttype.BARNETRYGD_INFORMASJONSBREV_TIL_FORELDER_OMFATTET_NORSK_LOVGIVNING_HAR_FÅTT_EN_SØKNAD_FRA_ANNEN_FORELDER
-    override val tittel: String = "Informasjonsbrev til forelder omfattet norsk lovgivning - har fått en søknad fra annen forelder"
+    override val tittel: String = "Informasjonsbrev om barnetrygd"
     override val brevkode: String = "informasjonsbrev-søknad-fra-annen-forelder"
     override val dokumentKategori: Dokumentkategori = Dokumentkategori.B
 }

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdInformasjonsbrevTilForelderOmfattetNorskLovgivningHarGjortVedtakTilAnnenForelderMetadata.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdInformasjonsbrevTilForelderOmfattetNorskLovgivningHarGjortVedtakTilAnnenForelderMetadata.kt
@@ -16,7 +16,7 @@ object BarnetrygdInformasjonsbrevTilForelderOmfattetNorskLovgivningHarGjortVedta
     override val behandlingstema: Behandlingstema? = null
     override val kanal: String? = null
     override val dokumenttype: Dokumenttype = Dokumenttype.BARNETRYGD_INFORMASJONSBREV_TIL_FORELDER_OMFATTET_NORSK_LOVGIVNING_HAR_GJORT_VEDTAK_TIL_ANNEN_FORELDER
-    override val tittel: String = "Informasjonsbrev til forelder omfattet norsk lovgivning - har gjort vedtak til annen forelder"
+    override val tittel: String = "Informasjonsbrev om barnetrygd"
     override val brevkode: String = "informasjonsbrev-gjort-vedtak-til-annen-forelder"
     override val dokumentKategori: Dokumentkategori = Dokumentkategori.B
 }

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdInformasjonsbrevTilForelderOmfattetNorskLovgivningVarselOmÅrligKontrollMetadata.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdInformasjonsbrevTilForelderOmfattetNorskLovgivningVarselOmÅrligKontrollMetadata.kt
@@ -16,7 +16,7 @@ object BarnetrygdInformasjonsbrevTilForelderOmfattetNorskLovgivningVarselOmÅrli
     override val behandlingstema: Behandlingstema? = null
     override val kanal: String? = null
     override val dokumenttype: Dokumenttype = Dokumenttype.BARNETRYGD_INFORMASJONSBREV_TIL_FORELDER_OMFATTET_NORSK_LOVGIVNING_VARSEL_OM_ÅRLIG_KONTROLL
-    override val tittel: String = "Informasjonsbrev til forelder omfattet norsk lovgivning - varsel om årlig kontroll"
+    override val tittel: String = "Informasjonsbrev om barnetrygd"
     override val brevkode: String = "informasjonsbrev-varsel-om-årlig-kontroll"
     override val dokumentKategori: Dokumentkategori = Dokumentkategori.B
 }

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdInnhenteOpplysningerOgInformasjonOmAtAnnenForelderMedSelvstendigRettHarSøktMetadata.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdInnhenteOpplysningerOgInformasjonOmAtAnnenForelderMedSelvstendigRettHarSøktMetadata.kt
@@ -16,7 +16,7 @@ object BarnetrygdInnhenteOpplysningerOgInformasjonOmAtAnnenForelderMedSelvstendi
     override val behandlingstema: Behandlingstema? = null
     override val kanal: String? = null
     override val dokumenttype: Dokumenttype = Dokumenttype.BARNETRYGD_INNHENTE_OPPLYSNINGER_OG_INFORMASJON_OM_AT_ANNEN_FORELDER_MED_SELVSTENDIG_RETT_HAR_SØKT
-    override val tittel: String = "Innhente opplysninger og informasjon om at annen forelder med selvstendig rett har søkt"
+    override val tittel: String = "Innhenting av opplysninger - barnetrygd"
     override val brevkode: String = "innhente-opplysninger-informasjon-annen-forelder"
     override val dokumentKategori: Dokumentkategori = Dokumentkategori.B
 }

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdVarselAnnenForelderMedSelvstendigRettSøkt.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/metadata/BarnetrygdVarselAnnenForelderMedSelvstendigRettSøkt.kt
@@ -16,7 +16,7 @@ object BarnetrygdVarselAnnenForelderMedSelvstendigRettSøkt : Dokumentmetadata {
     override val behandlingstema: Behandlingstema? = null
     override val kanal: String? = null
     override val dokumenttype: Dokumenttype = Dokumenttype.BARNETRYGD_VARSEL_ANNEN_FORELDER_MED_SELVSTENDIG_RETT_SØKT
-    override val tittel: String = "Varsel annen forelder med selvstendig rett søkt"
+    override val tittel: String = "Varsel om revurdering - barnetrygd"
     override val brevkode: String = "varsel-annen-forelder-med-selvstendig-rett-søkt"
     override val dokumentKategori: Dokumentkategori = Dokumentkategori.B
 }


### PR DESCRIPTION
[Favro-sak 1](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-16211)
[Favro-sak 2](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-16213)

Ønsker å endre dokumentbeskrivelse og tittel som vises i gosys m.m. 
Tittelen vi lagrer i Dokumentmetadata er den som blir lagret ned og vist de fleste steder. Menyvalget i ba-sak som vi ønsker å beholde blir satt av ba-sak-frontend og kommer fortsatt til å være riktig 😊 