### PR TITLE
Ikke kast feil ved 409 Conflict ved journalføring.

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivRestClient.kt
@@ -57,7 +57,7 @@ class DokarkivRestClient(
             return postForEntity(uri, jp, headers(navIdent))
         } catch (feilVedJournalføring: RuntimeException) {
             if (feilVedJournalføring is HttpClientErrorException.Conflict) {
-                logger.warn("409 ved oppretting av journalpost med eksternReferanseId=${jp.eksternReferanseId}. Denne jornaloisten er allerede journalført. Returnerer body fra feilmelding som er en OpprettJournalpostResponse.")
+                logger.warn("409 ved oppretting av journalpost med eksternReferanseId=${jp.eksternReferanseId}. Denne journalposten er allerede journalført. Returnerer body fra feilmelding som er en OpprettJournalpostResponse.")
                 return try {
                     feilVedJournalføring.getResponseBodyAs(OpprettJournalpostResponse::class.java)
                 } catch (parsingFeil: RuntimeException) {

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivRestClient.kt
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
+import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.HttpStatusCodeException
 import org.springframework.web.client.RestClientResponseException
 import org.springframework.web.client.RestOperations
@@ -54,8 +55,16 @@ class DokarkivRestClient(
         val uri = lagJournalpostUri(ferdigstill)
         try {
             return postForEntity(uri, jp, headers(navIdent))
-        } catch (e: RuntimeException) {
-            throw oppslagExceptionVed("opprettelse", e, jp.bruker?.id, "dokarkiv.opprettJournalpost")
+        } catch (feilVedJournalføring: RuntimeException) {
+            if (feilVedJournalføring is HttpClientErrorException.Conflict) {
+                logger.warn("409 ved oppretting av journalpost med eksternReferanseId=${jp.eksternReferanseId}. Denne jornaloisten er allerede journalført. Returnerer body fra feilmelding som er en OpprettJournalpostResponse.")
+                return try {
+                    feilVedJournalføring.getResponseBodyAs(OpprettJournalpostResponse::class.java)
+                } catch (parsingFeil: RuntimeException) {
+                    throw oppslagExceptionVed("opprettelse", feilVedJournalføring, jp.bruker?.id, "dokarkiv.opprettJournalpost")
+                }
+            }
+            throw oppslagExceptionVed("opprettelse", feilVedJournalføring, jp.bruker?.id, "dokarkiv.opprettJournalpost")
         }
     }
 

--- a/src/main/java/no/nav/familie/integrasjoner/config/ApiExceptionHandler.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/config/ApiExceptionHandler.kt
@@ -19,7 +19,6 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.client.ResourceAccessException
 import org.springframework.web.client.RestClientResponseException
 import org.springframework.web.context.request.async.AsyncRequestNotUsableException
-import java.nio.channels.ClosedChannelException
 
 @ControllerAdvice
 class ApiExceptionHandler {
@@ -141,7 +140,7 @@ class ApiExceptionHandler {
         when (e.level) {
             OppslagException.Level.KRITISK,
             OppslagException.Level.MEDIUM,
-                -> {
+            -> {
                 secureLogger.warn("OppslagException : $sensitivFeilmelding", e.error)
                 logger.warn("OppslagException : $feilmelding")
 

--- a/src/test/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivControllerTest.kt
@@ -187,7 +187,7 @@ class DokarkivControllerTest(
                 response()
                     .withStatusCode(409)
                     .withHeader("Content-Type", "application/json;charset=UTF-8")
-                    .withBody("Denne bodyen er ikk en OpprettJournalpostResponse"),
+                    .withBody("Denne bodyen er ikke en OpprettJournalpostResponse"),
             )
         val body =
             ArkiverDokumentRequest(


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23435
Hvis man prøver å journalføre en journalpost med samme eksternReferanseId, så får man en 409 Conflict. Da har det vært opp til klienten å sørge for å søke opp journalpostId med denne eksternReferanseId. Noe som ikke skjer i baks-mottak, men som ef-mottak gjør. Dette er unødvendig. Responsen fra dokarkiv har allerede all den infoen man trenger.

I stedet for å kaste 409 til klienten så returnerer man responsen fra dokariv. Så slipper klienten å måtte søke opp journalposten basert på eksternReferanseId som man måtte ha gjort i dag.
