### PR TITLE
Skal kunne opprette oppgaver med personident siden oppgavesystemet nå…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <kotlin.version>2.0.0</kotlin.version>
         <springdoc.version>2.6.0</springdoc.version>
         <felles.version>3.20240624143824_64bf8f2</felles.version>
-        <kontrakt.version>3.0_20240731134554_8101d8c</kontrakt.version>
+        <kontrakt.version>3.0_20240801145104_f611578</kontrakt.version>
         <token-validation-spring.version>5.0.1</token-validation-spring.version>
 
         <mock-server.version>5.15.0</mock-server.version>

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
@@ -8,7 +8,6 @@ import no.nav.familie.integrasjoner.felles.OppslagException
 import no.nav.familie.integrasjoner.felles.OppslagException.Level
 import no.nav.familie.integrasjoner.saksbehandler.SaksbehandlerService
 import no.nav.familie.integrasjoner.sikkerhet.SikkerhetsContext
-import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.oppgave.FinnMappeRequest
 import no.nav.familie.kontrakter.felles.oppgave.FinnMappeResponseDto
 import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveRequest
@@ -139,7 +138,8 @@ class OppgaveService constructor(
     fun opprettOppgave(request: OpprettOppgaveRequest): Long {
         val oppgave =
             Oppgave(
-                aktoerId = if (erAktørIdEllerFnr(request.ident)) getAktørId(request.ident!!, request.tema) else null,
+                aktoerId = if (erAktørId(request.ident)) request.ident!!.ident else null,
+                personident = if (erPersonident(request.ident)) request.ident!!.ident else null,
                 orgnr = if (request.ident?.gruppe == IdentGruppe.ORGNR) request.ident!!.ident else null,
                 samhandlernr = if (request.ident?.gruppe == IdentGruppe.SAMHANDLERNR) request.ident!!.ident else null,
                 saksreferanse = request.saksId,
@@ -214,18 +214,9 @@ class OppgaveService constructor(
         }
     }
 
-    private fun erAktørIdEllerFnr(oppgaveIdent: OppgaveIdentV2?) =
-        oppgaveIdent?.gruppe == IdentGruppe.FOLKEREGISTERIDENT || oppgaveIdent?.gruppe == IdentGruppe.AKTOERID
+    private fun erPersonident(oppgaveIdent: OppgaveIdentV2?) = oppgaveIdent?.gruppe == IdentGruppe.FOLKEREGISTERIDENT
 
-    private fun getAktørId(
-        oppgaveIdentV2: OppgaveIdentV2,
-        tema: Tema,
-    ): String =
-        if (oppgaveIdentV2.gruppe == IdentGruppe.AKTOERID) {
-            oppgaveIdentV2.ident ?: throw IllegalArgumentException("Mangler ident for gruppe=${oppgaveIdentV2.gruppe}")
-        } else {
-            aktørService.getAktørIdFraPdl(oppgaveIdentV2.ident!!, tema)
-        }
+    private fun erAktørId(oppgaveIdent: OppgaveIdentV2?) = oppgaveIdent?.gruppe == IdentGruppe.AKTOERID
 
     fun finnMapper(finnMappeRequest: FinnMappeRequest): FinnMappeResponseDto {
         val mappeRespons = oppgaveRestClient.finnMapper(finnMappeRequest)

--- a/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveServiceTest.kt
@@ -2,14 +2,22 @@ package no.nav.familie.integrasjoner.oppgave
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import no.nav.familie.integrasjoner.aktør.AktørService
 import no.nav.familie.integrasjoner.client.rest.OppgaveRestClient
 import no.nav.familie.integrasjoner.saksbehandler.SaksbehandlerService
+import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.oppgave.FinnMappeRequest
 import no.nav.familie.kontrakter.felles.oppgave.FinnMappeResponseDto
+import no.nav.familie.kontrakter.felles.oppgave.IdentGruppe
 import no.nav.familie.kontrakter.felles.oppgave.MappeDto
+import no.nav.familie.kontrakter.felles.oppgave.Oppgave
+import no.nav.familie.kontrakter.felles.oppgave.OppgaveIdentV2
+import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
+import no.nav.familie.kontrakter.felles.oppgave.OpprettOppgaveRequest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.time.LocalDate
 
 internal class OppgaveServiceTest {
     val oppgaveRestClient = mockk<OppgaveRestClient>()
@@ -54,5 +62,53 @@ internal class OppgaveServiceTest {
             )
         val response = oppgaveService.finnMapper(finnMappeRequest)
         assertThat(response.antallTreffTotalt).isEqualTo(1)
+    }
+
+    @Test
+    fun `skal sette personident når identgruppe er folkeregisterident`() {
+        val personIdent = "12345678912"
+        val oppgaveSlot = slot<Oppgave>()
+        val request = OpprettOppgaveRequest(
+            ident = OppgaveIdentV2(personIdent, IdentGruppe.FOLKEREGISTERIDENT),
+            fristFerdigstillelse = LocalDate.now().plusDays(3),
+            behandlingstema = "behandlingstema",
+            enhetsnummer = "enhetsnummer",
+            tema = Tema.BAR,
+            oppgavetype = Oppgavetype.BehandleSak,
+            saksId = "saksid",
+            beskrivelse = "Oppgavetekst",
+        )
+
+        every { oppgaveRestClient.opprettOppgave(capture(oppgaveSlot)) } returns 0L
+        every { saksbehandlerService.hentNavIdent(any()) } returns "ident"
+
+        val result = oppgaveService.opprettOppgave(request)
+
+        assertThat(oppgaveSlot.captured.personident).isEqualTo(personIdent)
+        assertThat(oppgaveSlot.captured.aktoerId).isNull()
+    }
+
+    @Test
+    fun `skal sette aktørid når identgruppe er aktørid`() {
+        val aktørid = "12345678912"
+        val oppgaveSlot = slot<Oppgave>()
+        val request = OpprettOppgaveRequest(
+            ident = OppgaveIdentV2(aktørid, IdentGruppe.AKTOERID),
+            fristFerdigstillelse = LocalDate.now().plusDays(3),
+            behandlingstema = "behandlingstema",
+            enhetsnummer = "enhetsnummer",
+            tema = Tema.BAR,
+            oppgavetype = Oppgavetype.BehandleSak,
+            saksId = "saksid",
+            beskrivelse = "Oppgavetekst",
+        )
+
+        every { oppgaveRestClient.opprettOppgave(capture(oppgaveSlot)) } returns 0L
+        every { saksbehandlerService.hentNavIdent(any()) } returns "ident"
+
+        val result = oppgaveService.opprettOppgave(request)
+
+        assertThat(oppgaveSlot.captured.aktoerId).isEqualTo(aktørid)
+        assertThat(oppgaveSlot.captured.personident).isNull()
     }
 }


### PR DESCRIPTION
… støtter dette

Oppretter oppgaver med personident hvis denne sendes med, sånn at vi kan unngå å hente aktørID. 

Relatert favro: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-20981