### PR TITLE
Legger til nye endepunkter og nye service-metoder for henting av dokument og journalpost med tilgangskontroll

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/journalpost/BaksTilgangsstyrtJournalpostService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/journalpost/BaksTilgangsstyrtJournalpostService.kt
@@ -23,7 +23,7 @@ class BaksTilgangsstyrtJournalpostService(
             )
         }
 
-    private fun harTilgangTilJournalpost(journalpost: Journalpost): Boolean {
+    fun harTilgangTilJournalpost(journalpost: Journalpost): Boolean {
         val tema = journalpost.tema?.let { tema -> Tema.valueOf(tema) }
         if (tema == null) {
             return true

--- a/src/main/java/no/nav/familie/integrasjoner/journalpost/HentJournalpostController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/journalpost/HentJournalpostController.kt
@@ -106,6 +106,19 @@ class HentJournalpostController(
             ),
         )
 
+    @GetMapping("hentdokument/tilgangsstyrt/baks/{journalpostId}/{dokumentInfoId}")
+    fun hentTilgangsstyrtBaksDokument(
+        @PathVariable journalpostId: String,
+        @PathVariable dokumentInfoId: String,
+        @RequestParam("variantFormat", required = false) variantFormat: String?,
+    ): ResponseEntity<Ressurs<ByteArray>> =
+        ResponseEntity.ok(
+            success(
+                journalpostService.hentTilgangsstyrtBaksDokument(journalpostId, dokumentInfoId, variantFormat ?: "ARKIV"),
+                "OK",
+            ),
+        )
+
     companion object {
         private val LOG = LoggerFactory.getLogger(HentJournalpostController::class.java)
         private val secureLogger = LoggerFactory.getLogger("secureLogger")

--- a/src/main/java/no/nav/familie/integrasjoner/journalpost/HentJournalpostController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/journalpost/HentJournalpostController.kt
@@ -78,6 +78,11 @@ class HentJournalpostController(
         @RequestParam(name = "journalpostId") journalpostId: String,
     ): ResponseEntity<Ressurs<Journalpost>> = ResponseEntity.ok(success(journalpostService.hentJournalpost(journalpostId), "OK"))
 
+    @GetMapping("tilgangsstyrt/baks")
+    fun hentTilgangsstyrtBaksJournalpost(
+        @RequestParam(name = "journalpostId") journalpostId: String,
+    ): ResponseEntity<Ressurs<Journalpost>> = ResponseEntity.ok(success(journalpostService.hentTilgangsstyrtBaksJournalpost(journalpostId), "OK"))
+
     @PostMapping
     fun hentJournalpostForBruker(
         @RequestBody journalposterForBrukerRequest: JournalposterForBrukerRequest,

--- a/src/main/java/no/nav/familie/integrasjoner/journalpost/JournalpostService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/journalpost/JournalpostService.kt
@@ -33,4 +33,17 @@ class JournalpostService
             dokumentInfoId: String,
             variantFormat: String,
         ): ByteArray = safHentDokumentRestClient.hentDokument(journalpostId, dokumentInfoId, variantFormat)
+
+        fun hentTilgangsstyrtBaksDokument(
+            journalpostId: String,
+            dokumentInfoId: String,
+            variantFormat: String,
+        ): ByteArray {
+            val journalpost = hentJournalpost(journalpostId)
+            if (baksTilgangsstyrtJournalpostService.harTilgangTilJournalpost(journalpost)) {
+                return hentDokument(journalpostId, dokumentInfoId, variantFormat)
+            } else {
+                throw JournalpostForbiddenException("Kan ikke hente dokument. Krever ekstra tilganger.")
+            }
+        }
     }

--- a/src/main/java/no/nav/familie/integrasjoner/journalpost/JournalpostService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/journalpost/JournalpostService.kt
@@ -19,6 +19,15 @@ class JournalpostService
     ) {
         fun hentJournalpost(journalpostId: String): Journalpost = safRestClient.hentJournalpost(journalpostId)
 
+        fun hentTilgangsstyrtBaksJournalpost(journalpostId: String): Journalpost {
+            val journalpost = hentJournalpost(journalpostId)
+            if (baksTilgangsstyrtJournalpostService.harTilgangTilJournalpost(journalpost)) {
+                return journalpost
+            } else {
+                throw JournalpostForbiddenException("Kan ikke hente journalpost. Krever ekstra tilganger.")
+            }
+        }
+
         fun finnJournalposter(journalposterForBrukerRequest: JournalposterForBrukerRequest): List<Journalpost> = safRestClient.finnJournalposter(journalposterForBrukerRequest)
 
         fun finnTilgangsstyrteBaksJournalposter(journalposterForBrukerRequest: JournalposterForBrukerRequest): List<TilgangsstyrtJournalpost> {

--- a/src/test/java/no/nav/familie/integrasjoner/journalpost/JournalpostServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/journalpost/JournalpostServiceTest.kt
@@ -8,11 +8,15 @@ import no.nav.familie.integrasjoner.client.rest.SafRestClient
 import no.nav.familie.kontrakter.felles.BrukerIdType
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.journalpost.Bruker
+import no.nav.familie.kontrakter.felles.journalpost.Dokumentvariantformat
 import no.nav.familie.kontrakter.felles.journalpost.Journalpost
 import no.nav.familie.kontrakter.felles.journalpost.JournalposterForBrukerRequest
 import no.nav.familie.kontrakter.felles.journalpost.TilgangsstyrtJournalpost
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertNotNull
 
 class JournalpostServiceTest {
     private val safRestClient: SafRestClient = mockk()
@@ -29,7 +33,7 @@ class JournalpostServiceTest {
         )
 
     @Nested
-    inner class FinnTilgangsstyrteJournalposter {
+    inner class FinnTilgangsstyrteBaksJournalposter {
         @Test
         fun`skal hente journalposter fra saf og deretter mappe om lista til tilgangsstyrte journalposter`() {
             // Arrange
@@ -44,6 +48,90 @@ class JournalpostServiceTest {
             // Assert
             verify(exactly = 1) { safRestClient.finnJournalposter(journalposterForBrukerRequest) }
             verify(exactly = 1) { baksTilgangsstyrtJournalpostService.mapTilTilgangsstyrteJournalposter(journalposter) }
+        }
+    }
+
+    @Nested
+    inner class HentTilgangsstyrtBaksDokument {
+        @Test
+        fun `skal hente dokument dersom dokument er digital søknad og saksbehandler har tilgang`() {
+            // Arrange
+            val journalpostId = "1234"
+            val dokumentId = "5678"
+            val variantFormat = Dokumentvariantformat.ARKIV
+            val dokumentString = "TestDokument"
+            val testDokument = dokumentString.toByteArray()
+
+            every { safRestClient.hentJournalpost(journalpostId) } returns mockk()
+            every { baksTilgangsstyrtJournalpostService.harTilgangTilJournalpost(any()) } returns true
+            every { safHentDokumentRestClient.hentDokument(journalpostId, dokumentId, variantFormat.name) } returns testDokument
+
+            // Act
+            val dokument = journalpostService.hentTilgangsstyrtBaksDokument(journalpostId, dokumentId, variantFormat.name)
+
+            // Assert
+            assertNotNull(dokument)
+            assertThat(dokument.decodeToString()).isEqualTo(dokumentString)
+            verify(exactly = 1) { safRestClient.hentJournalpost(journalpostId) }
+            verify(exactly = 1) { baksTilgangsstyrtJournalpostService.harTilgangTilJournalpost(any()) }
+            verify(exactly = 1) { safHentDokumentRestClient.hentDokument(journalpostId, dokumentId, variantFormat.name) }
+        }
+
+        @Test
+        fun `skal kaste JournalpostForbiddenException dersom dokument er digital søknad og saksbehandler ikke har tilgang`() {
+            // Arrange
+            val journalpostId = "1234"
+            val dokumentId = "5678"
+            val variantFormat = Dokumentvariantformat.ARKIV
+
+            every { safRestClient.hentJournalpost(journalpostId) } returns mockk()
+            every { baksTilgangsstyrtJournalpostService.harTilgangTilJournalpost(any()) } returns false
+
+            // Act & Assert
+            val dokument = assertThrows<JournalpostForbiddenException> { journalpostService.hentTilgangsstyrtBaksDokument(journalpostId, dokumentId, variantFormat.name) }
+
+            assertNotNull(dokument)
+            assertThat(dokument.message).isEqualTo("Kan ikke hente dokument. Krever ekstra tilganger.")
+            verify(exactly = 1) { safRestClient.hentJournalpost(journalpostId) }
+            verify(exactly = 1) { baksTilgangsstyrtJournalpostService.harTilgangTilJournalpost(any()) }
+            verify(exactly = 0) { safHentDokumentRestClient.hentDokument(journalpostId, dokumentId, variantFormat.name) }
+        }
+    }
+
+    @Nested
+    inner class HentTilgangsstyrtBaksJournalpost {
+        @Test
+        fun `skal hente journalpost dersom journalpost inneholder digital søknad og saksbehandler har tilgang`() {
+            // Arrange
+            val journalpostId = "1234"
+
+            every { safRestClient.hentJournalpost(journalpostId) } returns mockk()
+            every { baksTilgangsstyrtJournalpostService.harTilgangTilJournalpost(any()) } returns true
+
+            // Act
+            val journalpost = journalpostService.hentTilgangsstyrtBaksJournalpost(journalpostId)
+
+            // Assert
+            assertNotNull(journalpost)
+            verify(exactly = 1) { safRestClient.hentJournalpost(journalpostId) }
+            verify(exactly = 1) { baksTilgangsstyrtJournalpostService.harTilgangTilJournalpost(any()) }
+        }
+
+        @Test
+        fun `skal kaste JournalpostForbiddenException dersom journalpost inneholder digital søknad og saksbehandler ikke har tilgang`() {
+            // Arrange
+            val journalpostId = "1234"
+
+            every { safRestClient.hentJournalpost(journalpostId) } returns mockk()
+            every { baksTilgangsstyrtJournalpostService.harTilgangTilJournalpost(any()) } returns false
+
+            // Act & Assert
+            val journalpostForbiddenException = assertThrows<JournalpostForbiddenException> { journalpostService.hentTilgangsstyrtBaksJournalpost(journalpostId) }
+
+            assertNotNull(journalpostForbiddenException)
+            assertThat(journalpostForbiddenException.message).isEqualTo("Kan ikke hente journalpost. Krever ekstra tilganger.")
+            verify(exactly = 1) { safRestClient.hentJournalpost(journalpostId) }
+            verify(exactly = 1) { baksTilgangsstyrtJournalpostService.harTilgangTilJournalpost(any()) }
         }
     }
 }


### PR DESCRIPTION
Vi trenger tilgangskontroll ved henting av dokumenter og journalposter for baks. Dersom et dokument eller en journalpost er en digital søknad må saksbehandler ha tilgang til alle personer i søknad for å få lov til å hente ned dokumentet.