### PR TITLE
Ikke tell 410 Gone som feil i metrikken dokdist.distributer

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/DokdistRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/DokdistRestClient.kt
@@ -8,6 +8,7 @@ import no.nav.familie.integrasjoner.dokdist.domene.DistribuerJournalpostResponse
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
+import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestOperations
 import java.net.URI
 
@@ -24,8 +25,12 @@ class DokdistRestClient(
         try {
             postForEntity(distribuerUri, req)
         } catch (e: Exception) {
-            incrementLoggFeil("dokdist.distribuer")
-            throw e
+            if (e is HttpClientErrorException.Gone) {
+                throw e
+            } else {
+                incrementLoggFeil("dokdist.distribuer")
+                throw e
+            }
         }
 
     companion object {


### PR DESCRIPTION
 Siden dette er en forventet feilte er en forventet feil

F.eks. så prøver ba-sak å distribuere jevnlig brev til dødsbo som enda ikke har fått dødsboadresse. Dette vil se slik ut 

Klarte ikke å distribuere brev til journalpost 685996358 på behandling 5867958.
Httpstatus: 410 GONE
Melding: 410 Gone: "{"data":"{\"timestamp\":\"2024-12-13T07:36:35.871+00:00\",\"status\":410,\"error\":\"Gone\",\"message\":\"Mottaker er død og har ukjent adresse.\"

Disse vil man ikke telle med i metrikken som trigger alarm i grafana når mange feil skjer på kort tid.

<img width="1367" alt="image" src="https://github.com/user-attachments/assets/af1fb002-a352-4989-bb4b-d0043687bdd0" />
