### PR TITLE
Oppdaterer endepunkt med mulighet til å nullstille tilordnet ressurs.

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/OppgaveRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/OppgaveRestClient.kt
@@ -5,7 +5,7 @@ import no.nav.familie.http.client.AbstractPingableRestClient
 import no.nav.familie.http.util.UriUtil
 import no.nav.familie.integrasjoner.client.QueryParamUtil.toQueryParams
 import no.nav.familie.integrasjoner.felles.OppslagException
-import no.nav.familie.integrasjoner.oppgave.OppgaveByttEnhet
+import no.nav.familie.integrasjoner.oppgave.OppgaveByttEnhetOgTilordnetRessurs
 import no.nav.familie.integrasjoner.oppgave.domene.LIMIT_MOT_OPPGAVE
 import no.nav.familie.integrasjoner.oppgave.domene.OppgaveRequest
 import no.nav.familie.integrasjoner.oppgave.domene.toDto
@@ -150,18 +150,18 @@ class OppgaveRestClient(
                 },
             )
 
-    fun oppdaterEnhet(byttEnhetPatch: OppgaveByttEnhet): Oppgave? =
+    fun oppdaterEnhetOgTilordnetRessurs(byttEnhetOgTilordnetRessursPatch: OppgaveByttEnhetOgTilordnetRessurs): Oppgave? =
         Result
             .runCatching {
                 patchForEntity<Oppgave>(
-                    requestUrl(byttEnhetPatch.id),
-                    byttEnhetPatch,
+                    requestUrl(byttEnhetOgTilordnetRessursPatch.id),
+                    byttEnhetOgTilordnetRessursPatch,
                     httpHeaders(),
                 )
             }.fold(
                 onSuccess = { it },
                 onFailure = {
-                    var feilmelding = "Feil ved bytte av enhet for oppgave for ${byttEnhetPatch.id}."
+                    var feilmelding = "Feil ved bytte av enhet for oppgave for ${byttEnhetOgTilordnetRessursPatch.id}."
                     if (it is HttpStatusCodeException) {
                         feilmelding += " Response fra oppgave = ${it.responseBodyAsString}"
                     }

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
@@ -115,11 +115,14 @@ class OppgaveController(
         @Parameter(description = "Settes til true hvis man ønsker å flytte en oppgave uten å ta med seg mappa opp på oppgaven. Noen mapper hører spesifikt til en enhet, og man får da ikke flyttet oppgaven uten at mappen fjernes ")
         @RequestParam(name = "fjernMappeFraOppgave")
         fjernMappeFraOppgave: Boolean,
+        @Parameter(description = "Settes til true hvis man ønsker å nullstille tilordnet ressurs etter at enheten er endret.")
+        @RequestParam(name = "nullstillTilordnetRessurs")
+        nullstillTilordnetRessurs: Boolean = false,
         @Parameter(description = "Vil feile med 409 Conflict dersom versjonen ikke stemmer overens med oppgavesystemets versjon")
         @RequestParam(name = "versjon")
         versjon: Int?,
     ): ResponseEntity<Ressurs<OppgaveResponse>> {
-        oppgaveService.tilordneEnhet(oppgaveId, enhet, fjernMappeFraOppgave, versjon)
+        oppgaveService.tilordneEnhetOgNullstillTilordnetRessurs(oppgaveId, enhet, fjernMappeFraOppgave, nullstillTilordnetRessurs, versjon)
         return ResponseEntity.ok().body(success(OppgaveResponse(oppgaveId = oppgaveId), "Oppdatering av oppgave OK"))
     }
 }

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
@@ -234,15 +234,20 @@ class OppgaveService constructor(
         return finnMapper(finnMappeRequest).mapper
     }
 
-    fun tilordneEnhet(
+    fun tilordneEnhetOgNullstillTilordnetRessurs(
         oppgaveId: Long,
         enhet: String,
         fjernMappeFraOppgave: Boolean,
+        nullstillTilordnetRessurs: Boolean,
         versjon: Int?,
     ) {
         val oppgave = oppgaveRestClient.finnOppgaveMedId(oppgaveId)
         val mappeId = if (fjernMappeFraOppgave) null else oppgave.mappeId
         oppgaveRestClient.oppdaterEnhet(OppgaveByttEnhet(oppgaveId, enhet, versjon ?: oppgave.versjon!!, mappeId))
+
+        if (nullstillTilordnetRessurs) {
+            oppgaveRestClient.oppdaterOppgave(Oppgave(id = oppgaveId, tilordnetRessurs = null))
+        }
     }
 }
 

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveService.kt
@@ -243,19 +243,25 @@ class OppgaveService constructor(
     ) {
         val oppgave = oppgaveRestClient.finnOppgaveMedId(oppgaveId)
         val mappeId = if (fjernMappeFraOppgave) null else oppgave.mappeId
-        oppgaveRestClient.oppdaterEnhet(OppgaveByttEnhet(oppgaveId, enhet, versjon ?: oppgave.versjon!!, mappeId))
-
-        if (nullstillTilordnetRessurs) {
-            oppgaveRestClient.oppdaterOppgave(Oppgave(id = oppgaveId, tilordnetRessurs = null))
-        }
+        val tilordnetRessurs = if (nullstillTilordnetRessurs) null else oppgave.tilordnetRessurs
+        oppgaveRestClient.oppdaterEnhetOgTilordnetRessurs(
+            OppgaveByttEnhetOgTilordnetRessurs(
+                id = oppgaveId,
+                tildeltEnhetsnr = enhet,
+                versjon = versjon ?: oppgave.versjon!!,
+                mappeId = mappeId,
+                tilordnetRessurs = tilordnetRessurs,
+            ),
+        )
     }
 }
 
