### PR TITLE
chore/rydd endepunkt tilgangskontroll

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/kodeverk/CachedKodeverkService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/kodeverk/CachedKodeverkService.kt
@@ -12,9 +12,6 @@ class CachedKodeverkService(private val kodeverkClient: KodeverkClient) {
     @Cacheable("kodeverk_postestedMedHistorikk", sync = true)
     fun hentPostnummerMedHistorikk(): KodeverkDto = kodeverkClient.hentPostnummerMedHistorikk()
 
-    @Cacheable("kodeverk_postested")
-    fun hentPostnummer(): Map<String, String> = kodeverkClient.hentPostnummer().mapTerm()
-
     @Cacheable("kodeverk_landkoder")
     fun hentLandkoder(): Map<String, String> = kodeverkClient.hentLandkoder().mapTerm()
 

--- a/src/main/java/no/nav/familie/integrasjoner/kodeverk/KodeverkController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/kodeverk/KodeverkController.kt
@@ -17,18 +17,11 @@ import org.springframework.web.bind.annotation.RestController
  */
 @Unprotected
 @RestController
-@RequestMapping(path = ["/api/selvbetjening/kodeverk", "/api/kodeverk"], produces = [MediaType.APPLICATION_JSON_VALUE])
+@RequestMapping(path = ["/api/kodeverk"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class KodeverkController(private val kodeverkService: CachedKodeverkService) {
     @GetMapping("/poststed")
     fun hentPoststed(): ResponseEntity<Ressurs<KodeverkDto>> {
         return ResponseEntity.ok(Ressurs.Companion.success(kodeverkService.hentPostnummerMedHistorikk()))
-    }
-
-    @GetMapping("/poststed/{postnummer}")
-    fun hentPoststed(
-        @PathVariable postnummer: String,
-    ): ResponseEntity<Ressurs<String>> {
-        return ResponseEntity.ok(Ressurs.Companion.success(kodeverkService.hentPostnummer().getOrDefault(postnummer, "")))
     }
 
     @GetMapping("/landkoder")

--- a/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/TilgangskontrollController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/TilgangskontrollController.kt
@@ -5,7 +5,6 @@ import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.tilgangskontroll.Tilgang
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.context.annotation.Profile
-import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
@@ -16,29 +15,13 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping(value = ["/api/tilgang"])
 @Profile("!e2e")
 class TilgangskontrollController(private val tilgangskontrollService: TilgangskontrollService) {
-    @GetMapping(path = ["/person"])
-    @ProtectedWithClaims(issuer = "azuread")
-    fun tilgangTilPerson(
-        @RequestHeader(name = "Nav-Personident") personIdent: String,
-    ): Tilgang {
-        return tilgangskontrollService.sjekkTilgangTilBruker(personIdent)
-    }
-
     @PostMapping(path = ["/personer"])
     @ProtectedWithClaims(issuer = "azuread")
+    @Deprecated("Brukes kun av familie-tilbake")
     fun tilgangTilPersoner(
         @RequestBody personIdenter: List<String>,
     ): List<Tilgang> {
         return tilgangskontrollService.sjekkTilgangTilBrukere(personIdenter)
-    }
-
-    @GetMapping(path = ["/v2/person"])
-    @ProtectedWithClaims(issuer = "azuread")
-    fun tilgangTilPerson(
-        @RequestHeader(name = "Nav-Personident") personIdent: String,
-        @RequestHeader(name = "Nav-Tema") tema: Tema,
-    ): Tilgang {
-        return tilgangskontrollService.sjekkTilgangTilBruker(personIdent, tema)
     }
 
     @PostMapping(path = ["/v2/personer"])

--- a/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/TilgangskontrollControllerE2E.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/TilgangskontrollControllerE2E.kt
@@ -3,10 +3,8 @@ package no.nav.familie.integrasjoner.tilgangskontroll
 import no.nav.familie.kontrakter.felles.tilgangskontroll.Tilgang
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.context.annotation.Profile
-import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -14,14 +12,6 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping(value = ["/api/tilgang"])
 @Profile("e2e")
 class TilgangskontrollControllerE2E {
-    @GetMapping(path = ["/person"])
-    @ProtectedWithClaims(issuer = "azuread")
-    fun tilgangTilPerson(
-        @RequestHeader(name = "Nav-Personident") personIdent: String,
-    ): Tilgang {
-        return Tilgang(personIdent, true)
-    }
-
     @PostMapping(path = ["/personer"])
     @ProtectedWithClaims(issuer = "azuread")
     fun tilgangTilPersoner(

--- a/src/test/java/no/nav/familie/integrasjoner/kodeverk/CachedKodeverkServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/kodeverk/CachedKodeverkServiceTest.kt
@@ -20,26 +20,6 @@ class CachedKodeverkServiceTest {
     private val kodeverkService = CachedKodeverkService(kodeverkClientMock)
 
     @Test
-    fun `skal returnere poststed`() {
-        val beskrivelse = BeskrivelseDto(POSTSTED, "")
-        val beytning = BetydningDto(LocalDate.now(), LocalDate.now(), mapOf(KodeverkSpråk.BOKMÅL.kode to beskrivelse))
-        val kodeverk = KodeverkDto(mapOf(POSTNUMMER to listOf(beytning)))
-
-        every { kodeverkClientMock.hentPostnummer() } returns kodeverk
-
-        val poststedTest = kodeverkService.hentPostnummer()[POSTNUMMER]
-        assertThat(poststedTest).isEqualTo(POSTSTED)
-    }
-
-    @Test
-    fun `skal returnere tom poststed hvis den ikke finnes`() {
-        every { kodeverkClientMock.hentPostnummer() } returns KodeverkDto(emptyMap())
-
-        val poststedTest = kodeverkService.hentPostnummer()[POSTNUMMER]
-        assertThat(poststedTest).isNull()
-    }
-
-    @Test
     fun `skal returnere landkod`() {
         val beskrivelse = BeskrivelseDto(LAND, "")
         val betydning = BetydningDto(LocalDate.now(), LocalDate.now(), mapOf(KodeverkSpråk.BOKMÅL.kode to beskrivelse))


### PR DESCRIPTION
- **Sletter ubrukte endepunkt [GET] /api/tilgang/person, [GET] /api/tilgang/v2/person**
- **Fjerner ubrukt /selvbetjening/* path og [GET] /api/kodeverk/poststed/{postnummer}**

Tatt utgangspunkt i https://grafana.nav.cloud.nais.io/d/adj04nnum3ym8d/team-familie-endepunkter-i-bruk?orgId=1&from=now-10d&to=now&var-environment=prod&var-fssDatasource=000000011&var-gcpDatasource=000000021&viewPanel=1
• søkt i kibana for de siste 3 månedene
