### PR TITLE
Skjuler AsyncRequestNotUsableException

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/config/ApiExceptionHandler.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/config/ApiExceptionHandler.kt
@@ -17,6 +17,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.client.RestClientResponseException
+import org.springframework.web.context.request.async.AsyncRequestNotUsableException
 import java.nio.channels.ClosedChannelException
 
 @ControllerAdvice
@@ -48,6 +49,18 @@ class ApiExceptionHandler {
                     error = e,
                 ),
             )
+    }
+
+    /**
+     * AsyncRequestNotUsableException er en exception som blir kastet når en async request blir avbrutt. Velger
+     * å skjule denne exceptionen fra loggen da den ikke er interessant for oss.
+     */
+    @ExceptionHandler(AsyncRequestNotUsableException::class)
+    fun handlAsyncRequestNotUsableException(
+        e: AsyncRequestNotUsableException,
+    ): ResponseEntity<Ressurs<Any>>? {
+        logger.info("En AsyncRequestNotUsableException har oppstått, som skjer når en async request blir avbrutt", e)
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build()
     }
 
     @ExceptionHandler(MissingRequestHeaderException::class)


### PR DESCRIPTION
Vi får en alarm hver gang en client får avbrutt en async response. Det trigges da en AsyncRequestNotUsableException, som blir plukket opp av ExceptionHandleren våres og logger dermed error. Hadde ikke vi hatt en exception handler som plukket opp alle feil, så ville den blitt håndtert av  DefaultHandlerExceptionResolver uten videre feilhåndtering. Ser det derfor trygt at vi også ignorerer feil av denne typen 
https://github.com/spring-projects/spring-framework/issues/32509#issuecomment-2012860782