### PR TITLE
Bumper familie-kontrakter for å få oppdatert SerDes av KontantstøtteSøknad

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <kotlin.version>2.0.21</kotlin.version>
         <springdoc.version>2.6.0</springdoc.version>
         <felles.version>3.20241127123724_adfc561</felles.version>
-        <kontrakt.version>3.0_20241205134345_ebeccc9</kontrakt.version>
+        <kontrakt.version>3.0_20241211134553_5cc5b4b</kontrakt.version>
         <token-validation-spring.version>5.0.11</token-validation-spring.version>
 
         <mock-server.version>5.15.0</mock-server.version>

--- a/src/test/java/no/nav/familie/integrasjoner/baks/søknad/BaksSøknad.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/baks/søknad/BaksSøknad.kt
@@ -6,6 +6,7 @@ import no.nav.familie.kontrakter.felles.søknad.Søknadsfelt
 import no.nav.familie.kontrakter.ks.søknad.v1.RegistrertBostedType
 import no.nav.familie.kontrakter.ks.søknad.v1.SIVILSTANDTYPE
 import no.nav.familie.kontrakter.ks.søknad.v1.SøknadAdresse
+import no.nav.familie.kontrakter.ks.søknad.v1.TekstPåSpråkMap
 import no.nav.familie.kontrakter.ks.søknad.v5.KontantstøtteSøknad
 import no.nav.familie.kontrakter.ba.søknad.v8.Barn as BarnetrygdBarn
 import no.nav.familie.kontrakter.ba.søknad.v8.Søker as BarnetrygdSøker
@@ -22,7 +23,7 @@ fun lagKontantstøtteSøknad(
         barn = listOf(lagKontantstøtteBarn(barnFnr)),
         antallEøsSteg = 0,
         dokumentasjon = emptyList(),
-        teksterTilPdf = emptyMap(),
+        teksterTilPdf = mapOf("testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "Bokmål", "nn" to "Nynorsk", "en" to "Engelsk"))),
         originalSpråk = "NB",
         finnesPersonMedAdressebeskyttelse = false,
         erNoenAvBarnaFosterbarn = lagStringSøknadsfelt("Nei"),


### PR DESCRIPTION
Bumper familie-kontrakter slik at KontantstøtteSøknad er kompatibel med ny versjon av Jackson i Spring Boot 3.4.0