### PR TITLE
`OppslagException` når kall mot eksterne tjenester feiler

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/arbeidsfordeling/ArbeidsfordelingRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/arbeidsfordeling/ArbeidsfordelingRestClient.kt
@@ -1,10 +1,12 @@
 package no.nav.familie.integrasjoner.arbeidsfordeling
 
 import no.nav.familie.http.client.AbstractPingableRestClient
+import no.nav.familie.integrasjoner.felles.OppslagException
 import no.nav.familie.kontrakter.felles.arbeidsfordeling.Enhet
 import no.nav.familie.kontrakter.felles.navkontor.NavKontorEnhet
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.client.RestOperations
 import org.springframework.web.util.UriComponentsBuilder
@@ -18,32 +20,62 @@ class ArbeidsfordelingRestClient(
     restOperations: RestOperations,
 ) : AbstractPingableRestClient(restOperations, "norg2") {
     fun hentEnhet(geografiskOmråde: String): NavKontorEnhet =
-        getForEntity(
-            UriComponentsBuilder
-                .fromUri(norg2Uri)
-                .pathSegment("api/v1/enhet/navkontor/$geografiskOmråde")
-                .build()
-                .toUri(),
-        )
+        try {
+            getForEntity(
+                UriComponentsBuilder
+                    .fromUri(norg2Uri)
+                    .pathSegment("api/v1/enhet/navkontor/$geografiskOmråde")
+                    .build()
+                    .toUri(),
+            )
+        } catch (e: Exception) {
+            throw OppslagException(
+                "Feil ved henting av enhet",
+                "norg2.hentEnhet",
+                OppslagException.Level.MEDIUM,
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                e,
+            )
+        }
 
     fun hentNavkontor(enhetId: String): NavKontorEnhet =
-        getForEntity(
-            UriComponentsBuilder
-                .fromUri(norg2Uri)
-                .pathSegment("api/v1/enhet/$enhetId")
-                .build()
-                .toUri(),
-        )
+        try {
+            getForEntity(
+                UriComponentsBuilder
+                    .fromUri(norg2Uri)
+                    .pathSegment("api/v1/enhet/$enhetId")
+                    .build()
+                    .toUri(),
+            )
+        } catch (e: Exception) {
+            throw OppslagException(
+                "Feil ved henting av navkontor",
+                "norg2.hentNavkontor",
+                OppslagException.Level.MEDIUM,
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                e,
+            )
+        }
 
-    fun finnBehandlendeEnhetMedBesteMatch(arbeidsfordelingskriterie: ArbeidsfordelingKriterie): List<Enhet> {
-        val uri =
-            UriComponentsBuilder
-                .fromUri(norg2Uri)
-                .pathSegment("api/v1/arbeidsfordeling/enheter/bestmatch")
-                .build()
-                .toUri()
-        return postForEntity<List<NavKontorEnhet>>(uri, arbeidsfordelingskriterie).map { Enhet(enhetId = it.enhetNr, enhetNavn = it.navn) }
-    }
+    fun finnBehandlendeEnhetMedBesteMatch(arbeidsfordelingskriterie: ArbeidsfordelingKriterie): List<Enhet> =
+        try {
+            postForEntity<List<NavKontorEnhet>>(
+                UriComponentsBuilder
+                    .fromUri(norg2Uri)
+                    .pathSegment("api/v1/arbeidsfordeling/enheter/bestmatch")
+                    .build()
+                    .toUri(),
+                arbeidsfordelingskriterie,
+            ).map { Enhet(enhetId = it.enhetNr, enhetNavn = it.navn) }
+        } catch (e: Exception) {
+            throw OppslagException(
+                "Feil ved oppslag av best matchende behandlende enhet",
+                "norg2.finnBehandlendeEnhetMedBesteMatch",
+                OppslagException.Level.MEDIUM,
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                e,
+            )
+        }
 
     override val pingUri: URI
         get() =

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/AxsysRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/AxsysRestClient.kt
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Service
 import org.springframework.web.client.RestOperations
 import org.springframework.web.util.UriComponentsBuilder
 import java.net.URI
+import no.nav.familie.integrasjoner.felles.OppslagException
+import org.springframework.http.HttpStatus
 
 @Service
 class AxsysRestClient(
@@ -28,7 +30,13 @@ class AxsysRestClient(
             getForEntity<TilgangV2DTO>(uri)
         } catch (e: Exception) {
             incrementLoggFeil("axsys")
-            throw e
+            throw OppslagException(
+                "Feil ved henting av enheter Nav identer har tilgang til",
+                "axsys.hentEnheterNavIdentHarTilgangTil",
+                OppslagException.Level.MEDIUM,
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                e
+            )
         }
     }
 }

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/AxsysRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/AxsysRestClient.kt
@@ -29,7 +29,6 @@ class AxsysRestClient(
         return try {
             getForEntity<TilgangV2DTO>(uri)
         } catch (e: Exception) {
-            incrementLoggFeil("axsys")
             throw OppslagException(
                 "Feil ved henting av enheter Nav identer har tilgang til",
                 "axsys.hentEnheterNavIdentHarTilgangTil",

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/AzureGraphRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/AzureGraphRestClient.kt
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Service
 import org.springframework.web.client.RestOperations
 import org.springframework.web.util.UriComponentsBuilder
 import java.net.URI
+import no.nav.familie.integrasjoner.felles.OppslagException
+import org.springframework.http.HttpStatus
 
 @Service
 class AzureGraphRestClient(
@@ -43,16 +45,26 @@ class AzureGraphRestClient(
                 },
             )
         } catch (e: Exception) {
-            incrementLoggFeil("azure.saksbehandler.navIdent")
-            throw e
+            throw OppslagException(
+                "Feil ved henting av saksbehandler med nav ident",
+                "azure.saksbehandler.navIdent",
+                OppslagException.Level.MEDIUM,
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                e
+            )
         }
 
     fun hentSaksbehandler(id: String): AzureAdBruker =
         try {
             getForEntity(saksbehandlerUri(id))
         } catch (e: Exception) {
-            incrementLoggFeil("azure.saksbehandler.id")
-            throw e
+            throw throw OppslagException(
+                "Feil ved henting av saksbehandler med id",
+                "azure.saksbehandler.id",
+                OppslagException.Level.MEDIUM,
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                e
+            )
         }
 
     companion object {

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivRestClient.kt
@@ -137,14 +137,19 @@ class DokarkivRestClient(
             try {
                 patchForEntity<String>(uri, FerdigstillJournalPost(journalførendeEnhet), headers(navIdent))
             } catch (e: RestClientResponseException) {
-                incrementLoggFeil("dokarkiv.ferdigstill.feil")
                 if (e.statusCode.value() == HttpStatus.BAD_REQUEST.value()) {
                     throw KanIkkeFerdigstilleJournalpostException(
                         "Kan ikke ferdigstille journalpost " +
                             "$journalpostId body ${e.responseBodyAsString}",
                     )
                 }
-                throw e
+                throw OppslagException(
+                    "Feil ved ferdigstilling av journalpost",
+                    "dokarkiv.ferdigstill.feil",
+                    OppslagException.Level.MEDIUM,
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    e
+                )
             }
         }
     }

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/DokdistRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/DokdistRestClient.kt
@@ -2,11 +2,12 @@ package no.nav.familie.integrasjoner.client.rest
 
 import no.nav.familie.http.client.AbstractPingableRestClient
 import no.nav.familie.http.util.UriUtil
-import no.nav.familie.integrasjoner.config.incrementLoggFeil
 import no.nav.familie.integrasjoner.dokdist.domene.DistribuerJournalpostRequestTo
 import no.nav.familie.integrasjoner.dokdist.domene.DistribuerJournalpostResponseTo
+import no.nav.familie.integrasjoner.felles.OppslagException
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestOperations
@@ -28,8 +29,13 @@ class DokdistRestClient(
             if (e is HttpClientErrorException.Gone) {
                 throw e
             } else {
-                incrementLoggFeil("dokdist.distribuer")
-                throw e
+                throw OppslagException(
+                    "Feil ved distribuering av journalpost",
+                    "dokdist.distribuer.distribuerJournalpost",
+                    OppslagException.Level.MEDIUM,
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    e,
+                )
             }
         }
 

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/DokdistkanalRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/DokdistkanalRestClient.kt
@@ -2,14 +2,15 @@ package no.nav.familie.integrasjoner.client.rest
 
 import no.nav.familie.http.client.AbstractPingableRestClient
 import no.nav.familie.http.util.UriUtil
-import no.nav.familie.integrasjoner.config.incrementLoggFeil
 import no.nav.familie.integrasjoner.dokdistkanal.domene.BestemDistribusjonskanalRequest
 import no.nav.familie.integrasjoner.dokdistkanal.domene.BestemDistribusjonskanalResponse
+import no.nav.familie.integrasjoner.felles.OppslagException
 import no.nav.familie.log.mdc.MDCConstants
 import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestOperations
 import java.net.URI
@@ -27,8 +28,13 @@ class DokdistkanalRestClient(
         try {
             postForEntity(uri, req, httpHeaders())
         } catch (e: Exception) {
-            incrementLoggFeil("dokdist.kanal")
-            throw e
+            throw OppslagException(
+                "Feil ved henting av distribusjonskanal",
+                "dokdist.kanal.bestemDistribusjonskanal",
+                OppslagException.Level.MEDIUM,
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                e,
+            )
         }
 
     private fun httpHeaders(): HttpHeaders =

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/MedlRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/MedlRestClient.kt
@@ -1,11 +1,12 @@
 package no.nav.familie.integrasjoner.client.rest
 
 import no.nav.familie.http.client.AbstractPingableRestClient
-import no.nav.familie.integrasjoner.config.incrementLoggFeil
+import no.nav.familie.integrasjoner.felles.OppslagException
 import no.nav.familie.integrasjoner.medlemskap.MedlemskapsunntakResponse
 import no.nav.familie.log.NavHttpHeaders
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestOperations
 import org.springframework.web.util.UriComponentsBuilder
@@ -39,9 +40,13 @@ class MedlRestClient(
         try {
             return getForEntity(medlemskapsunntakUri, httpHeaders)
         } catch (e: Exception) {
-            incrementLoggFeil("medl.unntak")
-
-            throw RuntimeException("Feil ved kall til MEDL2", e)
+            throw OppslagException(
+                "Feil ved henting av medlemskapsunntak",
+                "medl.unntak",
+                OppslagException.Level.MEDIUM,
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                e,
+            )
         }
     }
 

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/PdlClientCredentialRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/PdlClientCredentialRestClient.kt
@@ -2,6 +2,7 @@ package no.nav.familie.integrasjoner.client.rest
 
 import no.nav.familie.http.client.AbstractRestClient
 import no.nav.familie.http.util.UriUtil
+import no.nav.familie.integrasjoner.felles.OppslagException
 import no.nav.familie.integrasjoner.felles.graphqlQuery
 import no.nav.familie.integrasjoner.personopplysning.PdlRequestException
 import no.nav.familie.integrasjoner.personopplysning.internal.PdlBolkResponse
@@ -11,6 +12,7 @@ import no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonMedRelasj
 import no.nav.familie.kontrakter.felles.Tema
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.client.RestOperations
 import java.net.URI
@@ -36,11 +38,22 @@ class PdlClientCredentialRestClient(
                 query = HENT_PERSON_RELASJONER_ADRESSEBESKYTTELSE,
             )
         val response =
-            postForEntity<PdlBolkResponse<PdlPersonMedRelasjonerOgAdressebeskyttelse>>(
-                pdlUri,
-                request,
-                pdlHttpHeaders(tema),
-            )
+            try {
+                postForEntity<PdlBolkResponse<PdlPersonMedRelasjonerOgAdressebeskyttelse>>(
+                    pdlUri,
+                    request,
+                    pdlHttpHeaders(tema),
+                )
+            } catch (e: Exception) {
+                throw OppslagException(
+                    "Feil ved henting av person med relasjoner og adressebeskyttelse",
+                    "pdl.cc.hentPersonMedRelasjonerOgAdressebeskyttelse",
+                    OppslagException.Level.MEDIUM,
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    e,
+                )
+            }
+
         return feilsjekkOgReturnerData(response)
     }
 

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/PdlRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/PdlRestClient.kt
@@ -49,11 +49,21 @@ class PdlRestClient(
             )
 
         val response: PdlResponse<PdlPersonMedAdressebeskyttelse> =
-            postForEntity(
-                pdlUri,
-                pdlAdressebeskyttelseRequest,
-                pdlHttpHeaders(tema),
-            )
+            try {
+                postForEntity(
+                    pdlUri,
+                    pdlAdressebeskyttelseRequest,
+                    pdlHttpHeaders(tema),
+                )
+            } catch (e: Exception) {
+                throw pdlOppslagException(
+                    personIdent = personIdent,
+                    httpStatus = HttpStatus.INTERNAL_SERVER_ERROR,
+                    error = e,
+                    feilmelding = "Feil ved henting av adressebeskyttelse",
+                    kilde = "PdlRestClient.hentAdressebeskyttelse",
+                )
+            }
 
         return feilsjekkOgReturnerData(response, personIdent, kilde = "PdlRestClient.hentAdressebeskyttelse") { it.person }
     }

--- a/src/main/java/no/nav/familie/integrasjoner/config/ApiExceptionHandler.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/config/ApiExceptionHandler.kt
@@ -47,8 +47,8 @@ class ApiExceptionHandler {
 
     @ExceptionHandler(RestClientResponseException::class)
     fun handleRestClientResponseException(e: RestClientResponseException): ResponseEntity<Ressurs<Any>> {
-        secureLogger.error("RestClientResponseException : ${e.responseBodyAsString}", e)
-        logger.error(
+        secureLogger.warn("RestClientResponseException : ${e.responseBodyAsString}", e)
+        logger.warn(
             "RestClientResponseException : {} {} {}",
             e.statusCode.value(),
             e.statusText,

--- a/src/test/java/no/nav/familie/integrasjoner/arbeidsfordeling/ArbeidsfordelingRestClientTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/arbeidsfordeling/ArbeidsfordelingRestClientTest.kt
@@ -24,7 +24,7 @@ class ArbeidsfordelingRestClientTest {
         @Test
         fun `skal kaste OppslagException ved feil mot Norg2`() {
             // Arrange
-            every { restOperations.exchange<NavKontorEnhet>(any<URI>(), eq(HttpMethod.GET)) } throws RuntimeException("Noe gikk galt")
+            every { restOperations.exchange<NavKontorEnhet>(any<URI>(), eq(HttpMethod.GET), any<HttpEntity<Void>>()) } throws RuntimeException("Noe gikk galt")
 
             // Act & Assert
             val oppslagException = assertThrows<OppslagException> { arbeidsfordelingRestClient.hentEnhet("oslo") }
@@ -41,7 +41,7 @@ class ArbeidsfordelingRestClientTest {
         @Test
         fun `skal kaste OppslagException ved feil mot Norg2`() {
             // Arrange
-            every { restOperations.exchange<NavKontorEnhet>(any<URI>(), eq(HttpMethod.GET)) } throws RuntimeException("Noe gikk galt")
+            every { restOperations.exchange<NavKontorEnhet>(any<URI>(), eq(HttpMethod.GET), any<HttpEntity<Void>>()) } throws RuntimeException("Noe gikk galt")
 
             // Act & Assert
             val oppslagException = assertThrows<OppslagException> { arbeidsfordelingRestClient.hentNavkontor("1234") }

--- a/src/test/java/no/nav/familie/integrasjoner/arbeidsfordeling/ArbeidsfordelingRestClientTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/arbeidsfordeling/ArbeidsfordelingRestClientTest.kt
@@ -1,0 +1,82 @@
+package no.nav.familie.integrasjoner.arbeidsfordeling
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.integrasjoner.felles.OppslagException
+import no.nav.familie.kontrakter.felles.navkontor.NavKontorEnhet
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.web.client.RestOperations
+import org.springframework.web.client.exchange
+import java.net.URI
+
+class ArbeidsfordelingRestClientTest {
+    private val restOperations: RestOperations = mockk()
+    private val arbeidsfordelingRestClient: ArbeidsfordelingRestClient = ArbeidsfordelingRestClient(URI.create("norg2"), restOperations)
+
+    @Nested
+    inner class HentEnhet {
+        @Test
+        fun `skal kaste OppslagException ved feil mot Norg2`() {
+            // Arrange
+            every { restOperations.exchange<NavKontorEnhet>(any<URI>(), eq(HttpMethod.GET)) } throws RuntimeException("Noe gikk galt")
+
+            // Act & Assert
+            val oppslagException = assertThrows<OppslagException> { arbeidsfordelingRestClient.hentEnhet("oslo") }
+
+            assertThat(oppslagException.message).isEqualTo("Feil ved henting av enhet")
+            assertThat(oppslagException.kilde).isEqualTo("norg2.hentEnhet")
+            assertThat(oppslagException.level).isEqualTo(OppslagException.Level.MEDIUM)
+            assertThat(oppslagException.httpStatus).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        }
+    }
+
+    @Nested
+    inner class HentNavkontor {
+        @Test
+        fun `skal kaste OppslagException ved feil mot Norg2`() {
+            // Arrange
+            every { restOperations.exchange<NavKontorEnhet>(any<URI>(), eq(HttpMethod.GET)) } throws RuntimeException("Noe gikk galt")
+
+            // Act & Assert
+            val oppslagException = assertThrows<OppslagException> { arbeidsfordelingRestClient.hentNavkontor("1234") }
+
+            assertThat(oppslagException.message).isEqualTo("Feil ved henting av navkontor")
+            assertThat(oppslagException.kilde).isEqualTo("norg2.hentNavkontor")
+            assertThat(oppslagException.level).isEqualTo(OppslagException.Level.MEDIUM)
+            assertThat(oppslagException.httpStatus).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        }
+    }
+
+    @Nested
+    inner class FinnBehandlendeEnhetMedBesteMatch {
+        @Test
+        fun `skal kaste OppslagException ved feil mot Norg2`() {
+            // Arrange
+            every { restOperations.exchange<List<NavKontorEnhet>>(any<URI>(), eq(HttpMethod.POST), any<HttpEntity<ArbeidsfordelingKriterie>>()) } throws RuntimeException("Noe gikk galt")
+
+            // Act & Assert
+            val oppslagException =
+                assertThrows<OppslagException> {
+                    arbeidsfordelingRestClient.finnBehandlendeEnhetMedBesteMatch(
+                        ArbeidsfordelingKriterie(
+                            "",
+                            geografiskOmraade = "Oslo",
+                            diskresjonskode = null,
+                            skjermet = false,
+                        ),
+                    )
+                }
+
+            assertThat(oppslagException.message).isEqualTo("Feil ved oppslag av best matchende behandlende enhet")
+            assertThat(oppslagException.kilde).isEqualTo("norg2.finnBehandlendeEnhetMedBesteMatch")
+            assertThat(oppslagException.level).isEqualTo(OppslagException.Level.MEDIUM)
+            assertThat(oppslagException.httpStatus).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        }
+    }
+}

--- a/src/test/java/no/nav/familie/integrasjoner/client/rest/AxsysRestClientTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/client/rest/AxsysRestClientTest.kt
@@ -1,0 +1,43 @@
+package no.nav.familie.integrasjoner.client.rest
+
+import io.mockk.every
+import io.mockk.mockk
+import java.net.URI
+import no.nav.familie.integrasjoner.axsys.TilgangV2DTO
+import no.nav.familie.integrasjoner.felles.OppslagException
+import no.nav.familie.kontrakter.felles.NavIdent
+import no.nav.familie.kontrakter.felles.navkontor.NavKontorEnhet
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.web.client.RestOperations
+import org.springframework.web.client.exchange
+
+class AxsysRestClientTest {
+    private val restOperations: RestOperations = mockk()
+    private val axsysRestClient: AxsysRestClient = AxsysRestClient(
+        enhetBaseUrl = URI("http://localhost:8080"),
+        restTemplate = restOperations
+    )
+
+    @Nested
+    inner class HentEnheterNavIdentHarTilgangTil {
+        @Test
+        fun `skal kaste OppslagException ved feil mot axsys`() {
+            // Arrange
+            every { restOperations.exchange<TilgangV2DTO>(any<URI>(), eq(HttpMethod.GET), any<HttpEntity<Void>>()) } throws RuntimeException("Noe gikk galt")
+
+            // Act & Assert
+            val oppslagException = assertThrows<OppslagException> { axsysRestClient.hentEnheterNavIdentHarTilgangTil(NavIdent("1234")) }
+
+            assertThat(oppslagException.message).isEqualTo("Feil ved henting av enheter Nav identer har tilgang til")
+            assertThat(oppslagException.kilde).isEqualTo("axsys.hentEnheterNavIdentHarTilgangTil")
+            assertThat(oppslagException.level).isEqualTo(OppslagException.Level.MEDIUM)
+            assertThat(oppslagException.httpStatus).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        }
+    }
+}

--- a/src/test/java/no/nav/familie/integrasjoner/client/rest/AzureGraphRestClientTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/client/rest/AzureGraphRestClientTest.kt
@@ -1,0 +1,61 @@
+package no.nav.familie.integrasjoner.client.rest
+
+import io.mockk.every
+import io.mockk.mockk
+import java.net.URI
+import no.nav.familie.integrasjoner.axsys.TilgangV2DTO
+import no.nav.familie.integrasjoner.azure.domene.AzureAdBruker
+import no.nav.familie.integrasjoner.azure.domene.AzureAdBrukere
+import no.nav.familie.integrasjoner.felles.OppslagException
+import no.nav.familie.kontrakter.felles.NavIdent
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.web.client.RestOperations
+import org.springframework.web.client.exchange
+
+class AzureGraphRestClientTest {
+    private val restOperations: RestOperations = mockk()
+    private val azureGraphRestClient: AzureGraphRestClient = AzureGraphRestClient(
+        restTemplate = restOperations,
+        aadGraphURI = URI("http://localhost:8080"),
+    )
+
+    @Nested
+    inner class FinnSaksbehandler {
+        @Test
+        fun `skal kaste OppslagException ved feil mot azure`() {
+            // Arrange
+            every { restOperations.exchange<AzureAdBrukere>(any<URI>(), eq(HttpMethod.GET), any<HttpEntity<Void>>()) } throws RuntimeException("Noe gikk galt")
+
+            // Act & Assert
+            val oppslagException = assertThrows<OppslagException> { azureGraphRestClient.finnSaksbehandler("1234") }
+
+            assertThat(oppslagException.message).isEqualTo("Feil ved henting av saksbehandler med nav ident")
+            assertThat(oppslagException.kilde).isEqualTo("azure.saksbehandler.navIdent")
+            assertThat(oppslagException.level).isEqualTo(OppslagException.Level.MEDIUM)
+            assertThat(oppslagException.httpStatus).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        }
+    }
+
+    @Nested
+    inner class HentSaksbehandler {
+        @Test
+        fun `skal kaste OppslagException ved feil mot azure`() {
+            // Arrange
+            every { restOperations.exchange<AzureAdBruker>(any<URI>(), eq(HttpMethod.GET), any<HttpEntity<Void>>()) } throws RuntimeException("Noe gikk galt")
+
+            // Act & Assert
+            val oppslagException = assertThrows<OppslagException> { azureGraphRestClient.hentSaksbehandler("1234") }
+
+            assertThat(oppslagException.message).isEqualTo("Feil ved henting av saksbehandler med id")
+            assertThat(oppslagException.kilde).isEqualTo("azure.saksbehandler.id")
+            assertThat(oppslagException.level).isEqualTo(OppslagException.Level.MEDIUM)
+            assertThat(oppslagException.httpStatus).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        }
+    }
+}

--- a/src/test/java/no/nav/familie/integrasjoner/client/rest/DokarkivRestClientTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/client/rest/DokarkivRestClientTest.kt
@@ -1,0 +1,69 @@
+package no.nav.familie.integrasjoner.client.rest
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import java.net.URI
+import no.nav.familie.integrasjoner.azure.domene.AzureAdBrukere
+import no.nav.familie.integrasjoner.dokarkiv.client.domene.FerdigstillJournalPost
+import no.nav.familie.integrasjoner.felles.MDCOperations
+import no.nav.familie.integrasjoner.felles.OppslagException
+import no.nav.familie.log.mdc.MDCConstants.MDC_CALL_ID
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.slf4j.MDC
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.web.client.RestClientResponseException
+import org.springframework.web.client.RestOperations
+import org.springframework.web.client.exchange
+
+class DokarkivRestClientTest {
+    private val restOperations: RestOperations = mockk()
+    private val dokarkivRestClient: DokarkivRestClient = DokarkivRestClient(
+        dokarkivUrl = URI("http://localhost:8080/dokarkiv"),
+        restOperations = restOperations,
+    )
+
+    @BeforeEach
+    fun setUp() {
+        mockkStatic(MDC::class)
+        every { MDC.get(MDC_CALL_ID) } returns "123-321-412"
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(MDC::class)
+    }
+
+    @Nested
+    inner class FerdigstillJournalpost {
+        @Test
+        fun `skal kaste OppslagException ved feil mot dokarkiv`() {
+            // Arrange
+            every { restOperations.exchange<String>(any<URI>(), eq(HttpMethod.PATCH), any<HttpEntity<FerdigstillJournalPost>>()) } throws RestClientResponseException(
+                "Noe gikk galt",
+                HttpStatus.NOT_FOUND,
+                "bad request",
+                null,
+                null,
+                null
+            )
+
+            // Act & Assert
+            val oppslagException = assertThrows<OppslagException> { dokarkivRestClient.ferdigstillJournalpost("1234", "oslo", "4321") }
+
+            assertThat(oppslagException.message).isEqualTo("Feil ved ferdigstilling av journalpost")
+            assertThat(oppslagException.kilde).isEqualTo("dokarkiv.ferdigstill.feil")
+            assertThat(oppslagException.level).isEqualTo(OppslagException.Level.MEDIUM)
+            assertThat(oppslagException.httpStatus).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        }
+    }
+}

--- a/src/test/java/no/nav/familie/integrasjoner/client/rest/DokdistRestClientTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/client/rest/DokdistRestClientTest.kt
@@ -1,0 +1,54 @@
+package no.nav.familie.integrasjoner.client.rest
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.integrasjoner.dokdist.domene.DistribuerJournalpostRequestTo
+import no.nav.familie.integrasjoner.dokdist.domene.DistribuerJournalpostResponseTo
+import no.nav.familie.integrasjoner.felles.OppslagException
+import no.nav.familie.kontrakter.felles.Fagsystem
+import no.nav.familie.kontrakter.felles.dokdist.Distribusjonstidspunkt
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.web.client.RestOperations
+import org.springframework.web.client.exchange
+import java.net.URI
+
+class DokdistRestClientTest {
+    private val restOperations: RestOperations = mockk()
+    private val dokdistRestClient: DokdistRestClient = DokdistRestClient(dokdistUri = URI.create("dokdistkanal"), restTemplate = restOperations)
+
+    @Nested
+    inner class DistribuerJournalpost {
+        @Test
+        fun `skal kaste OppslagException når kall mot dokdist feiler`() {
+            // Arrange
+            every { restOperations.exchange<DistribuerJournalpostResponseTo?>(any<URI>(), eq(HttpMethod.POST), any<HttpEntity<DistribuerJournalpostRequestTo>>()) } throws RuntimeException("Noe gikk galt")
+
+            // Act & Assert
+            val oppslagException =
+                assertThrows<OppslagException> {
+                    dokdistRestClient.distribuerJournalpost(
+                        DistribuerJournalpostRequestTo(
+                            journalpostId = "",
+                            batchId = null,
+                            bestillendeFagsystem = Fagsystem.BA.navn,
+                            adresse = null,
+                            dokumentProdApp = "",
+                            distribusjonstype = null,
+                            distribusjonstidspunkt = Distribusjonstidspunkt.KJERNETID,
+                        ),
+                    )
+                }
+
+            assertThat(oppslagException.message).isEqualTo("Feil ved distribuering av journalpost")
+            assertThat(oppslagException.kilde).isEqualTo("dokdist.distribuer.distribuerJournalpost")
+            assertThat(oppslagException.level).isEqualTo(OppslagException.Level.MEDIUM)
+            assertThat(oppslagException.httpStatus).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        }
+    }
+}

--- a/src/test/java/no/nav/familie/integrasjoner/client/rest/DokdistkanalRestClientTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/client/rest/DokdistkanalRestClientTest.kt
@@ -1,0 +1,52 @@
+package no.nav.familie.integrasjoner.client.rest
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.integrasjoner.dokdistkanal.domene.BestemDistribusjonskanalRequest
+import no.nav.familie.integrasjoner.dokdistkanal.domene.BestemDistribusjonskanalResponse
+import no.nav.familie.integrasjoner.felles.OppslagException
+import no.nav.familie.kontrakter.felles.Tema
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.web.client.RestOperations
+import org.springframework.web.client.exchange
+import java.net.URI
+
+class DokdistkanalRestClientTest {
+    private val restOperations: RestOperations = mockk()
+    private val dokdistkanalRestClient: DokdistkanalRestClient = DokdistkanalRestClient(dokdistkanalUri = URI.create("dokdistkanal"), restTemplate = restOperations)
+
+    @Nested
+    inner class BestemDistribusjonskanal {
+        @Test
+        fun `skal kaste OppslagException ved feil mot dokdistkanal`() {
+            // Arrange
+            every { restOperations.exchange<BestemDistribusjonskanalResponse>(any<URI>(), eq(HttpMethod.POST), any<HttpEntity<BestemDistribusjonskanalRequest>>()) } throws RuntimeException("Noe gikk galt")
+
+            // Act & Assert
+            val oppslagException =
+                assertThrows<OppslagException> {
+                    dokdistkanalRestClient.bestemDistribusjonskanal(
+                        BestemDistribusjonskanalRequest(
+                            brukerId = "12345678910",
+                            mottakerId = "12345678911",
+                            tema = Tema.BAR,
+                            dokumenttypeId = null,
+                            erArkivert = null,
+                            forsendelseStørrelse = null,
+                        ),
+                    )
+                }
+
+            assertThat(oppslagException.message).isEqualTo("Feil ved henting av distribusjonskanal")
+            assertThat(oppslagException.kilde).isEqualTo("dokdist.kanal.bestemDistribusjonskanal")
+            assertThat(oppslagException.level).isEqualTo(OppslagException.Level.MEDIUM)
+            assertThat(oppslagException.httpStatus).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        }
+    }
+}

--- a/src/test/java/no/nav/familie/integrasjoner/client/rest/MedlRestClientTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/client/rest/MedlRestClientTest.kt
@@ -1,0 +1,41 @@
+package no.nav.familie.integrasjoner.client.rest
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.integrasjoner.felles.OppslagException
+import no.nav.familie.integrasjoner.medlemskap.MedlemskapsunntakResponse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.web.client.RestOperations
+import org.springframework.web.client.exchange
+import java.net.URI
+
+class MedlRestClientTest {
+    private val restOperations: RestOperations = mockk()
+    private val medlRestClient: MedlRestClient = MedlRestClient(medl2BaseUrl = URI.create("medl"), restTemplate = restOperations)
+
+    @Nested
+    inner class HentMedlemskapsUnntakResponse {
+        @Test
+        fun `skal kaste OppslagException hvis henting av medlemskapsunntak feiler`() {
+            // Arrange
+            every { restOperations.exchange<List<MedlemskapsunntakResponse>>(any<URI>(), eq(HttpMethod.GET), any<HttpEntity<Void>>()) } throws RuntimeException("Noe gikk galt")
+
+            // Act & Assert
+            val oppslagException =
+                assertThrows<OppslagException> {
+                    medlRestClient.hentMedlemskapsUnntakResponse(aktørId = "1234")
+                }
+
+            assertThat(oppslagException.message).isEqualTo("Feil ved henting av medlemskapsunntak")
+            assertThat(oppslagException.kilde).isEqualTo("medl.unntak")
+            assertThat(oppslagException.level).isEqualTo(OppslagException.Level.MEDIUM)
+            assertThat(oppslagException.httpStatus).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        }
+    }
+}

--- a/src/test/java/no/nav/familie/integrasjoner/client/rest/PdlClientCredentialRestClientTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/client/rest/PdlClientCredentialRestClientTest.kt
@@ -1,0 +1,44 @@
+package no.nav.familie.integrasjoner.client.rest
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.integrasjoner.felles.OppslagException
+import no.nav.familie.integrasjoner.personopplysning.internal.PdlBolkResponse
+import no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonBolkRequest
+import no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonMedRelasjonerOgAdressebeskyttelse
+import no.nav.familie.kontrakter.felles.Tema
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.web.client.RestOperations
+import org.springframework.web.client.exchange
+import java.net.URI
+
+class PdlClientCredentialRestClientTest {
+    private val restOperations: RestOperations = mockk()
+    private val pdlClientCredentialRestClient: PdlClientCredentialRestClient = PdlClientCredentialRestClient(pdlBaseUrl = URI.create("pdl"), restTemplate = restOperations)
+
+    @Nested
+    inner class HentPersonMedRelasjonerOgAdressebeskyttelse {
+        @Test
+        fun `skal kaste OppslagException når kall mot PDL feiler`() {
+            // Arrange
+            every { restOperations.exchange<PdlBolkResponse<PdlPersonMedRelasjonerOgAdressebeskyttelse>>(any<URI>(), eq(HttpMethod.POST), any<HttpEntity<PdlPersonBolkRequest>>()) } throws RuntimeException("Noe gikk galt")
+
+            // Act & Assert
+            val oppslagException =
+                assertThrows<OppslagException> {
+                    pdlClientCredentialRestClient.hentPersonMedRelasjonerOgAdressebeskyttelse(listOf("12345678910"), Tema.BAR)
+                }
+
+            assertThat(oppslagException.message).isEqualTo("Feil ved henting av person med relasjoner og adressebeskyttelse")
+            assertThat(oppslagException.kilde).isEqualTo("pdl.cc.hentPersonMedRelasjonerOgAdressebeskyttelse")
+            assertThat(oppslagException.level).isEqualTo(OppslagException.Level.MEDIUM)
+            assertThat(oppslagException.httpStatus).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        }
+    }
+}

--- a/src/test/java/no/nav/familie/integrasjoner/client/rest/PdlRestClientTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/client/rest/PdlRestClientTest.kt
@@ -1,13 +1,30 @@
 package no.nav.familie.integrasjoner.client.rest
 
 import com.fasterxml.jackson.module.kotlin.readValue
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.integrasjoner.felles.OppslagException
 import no.nav.familie.integrasjoner.geografisktilknytning.PdlHentGeografiskTilknytning
+import no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonMedAdressebeskyttelse
+import no.nav.familie.integrasjoner.personopplysning.internal.PdlPersonRequest
 import no.nav.familie.integrasjoner.personopplysning.internal.PdlResponse
+import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.objectMapper
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.web.client.RestOperations
+import org.springframework.web.client.exchange
+import java.net.URI
 
 class PdlRestClientTest {
+    private val restOperations: RestOperations = mockk()
+    private val pdlRestClient: PdlRestClient = PdlRestClient(pdlBaseUrl = URI.create("pdl"), restTemplate = restOperations)
+
     @Test
     fun `skal parse harUnathorizedFeil`() {
         val response: PdlResponse<PdlHentGeografiskTilknytning> = objectMapper.readValue<PdlResponse<PdlHentGeografiskTilknytning>>(jsonFeilmelding)
@@ -15,6 +32,26 @@ class PdlRestClientTest {
         assertThat(response.harUnauthorizedFeil()).isTrue()
         val detaljertFeilmeldingFraPdl = response.errors?.joinToString { it.extensions.toString() }
         assertThat(detaljertFeilmeldingFraPdl).contains("adressebeskyttelse_strengt_fortrolig_adresse")
+    }
+
+    @Nested
+    inner class HentAdressebeskyttelse {
+        @Test
+        fun `skal kaste OppslagException hvis kall mot PDL feiler`() {
+            // Arrange
+            every { restOperations.exchange<PdlResponse<PdlPersonMedAdressebeskyttelse>>(any<URI>(), eq(HttpMethod.POST), any<HttpEntity<PdlPersonRequest>>()) } throws RuntimeException("Noe gikk galt")
+
+            // Act & Assert
+            val oppslagException =
+                assertThrows<OppslagException> {
+                    pdlRestClient.hentAdressebeskyttelse("12345678910", Tema.BAR)
+                }
+
+            assertThat(oppslagException.message).isEqualTo("Feil ved henting av adressebeskyttelse")
+            assertThat(oppslagException.kilde).isEqualTo("PdlRestClient.hentAdressebeskyttelse")
+            assertThat(oppslagException.level).isEqualTo(OppslagException.Level.MEDIUM)
+            assertThat(oppslagException.httpStatus).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        }
     }
 
     /**

--- a/src/test/java/no/nav/familie/integrasjoner/dokdistkanal/DokdistkanalControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/dokdistkanal/DokdistkanalControllerTest.kt
@@ -90,7 +90,7 @@ class DokdistkanalControllerTest : OppslagSpringRunnerTest() {
             )
 
         assertThat(response?.status).isEqualTo(Ressurs.Status.FEILET)
-        assertThat(response?.melding).contains("Noe gikk galt")
+        assertThat(response?.melding).contains("Feil ved henting av distribusjonskanal")
     }
 
     @Test


### PR DESCRIPTION
Vi ønsker å unngå at det logges `error` når kall mot eksterne tjenester feiler. For å allikevel kunne trigge alarmer ved feil, er det tidligere utviklet en egen exception `OppslagException` med tilhørende exception-handler, som sørger for at vi kun logger `warning` og at vi oppdaterer en metrikk for antall feil når denne kastes.

Vi legger her til `OppslagException` i en del klienter som tidligere ville truffet "default"-handler og logget `error`.