### PR TITLE
Reverter oppdatering av aareg url for preprod

### DIFF
--- a/src/main/resources/application-preprod-q1.yaml
+++ b/src/main/resources/application-preprod-q1.yaml
@@ -146,7 +146,7 @@ FORSTESIDEGENERATOR_URL: https://foerstesidegenerator-q1.dev.intern.nav.no
 EGEN_ANSATT_URL: https://skjermede-personer-pip.nais.preprod.local
 DOKDIST_URL: https://dokdistfordeling-q1.dev.intern.nav.no
 DOKDISTKANAL_URL: https://dokdistkanal-q1.dev.intern.nav.no
-AAREG_URL: https://aareg-services-q1.intern.dev.nav.no/api
+AAREG_URL: https://aareg-services-q1.dev.intern.nav.no/api
 SKYGGE_SAK_URL: https://sak-q1.dev.intern.nav.no
 NORG2_URL: https://norg2.dev.adeo.no/norg2/
 

--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -149,7 +149,7 @@ FORSTESIDEGENERATOR_URL: https://foerstesidegenerator-q2.dev.intern.nav.no
 EGEN_ANSATT_URL: https://skjermede-personer-pip.nais.preprod.local
 DOKDIST_URL: https://dokdistfordeling-q2.dev.intern.nav.no
 DOKDISTKANAL_URL: https://dokdistkanal.dev.intern.nav.no
-AAREG_URL: https://aareg-services.intern.dev.nav.no/api
+AAREG_URL: https://aareg-services.dev.intern.nav.no/api
 SKYGGE_SAK_URL: https://sak-q2.dev.intern.nav.no
 NORG2_URL: https://norg2.dev.adeo.no/norg2/
 SFTP_HOST: b27apvl00364.preprod.local


### PR DESCRIPTION
Hvorfor ? 

Ser ut som at de har noen problemer med intern.dev ingressen, så de har begge kjørende akkurat nå. Satser derfor på dev.intern i mellomtiden ? 

https://nav-it.slack.com/archives/CAY78MSH5/p1698409325579779