### PR TITLE
Reverterer spring boot 3.4.0 oppdatering

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.0</version>
+        <version>3.3.5</version>
     </parent>
 
     <groupId>no.nav.familie.integrasjoner</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,15 +20,15 @@
         <sha1></sha1>
         <changelist>-SNAPSHOT</changelist>
         <java.version>21</java.version>
-        <kotlin.version>2.1.0</kotlin.version>
-        <springdoc.version>2.7.0</springdoc.version>
+        <kotlin.version>2.0.21</kotlin.version>
+        <springdoc.version>2.6.0</springdoc.version>
         <felles.version>3.20241127123724_adfc561</felles.version>
-        <kontrakt.version>3.0_20241206132953_18ef9da</kontrakt.version>
-        <token-validation-spring.version>5.0.13</token-validation-spring.version>
+        <kontrakt.version>3.0_20241205134345_ebeccc9</kontrakt.version>
+        <token-validation-spring.version>5.0.11</token-validation-spring.version>
 
         <mock-server.version>5.15.0</mock-server.version>
 
-        <spring.cloud>4.2.0</spring.cloud>
+        <spring.cloud>4.1.4</spring.cloud>
 
     </properties>
 
@@ -386,7 +386,7 @@
                     <dependency>
                         <groupId>com.pinterest.ktlint</groupId>
                         <artifactId>ktlint-cli</artifactId>
-                        <version>1.5.0</version>
+                        <version>1.4.1</version>
                     </dependency>
                     <!-- additional 3rd party ruleset(s) can be specified here -->
                 </dependencies>
@@ -395,7 +395,7 @@
                 <!-- For å få dependency graph i SLSA som pushes av docker-build-push parameter byosbom -->
                 <groupId>org.cyclonedx</groupId>
                 <artifactId>cyclonedx-maven-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>2.9.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/src/main/java/no/nav/familie/integrasjoner/config/IntegrasjonConfig.java
+++ b/src/main/java/no/nav/familie/integrasjoner/config/IntegrasjonConfig.java
@@ -14,6 +14,7 @@ import java.net.URI;
 public class IntegrasjonConfig {
 
     @Bean
+    @Autowired
     @Profile("!mock-sts")
     public StsRestClient stsRestClient(ObjectMapper objectMapper,
                                        @Value("${STS_URL}") URI stsUrl,

--- a/src/test/java/no/nav/familie/integrasjoner/baks/søknad/BaksVersjonertSøknadServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/baks/søknad/BaksVersjonertSøknadServiceTest.kt
@@ -77,7 +77,7 @@ class BaksVersjonertSøknadServiceTest {
         }
 
         @Test
-        fun `skal kaste feil dersom tema ikke er BAR eller KON`() {
+        fun`skal kaste feil dersom tema ikke er BAR eller KON`() {
             // Act & Assert
             val exception = assertThrows<IllegalArgumentException> { baksVersjonertSøknadService.hentBaksSøknadBase(mockk(), Tema.ENF) }
             assertThat(exception.message).isEqualTo("Støtter ikke deserialisering av søknad for tema ${Tema.ENF.name}")

--- a/src/test/java/no/nav/familie/integrasjoner/journalpost/JournalpostServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/journalpost/JournalpostServiceTest.kt
@@ -35,7 +35,7 @@ class JournalpostServiceTest {
     @Nested
     inner class FinnTilgangsstyrteBaksJournalposter {
         @Test
-        fun `skal hente journalposter fra saf og deretter mappe om lista til tilgangsstyrte journalposter`() {
+        fun`skal hente journalposter fra saf og deretter mappe om lista til tilgangsstyrte journalposter`() {
             // Arrange
             val journalposterForBrukerRequest = JournalposterForBrukerRequest(brukerId = Bruker("1", BrukerIdType.FNR), antall = 100, tema = listOf(Tema.BAR))
             val journalposter = listOf(mockk<Journalpost>())


### PR DESCRIPTION
3.4.0 fører til serialiserings/deserialiserings issue med familie kontrakter. 
Vi hadde samme problem i ~familie-baks-soknad-api~ familie-baks-mottak sist uke.
