### PR TITLE
Pga vedlegg på 400mb øker vi proxy body size til 800 - som burde være…

### DIFF
--- a/app-prod.teamfamilie.yaml
+++ b/app-prod.teamfamilie.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: teamfamilie
   annotations:
-    nginx.ingress.kubernetes.io/proxy-body-size: "500M"
+    nginx.ingress.kubernetes.io/proxy-body-size: "800M"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
 
 spec:


### PR DESCRIPTION
… nok når vedlegg serialiseres med JSON. 

Finner ikke noe "OOM" i loggene, så antar det er her prosessen stopper. 