### PR TITLE
Fiks: Validering av postadresse på samme vis som Dokdistfordeling

### DIFF
--- a/src/test/java/no/nav/familie/integrasjoner/dokdistkanal/DokdistkanalControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/dokdistkanal/DokdistkanalControllerTest.kt
@@ -143,10 +143,14 @@ class DokdistkanalControllerTest : OppslagSpringRunnerTest() {
             regelBegrunnelse = "Finner ikke personen i PDL",
         )
 
-        stubFor(post(urlPathMatching("/rest/bestemDistribusjonskanal"))
-                    .willReturn(okJson(objectMapper.writeValueAsString(dokdistkanalRespons))))
-        stubFor(post(urlPathMatching("/rest/postadresse"))
-                    .willReturn(notFound()))
+        stubFor(
+            post(urlPathMatching("/rest/bestemDistribusjonskanal"))
+                .willReturn(okJson(objectMapper.writeValueAsString(dokdistkanalRespons))),
+        )
+        stubFor(
+            post(urlPathMatching("/rest/postadresse"))
+                .willReturn(notFound()),
+        )
 
         val response =
             restTemplate.postForObject<Ressurs<String>>(


### PR DESCRIPTION
(Jf. https://github.com/navikt/dokdistfordeling/blob/master/rdist002/src/main/java/no/nav/dokdistfordeling/Rdist002ValidationUtil.java#L60)

Burde fikse punkt nr. 2 ang. forventet oppførsel her: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17868 