### PR TITLE
Skrur av appdynamics, enabler observability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-FROM ghcr.io/navikt/baseimages/temurin:21-appdynamics
+FROM ghcr.io/navikt/baseimages/temurin:21
 
-ENV APPD_ENABLED=true
 ENV APP_NAME=familie-integrasjoner
 
 COPY ./target/familie-integrasjoner.jar "app.jar"

--- a/app-preprod.teamfamilie.yaml
+++ b/app-preprod.teamfamilie.yaml
@@ -93,6 +93,11 @@ spec:
   ingresses:
     - https://familie-integrasjoner.dev-fss-pub.nais.io
     - https://familie-integrasjoner.intern.dev.nav.no
+
+  observability:
+    autoInstrumentation:
+      enabled: true
+      runtime: java
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: preprod

--- a/app-prod.teamfamilie.yaml
+++ b/app-prod.teamfamilie.yaml
@@ -88,6 +88,14 @@ spec:
     - https://familie-integrasjoner.prod-fss-pub.nais.io
     - https://familie-integrasjoner.nais.adeo.no
     - https://familie-integrasjoner.intern.nav.no
+
+  observability:
+    autoInstrumentation:
+      enabled: true
+      runtime: java
+      destinations:
+        - id: "grafana-lgtm"
+        - id: "elastic-apm"
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: prod

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -165,9 +165,3 @@ OPPGAVE_URL: https://oppgave.nais.adeo.no
 NORG2_URL: https://norg2.nais.adeo.no/norg2/
 REGOPPSLAG_URL: https://regoppslag.intern.nav.no
 SFTP_HOST: a01drvl099.adeo.no
-
-# Appdynamics
-APPDYNAMICS_CONTROLLER_HOST_NAME: appdynamics.adeo.no
-APPDYNAMICS_CONTROLLER_PORT: 443
-APPDYNAMICS_CONTROLLER_SSL_ENABLED: true
-APPDYNAMICS_AGENT_ACCOUNT_NAME: PROD


### PR DESCRIPTION
Fordi appdynamics forsvinner. Tester med elastic-apm i prod. Grafana er default
https://docs.nais.io/observability/how-to/migrate-from-appd/
https://nav-it.slack.com/archives/C05DXMSNSV8/p1725023816588279