-data class OppgaveByttEnhet(
+data class OppgaveByttEnhetOgTilordnetRessurs(
     val id: Long,
     val tildeltEnhetsnr: String,
     val versjon: Int,
     @JsonInclude(JsonInclude.Include.ALWAYS) val mappeId: Long? = null,
+    @JsonInclude(JsonInclude.Include.ALWAYS) val tilordnetRessurs: String? = null,
 )
 
 /**

--- a/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveControllerTest.kt
@@ -495,6 +495,7 @@ class OppgaveControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `Endre enhet på oppgave skal endre enhet og nullstille tilordnet ressurs hvis nullstillTilordnetRessurs-flagg er satt til true`() {
+        // Arrange
         stubFor(get("/api/v1/oppgaver/$OPPGAVE_ID").willReturn(okJson(gyldigOppgaveResponse("hentOppgave.json"))))
 
         stubFor(
@@ -517,12 +518,15 @@ class OppgaveControllerTest : OppslagSpringRunnerTest() {
                 tema = null,
             )
 
+        // Act
         val response: ResponseEntity<Ressurs<OppgaveResponse>> =
             restTemplate.exchange(
                 localhost("$OPPGAVE_URL/$OPPGAVE_ID/enhet/4833?fjernMappeFraOppgave=false&nullstillTilordnetRessurs=true"),
                 HttpMethod.PATCH,
                 HttpEntity(oppgave, headers),
             )
+
+        // Assert
         assertThat(response.body?.data?.oppgaveId).isEqualTo(OPPGAVE_ID)
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
     }

--- a/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveServiceTest.kt
@@ -17,6 +17,7 @@ import no.nav.familie.kontrakter.felles.oppgave.OppgaveIdentV2
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.kontrakter.felles.oppgave.OpprettOppgaveRequest
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
@@ -115,92 +116,95 @@ internal class OppgaveServiceTest {
         assertThat(oppgaveSlot.captured.personident).isNull()
     }
 
-    @Test
-    fun `tilordneEnhetOgNullstillTilordnetRessurs skal fjerne mappe fra oppgave dersom det settes til true`() {
-        // Arrange
-        val oppgaveId = 1L
-        val oppgaveByttEnhetOgTilordnetRessursRessursSlot = slot<OppgaveByttEnhetOgTilordnetRessurs>()
-        val oppgaveMedMappe = Oppgave(id = oppgaveId, mappeId = 50)
+    @Nested
+    inner class TilordneEnhetOgNullstillTilordnetRessursTest {
+        @Test
+        fun `skal fjerne mappe fra oppgave dersom det settes til true`() {
+            // Arrange
+            val oppgaveId = 1L
+            val oppgaveByttEnhetOgTilordnetRessursRessursSlot = slot<OppgaveByttEnhetOgTilordnetRessurs>()
+            val oppgaveMedMappe = Oppgave(id = oppgaveId, mappeId = 50)
 
-        every { oppgaveRestClient.finnOppgaveMedId(oppgaveId) } returns oppgaveMedMappe
-        every { oppgaveRestClient.oppdaterEnhetOgTilordnetRessurs(capture(oppgaveByttEnhetOgTilordnetRessursRessursSlot)) } returns oppgaveMedMappe
+            every { oppgaveRestClient.finnOppgaveMedId(oppgaveId) } returns oppgaveMedMappe
+            every { oppgaveRestClient.oppdaterEnhetOgTilordnetRessurs(capture(oppgaveByttEnhetOgTilordnetRessursRessursSlot)) } returns oppgaveMedMappe
 
-        // Act
-        oppgaveService.tilordneEnhetOgNullstillTilordnetRessurs(
-            oppgaveId = 1L,
-            enhet = "nyEnhet",
-            fjernMappeFraOppgave = true,
-            nullstillTilordnetRessurs = false,
-            versjon = 0,
-        )
+            // Act
+            oppgaveService.tilordneEnhetOgNullstillTilordnetRessurs(
+                oppgaveId = 1L,
+                enhet = "nyEnhet",
+                fjernMappeFraOppgave = true,
+                nullstillTilordnetRessurs = false,
+                versjon = 0,
+            )
 
-        // Assert
-        val oppgaveByttEnhetOgTilordnetRessurs = oppgaveByttEnhetOgTilordnetRessursRessursSlot.captured
+            // Assert
+            val oppgaveByttEnhetOgTilordnetRessurs = oppgaveByttEnhetOgTilordnetRessursRessursSlot.captured
 
-        assertThat(oppgaveByttEnhetOgTilordnetRessurs.id).isEqualTo(1)
-        assertThat(oppgaveByttEnhetOgTilordnetRessurs.mappeId).isNull()
-        assertThat(oppgaveByttEnhetOgTilordnetRessurs.tildeltEnhetsnr).isEqualTo("nyEnhet")
+            assertThat(oppgaveByttEnhetOgTilordnetRessurs.id).isEqualTo(1)
+            assertThat(oppgaveByttEnhetOgTilordnetRessurs.mappeId).isNull()
+            assertThat(oppgaveByttEnhetOgTilordnetRessurs.tildeltEnhetsnr).isEqualTo("nyEnhet")
 
-        verify(exactly = 1) { oppgaveRestClient.finnOppgaveMedId(oppgaveId) }
-        verify(exactly = 1) { oppgaveRestClient.oppdaterEnhetOgTilordnetRessurs(oppgaveByttEnhetOgTilordnetRessurs) }
-    }
+            verify(exactly = 1) { oppgaveRestClient.finnOppgaveMedId(oppgaveId) }
+            verify(exactly = 1) { oppgaveRestClient.oppdaterEnhetOgTilordnetRessurs(oppgaveByttEnhetOgTilordnetRessurs) }
+        }
 
-    @Test
-    fun `tilordneEnhetOgNullstillTilordnetRessurs skal ikke fjerne mappe fra oppgave dersom det settes til false`() {
-        // Arrange
-        val oppgaveId = 1L
-        val oppgaveByttEnhetOgTilordnetRessursRessursSlot = slot<OppgaveByttEnhetOgTilordnetRessurs>()
-        val oppgaveMedMappe = Oppgave(id = oppgaveId, mappeId = 50)
+        @Test
+        fun `skal ikke fjerne mappe fra oppgave dersom det settes til false`() {
+            // Arrange
+            val oppgaveId = 1L
+            val oppgaveByttEnhetOgTilordnetRessursRessursSlot = slot<OppgaveByttEnhetOgTilordnetRessurs>()
+            val oppgaveMedMappe = Oppgave(id = oppgaveId, mappeId = 50)
 
-        every { oppgaveRestClient.finnOppgaveMedId(oppgaveId) } returns oppgaveMedMappe
-        every { oppgaveRestClient.oppdaterEnhetOgTilordnetRessurs(capture(oppgaveByttEnhetOgTilordnetRessursRessursSlot)) } returns oppgaveMedMappe
+            every { oppgaveRestClient.finnOppgaveMedId(oppgaveId) } returns oppgaveMedMappe
+            every { oppgaveRestClient.oppdaterEnhetOgTilordnetRessurs(capture(oppgaveByttEnhetOgTilordnetRessursRessursSlot)) } returns oppgaveMedMappe
 
-        // Act
-        oppgaveService.tilordneEnhetOgNullstillTilordnetRessurs(
-            oppgaveId = 1L,
-            enhet = "nyEnhet",
-            fjernMappeFraOppgave = false,
-            nullstillTilordnetRessurs = false,
-            versjon = 0,
-        )
+            // Act
+            oppgaveService.tilordneEnhetOgNullstillTilordnetRessurs(
+                oppgaveId = 1L,
+                enhet = "nyEnhet",
+                fjernMappeFraOppgave = false,
+                nullstillTilordnetRessurs = false,
+                versjon = 0,
+            )
 
-        // Assert
-        val oppgaveByttEnhetOgTilordnetRessurs = oppgaveByttEnhetOgTilordnetRessursRessursSlot.captured
+            // Assert
+            val oppgaveByttEnhetOgTilordnetRessurs = oppgaveByttEnhetOgTilordnetRessursRessursSlot.captured
 
-        assertThat(oppgaveByttEnhetOgTilordnetRessurs.id).isEqualTo(1)
-        assertThat(oppgaveByttEnhetOgTilordnetRessurs.mappeId).isEqualTo(50)
-        assertThat(oppgaveByttEnhetOgTilordnetRessurs.tildeltEnhetsnr).isEqualTo("nyEnhet")
+            assertThat(oppgaveByttEnhetOgTilordnetRessurs.id).isEqualTo(1)
+            assertThat(oppgaveByttEnhetOgTilordnetRessurs.mappeId).isEqualTo(50)
+            assertThat(oppgaveByttEnhetOgTilordnetRessurs.tildeltEnhetsnr).isEqualTo("nyEnhet")
 
-        verify(exactly = 1) { oppgaveRestClient.finnOppgaveMedId(oppgaveId) }
-        verify(exactly = 1) { oppgaveRestClient.oppdaterEnhetOgTilordnetRessurs(oppgaveByttEnhetOgTilordnetRessurs) }
-    }
+            verify(exactly = 1) { oppgaveRestClient.finnOppgaveMedId(oppgaveId) }
+            verify(exactly = 1) { oppgaveRestClient.oppdaterEnhetOgTilordnetRessurs(oppgaveByttEnhetOgTilordnetRessurs) }
+        }
 
-    @Test
-    fun `tilordneEnhetOgNullstillTilordnetRessurs skal nullstille tilordnet ressurs hvis det settes til true`() {
-        // Arrange
-        val oppgaveId = 1L
-        val oppgaveByttEnhetOgTilordnetRessursRessursSlot = slot<OppgaveByttEnhetOgTilordnetRessurs>()
-        val oppgaveMedMappe = Oppgave(id = oppgaveId, mappeId = 50, tilordnetRessurs = "tilordnetRessurs")
+        @Test
+        fun `skal nullstille tilordnet ressurs hvis det settes til true`() {
+            // Arrange
+            val oppgaveId = 1L
+            val oppgaveByttEnhetOgTilordnetRessursRessursSlot = slot<OppgaveByttEnhetOgTilordnetRessurs>()
+            val oppgaveMedMappe = Oppgave(id = oppgaveId, mappeId = 50, tilordnetRessurs = "tilordnetRessurs")
 
-        every { oppgaveRestClient.finnOppgaveMedId(oppgaveId) } returns oppgaveMedMappe
-        every { oppgaveRestClient.oppdaterEnhetOgTilordnetRessurs(capture(oppgaveByttEnhetOgTilordnetRessursRessursSlot)) } returns oppgaveMedMappe
+            every { oppgaveRestClient.finnOppgaveMedId(oppgaveId) } returns oppgaveMedMappe
+            every { oppgaveRestClient.oppdaterEnhetOgTilordnetRessurs(capture(oppgaveByttEnhetOgTilordnetRessursRessursSlot)) } returns oppgaveMedMappe
 
-        // Act
-        oppgaveService.tilordneEnhetOgNullstillTilordnetRessurs(
-            oppgaveId = 1L,
-            enhet = "nyEnhet",
-            fjernMappeFraOppgave = false,
-            nullstillTilordnetRessurs = true,
-            versjon = 0,
-        )
+            // Act
+            oppgaveService.tilordneEnhetOgNullstillTilordnetRessurs(
+                oppgaveId = 1L,
+                enhet = "nyEnhet",
+                fjernMappeFraOppgave = false,
+                nullstillTilordnetRessurs = true,
+                versjon = 0,
+            )
 
-        // Assert
-        val oppgaveByttEnhetOgTilordnetRessurs = oppgaveByttEnhetOgTilordnetRessursRessursSlot.captured
+            // Assert
+            val oppgaveByttEnhetOgTilordnetRessurs = oppgaveByttEnhetOgTilordnetRessursRessursSlot.captured
 
-        assertThat(oppgaveByttEnhetOgTilordnetRessurs.id).isEqualTo(1L)
-        assertThat(oppgaveByttEnhetOgTilordnetRessurs.tilordnetRessurs).isNull()
+            assertThat(oppgaveByttEnhetOgTilordnetRessurs.id).isEqualTo(1L)
+            assertThat(oppgaveByttEnhetOgTilordnetRessurs.tilordnetRessurs).isNull()
 
-        verify(exactly = 1) { oppgaveRestClient.finnOppgaveMedId(oppgaveId) }
-        verify(exactly = 1) { oppgaveRestClient.oppdaterEnhetOgTilordnetRessurs(oppgaveByttEnhetOgTilordnetRessurs) }
+            verify(exactly = 1) { oppgaveRestClient.finnOppgaveMedId(oppgaveId) }
+            verify(exactly = 1) { oppgaveRestClient.oppdaterEnhetOgTilordnetRessurs(oppgaveByttEnhetOgTilordnetRessurs) }
+        }
     }
 }

--- a/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveServiceTest.kt
@@ -173,6 +173,7 @@ internal class OppgaveServiceTest {
 
         verify(exactly = 1) { oppgaveRestClient.finnOppgaveMedId(oppgaveId) }
         verify(exactly = 1) { oppgaveRestClient.oppdaterEnhet(oppgaveByttEnhet) }
+        verify(exactly = 0) { oppgaveRestClient.oppdaterOppgave(any()) }
     }
 
     @Test

--- a/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveServiceTest.kt
@@ -119,11 +119,11 @@ internal class OppgaveServiceTest {
     fun `tilordneEnhetOgNullstillTilordnetRessurs skal fjerne mappe fra oppgave dersom det settes til true`() {
         // Arrange
         val oppgaveId = 1L
-        val oppgaveByttEnhetSlot = slot<OppgaveByttEnhet>()
+        val oppgaveByttEnhetOgTilordnetRessursRessursSlot = slot<OppgaveByttEnhetOgTilordnetRessurs>()
         val oppgaveMedMappe = Oppgave(id = oppgaveId, mappeId = 50)
 
         every { oppgaveRestClient.finnOppgaveMedId(oppgaveId) } returns oppgaveMedMappe
-        every { oppgaveRestClient.oppdaterEnhet(capture(oppgaveByttEnhetSlot)) } returns oppgaveMedMappe
+        every { oppgaveRestClient.oppdaterEnhetOgTilordnetRessurs(capture(oppgaveByttEnhetOgTilordnetRessursRessursSlot)) } returns oppgaveMedMappe
 
         // Act
         oppgaveService.tilordneEnhetOgNullstillTilordnetRessurs(
@@ -135,25 +135,25 @@ internal class OppgaveServiceTest {
         )
 
         // Assert
-        val oppgaveByttEnhet = oppgaveByttEnhetSlot.captured
+        val oppgaveByttEnhetOgTilordnetRessurs = oppgaveByttEnhetOgTilordnetRessursRessursSlot.captured
 
-        assertThat(oppgaveByttEnhet.id).isEqualTo(1)
-        assertThat(oppgaveByttEnhet.mappeId).isNull()
-        assertThat(oppgaveByttEnhet.tildeltEnhetsnr).isEqualTo("nyEnhet")
+        assertThat(oppgaveByttEnhetOgTilordnetRessurs.id).isEqualTo(1)
+        assertThat(oppgaveByttEnhetOgTilordnetRessurs.mappeId).isNull()
+        assertThat(oppgaveByttEnhetOgTilordnetRessurs.tildeltEnhetsnr).isEqualTo("nyEnhet")
 
         verify(exactly = 1) { oppgaveRestClient.finnOppgaveMedId(oppgaveId) }
-        verify(exactly = 1) { oppgaveRestClient.oppdaterEnhet(oppgaveByttEnhet) }
+        verify(exactly = 1) { oppgaveRestClient.oppdaterEnhetOgTilordnetRessurs(oppgaveByttEnhetOgTilordnetRessurs) }
     }
 
     @Test
     fun `tilordneEnhetOgNullstillTilordnetRessurs skal ikke fjerne mappe fra oppgave dersom det settes til false`() {
         // Arrange
         val oppgaveId = 1L
-        val oppgaveByttEnhetSlot = slot<OppgaveByttEnhet>()
+        val oppgaveByttEnhetOgTilordnetRessursRessursSlot = slot<OppgaveByttEnhetOgTilordnetRessurs>()
         val oppgaveMedMappe = Oppgave(id = oppgaveId, mappeId = 50)
 
         every { oppgaveRestClient.finnOppgaveMedId(oppgaveId) } returns oppgaveMedMappe
-        every { oppgaveRestClient.oppdaterEnhet(capture(oppgaveByttEnhetSlot)) } returns oppgaveMedMappe
+        every { oppgaveRestClient.oppdaterEnhetOgTilordnetRessurs(capture(oppgaveByttEnhetOgTilordnetRessursRessursSlot)) } returns oppgaveMedMappe
 
         // Act
         oppgaveService.tilordneEnhetOgNullstillTilordnetRessurs(
@@ -165,28 +165,25 @@ internal class OppgaveServiceTest {
         )
 
         // Assert
-        val oppgaveByttEnhet = oppgaveByttEnhetSlot.captured
+        val oppgaveByttEnhetOgTilordnetRessurs = oppgaveByttEnhetOgTilordnetRessursRessursSlot.captured
 
-        assertThat(oppgaveByttEnhet.id).isEqualTo(1)
-        assertThat(oppgaveByttEnhet.mappeId).isEqualTo(50)
-        assertThat(oppgaveByttEnhet.tildeltEnhetsnr).isEqualTo("nyEnhet")
+        assertThat(oppgaveByttEnhetOgTilordnetRessurs.id).isEqualTo(1)
+        assertThat(oppgaveByttEnhetOgTilordnetRessurs.mappeId).isEqualTo(50)
+        assertThat(oppgaveByttEnhetOgTilordnetRessurs.tildeltEnhetsnr).isEqualTo("nyEnhet")
 
         verify(exactly = 1) { oppgaveRestClient.finnOppgaveMedId(oppgaveId) }
-        verify(exactly = 1) { oppgaveRestClient.oppdaterEnhet(oppgaveByttEnhet) }
-        verify(exactly = 0) { oppgaveRestClient.oppdaterOppgave(any()) }
+        verify(exactly = 1) { oppgaveRestClient.oppdaterEnhetOgTilordnetRessurs(oppgaveByttEnhetOgTilordnetRessurs) }
     }
 
     @Test
     fun `tilordneEnhetOgNullstillTilordnetRessurs skal nullstille tilordnet ressurs hvis det settes til true`() {
         // Arrange
         val oppgaveId = 1L
-        val oppgaveByttEnhetSlot = slot<OppgaveByttEnhet>()
-        val oppgaveSlot = slot<Oppgave>()
-        val oppgaveMedMappe = Oppgave(id = oppgaveId, mappeId = 50)
+        val oppgaveByttEnhetOgTilordnetRessursRessursSlot = slot<OppgaveByttEnhetOgTilordnetRessurs>()
+        val oppgaveMedMappe = Oppgave(id = oppgaveId, mappeId = 50, tilordnetRessurs = "tilordnetRessurs")
 
         every { oppgaveRestClient.finnOppgaveMedId(oppgaveId) } returns oppgaveMedMappe
-        every { oppgaveRestClient.oppdaterEnhet(capture(oppgaveByttEnhetSlot)) } returns oppgaveMedMappe
-        every { oppgaveRestClient.oppdaterOppgave(capture(oppgaveSlot)) } returns oppgaveMedMappe
+        every { oppgaveRestClient.oppdaterEnhetOgTilordnetRessurs(capture(oppgaveByttEnhetOgTilordnetRessursRessursSlot)) } returns oppgaveMedMappe
 
         // Act
         oppgaveService.tilordneEnhetOgNullstillTilordnetRessurs(
@@ -198,14 +195,12 @@ internal class OppgaveServiceTest {
         )
 
         // Assert
-        val oppgaveByttEnhet = oppgaveByttEnhetSlot.captured
-        val nullstiltOppgave = oppgaveSlot.captured
+        val oppgaveByttEnhetOgTilordnetRessurs = oppgaveByttEnhetOgTilordnetRessursRessursSlot.captured
 
-        assertThat(nullstiltOppgave.id).isEqualTo(1L)
-        assertThat(nullstiltOppgave.tilordnetRessurs).isNull()
+        assertThat(oppgaveByttEnhetOgTilordnetRessurs.id).isEqualTo(1L)
+        assertThat(oppgaveByttEnhetOgTilordnetRessurs.tilordnetRessurs).isNull()
 
         verify(exactly = 1) { oppgaveRestClient.finnOppgaveMedId(oppgaveId) }
-        verify(exactly = 1) { oppgaveRestClient.oppdaterEnhet(oppgaveByttEnhet) }
-        verify(exactly = 1) { oppgaveRestClient.oppdaterOppgave(capture(oppgaveSlot)) }
+        verify(exactly = 1) { oppgaveRestClient.oppdaterEnhetOgTilordnetRessurs(oppgaveByttEnhetOgTilordnetRessurs) }
     }
 }

--- a/src/test/resources/oppgave/hentOppgave.json
+++ b/src/test/resources/oppgave/hentOppgave.json
@@ -30,5 +30,6 @@
   "endretTidspunkt": "2020-01-02T13:15:22.551+01:00",
   "prioritet": "NORM",
   "status": "OPPRETTET",
-  "metadata": {}
+  "metadata": {},
+  "tilordnetRessurs": "NAV_1"
 }


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22778

Vi må nullstille ressurs på denne måten.
Ved å sende inn null til patch oppgave endepunktet så vil ikke familie-integrasjoner forstå at det er NULL, men heller at man ikke har sendt inn noe felt, og derfor ikke gjøre noe med tilordnetressurs feltet.