### PR TITLE
Oppdaterer felles kontrakter og bruker AvsenderMottakerIdType istedenfor BrukerIdType inne i avsenderMottaker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <kotlin.version>2.0.21</kotlin.version>
         <springdoc.version>2.6.0</springdoc.version>
         <felles.version>3.20240913110742_adb42f8</felles.version>
-        <kontrakt.version>3.0_20241018104853_fa92410</kontrakt.version>
+        <kontrakt.version>3.0_20241030085021_493c354</kontrakt.version>
         <token-validation-spring.version>5.0.5</token-validation-spring.version>
 
         <mock-server.version>5.15.0</mock-server.version>

--- a/src/main/java/no/nav/familie/integrasjoner/baks/søknad/BaksVersjonertSøknadService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/baks/søknad/BaksVersjonertSøknadService.kt
@@ -20,8 +20,8 @@ class BaksVersjonertSøknadService(
         tema: Tema,
     ): BaksSøknadBase =
         when (tema) {
-            Tema.KON -> hentVersjonertKontantstøtteSøknad(journalpost).baksSøknadBase
-            Tema.BAR -> hentVersjonertBarnetrygdSøknad(journalpost).baksSøknadBase
+            Tema.KON -> hentVersjonertKontantstøtteSøknad(journalpost).kontantstøtteSøknad
+            Tema.BAR -> hentVersjonertBarnetrygdSøknad(journalpost).barnetrygdSøknad
             else -> throw IllegalArgumentException("Støtter ikke deserialisering av søknad for tema $tema")
         }
 

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivService.kt
@@ -24,6 +24,7 @@ import no.nav.familie.kontrakter.felles.dokarkiv.Sak
 import no.nav.familie.kontrakter.felles.dokarkiv.v2.ArkiverDokumentRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.v2.Dokument
 import no.nav.familie.kontrakter.felles.dokarkiv.v2.Filtype
+import no.nav.familie.kontrakter.felles.journalpost.AvsenderMottakerIdType
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
@@ -58,7 +59,7 @@ class DokarkivService(
         val avsenderMottaker =
             arkiverDokumentRequest.avsenderMottaker ?: arkiverDokumentRequest.fnr.let {
                 val navn = hentNavnForFnr(fnr = arkiverDokumentRequest.fnr, behandlingstema = metadata.tema)
-                AvsenderMottaker(it, BrukerIdType.FNR, navn)
+                AvsenderMottaker(it, AvsenderMottakerIdType.FNR, navn)
             }
 
         val dokumenter = mutableListOf(mapHoveddokument(arkiverDokumentRequest.hoveddokumentvarianter))

--- a/src/test/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivServiceTest.kt
@@ -30,6 +30,7 @@ import no.nav.familie.kontrakter.felles.dokarkiv.v2.ArkiverDokumentRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.v2.Dokument
 import no.nav.familie.kontrakter.felles.dokarkiv.v2.Filtype
 import no.nav.familie.kontrakter.felles.dokarkiv.v2.Førsteside
+import no.nav.familie.kontrakter.felles.journalpost.AvsenderMottakerIdType
 import no.nav.familie.log.mdc.MDCConstants
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
@@ -358,7 +359,7 @@ class DokarkivServiceTest {
         sak: Sak? = null,
     ) {
         assertThat(request.avsenderMottaker!!.id).isEqualTo(FNR)
-        assertThat(request.avsenderMottaker!!.idType).isEqualTo(BrukerIdType.FNR)
+        assertThat(request.avsenderMottaker!!.idType).isEqualTo(AvsenderMottakerIdType.FNR)
         assertThat(request.bruker!!.id).isEqualTo(FNR)
         assertThat(request.bruker!!.idType).isEqualTo(BrukerIdType.FNR)
         assertThat(request.behandlingstema).isEqualTo(KontanstøtteSøknadMetadata.behandlingstema.value)
@@ -386,7 +387,7 @@ class DokarkivServiceTest {
         sak: Sak,
     ) {
         assertThat(request.avsenderMottaker!!.id).isEqualTo(FNR)
-        assertThat(request.avsenderMottaker!!.idType).isEqualTo(BrukerIdType.FNR)
+        assertThat(request.avsenderMottaker!!.idType).isEqualTo(AvsenderMottakerIdType.FNR)
         assertThat(request.bruker!!.id).isEqualTo(FNR)
         assertThat(request.bruker!!.idType).isEqualTo(BrukerIdType.FNR)
         assertThat(request.behandlingstema).isEqualTo(BarnetrygdVedtakMetadata.behandlingstema.value)


### PR DESCRIPTION
Relatert til favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22897

Det har blitt feilaktig brukt BrukerIdType inne i dataklassen AvsenderMottaker.
Dette ble rettet opp i familie-kontrakter, og nå må familie-integrasjoner justeres.