### PR TITLE
Justerer logikk for når vi forsøker å hente ORIGINAL variant av digitale søknader for tilgangssjekk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <kotlin.version>2.0.21</kotlin.version>
         <springdoc.version>2.6.0</springdoc.version>
         <felles.version>3.20241127123724_adfc561</felles.version>
-        <kontrakt.version>3.0_20241127135607_0f52105</kontrakt.version>
+        <kontrakt.version>3.0_20241205134345_ebeccc9</kontrakt.version>
         <token-validation-spring.version>5.0.11</token-validation-spring.version>
 
         <mock-server.version>5.15.0</mock-server.version>


### PR DESCRIPTION
Favro: [NAV-23550](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23550)
Av og til dukker det opp journalposter som ikke har `ORIGINAL` variant av digital søknad for KS og BA til tross for at de burde hatt det med tanke på opprettet dato. Forsøker her kun å hente `ORIGINAL` variant dersom vi ser at den finnes på journalpost. Dersom journalposten burde hatt en `ORIGINAL` variant logger vi dette som en Warning.