### PR TITLE
Legger inn axsys config i e2e, slik at e2e-testene i familie-tilbake kjører

### DIFF
--- a/src/main/resources/application-e2e.yml
+++ b/src/main/resources/application-e2e.yml
@@ -130,6 +130,24 @@ no.nav.security.jwt:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
+      axsys:
+        resource-url: ${AXSYS_URL}
+        token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+        grant-type: client_credentials
+        scope: ${AXSYS_SCOPE}
+        authentication:
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
+          client-auth-method: client_secret_basic
+      axsys-onbehalf-of:
+        resource-url: ${AXSYS_URL}
+        token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+        grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
+        scope: ${AXSYS_SCOPE}
+        authentication:
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
+          client-auth-method: client_secret_basic
 
 AZURE_APP_CLIENT_ID: ${INTEGRASJONER_CLIENT_ID}
 AZURE_APP_CLIENT_SECRET: ${INTEGRASJONER_CLIENT_SECRET}
@@ -140,6 +158,7 @@ FORSTESIDEGENERATOR_URL:
 MEDL2_URL: http://vtp:8060/rest/medl2
 NORG2_URL: #Mockes lokalt
 
+AXSYS_URL: http://familie-mock-server:1337/rest/api/enhetstilganger/
 DOKDIST_URL: http://familie-mock-server:1337/rest/api/dokdist/
 DOKARKIV_V1_URL: http://familie-mock-server:1337/rest/api/dokarkiv/
 OPPGAVE_URL: http://familie-mock-server:1337/rest/api/oppgave/


### PR DESCRIPTION
Link til et bygg som feiler i familie-tilbake: https://github.com/navikt/familie-tilbake/actions/runs/10921137346/job/30312698726

Link til logger som viser at det mangler axsys config for familie-integrasjoner: https://github.com/navikt/familie-tilbake/actions/runs/10921137346/artifacts/1947423582
