### PR TITLE
Legger ved feilmelding dersom vi mottar unautorized fra pdl

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/PdlRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/PdlRestClient.kt
@@ -125,7 +125,8 @@ class PdlRestClient(
             }
             if (pdlResponse.harUnauthorizedFeil()) {
                 secureLogger.info("Har ikke tilgang til person med ident=$personIdent i PDL")
-                throw PdlUnauthorizedException()
+                val pdlUnauthorizedDetails = pdlResponse.tilPdlUnauthorizedDetails().first()
+                throw PdlUnauthorizedException(melding = pdlUnauthorizedDetails.cause ?: pdlUnauthorizedDetails.policy)
             }
             throw pdlOppslagException(
                 feilmelding = "Feil ved oppslag på person: ${pdlResponse.errorMessages()}. Se secureLogs for mer info.",
@@ -185,7 +186,8 @@ class PdlRestClient(
                 if (response.harUnauthorizedFeil()) {
                     secureLogger.info("Har ikke tilgang til å hente geografisk tilknytning for ident=$personIdent i PDL. Ekstra info: ${response.errors?.joinToString { it.extensions.toString() } ?: "Ingen detaljer"}")
                     secureLogger.error("Ikke tilgang til oppslag på geografisk tilknytning på person. Feilmelding fra PDL: ${response.errorMessages()}")
-                    throw PdlUnauthorizedException()
+                    val pdlUnauthorizedDetails = response.tilPdlUnauthorizedDetails().first()
+                    throw PdlUnauthorizedException(melding = pdlUnauthorizedDetails.cause ?: pdlUnauthorizedDetails.policy)
                 }
                 throw pdlOppslagException(
                     feilmelding = "Feil ved oppslag på geografisk tilknytning på person: ${response.errorMessages()}",

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/PdlRequestException.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/PdlRequestException.kt
@@ -6,4 +6,6 @@ open class PdlRequestException(
 
 class PdlNotFoundException : PdlRequestException()
 
-class PdlUnauthorizedException : PdlRequestException()
+class PdlUnauthorizedException(
+    melding: String,
+) : PdlRequestException(melding = melding)

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlResponse.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlResponse.kt
@@ -17,6 +17,9 @@ data class PdlResponse<T>(
     fun harNotFoundFeil(): Boolean = errors?.any { it.extensions?.notFound() == true } ?: false
 
     fun harUnauthorizedFeil(): Boolean = errors?.any { it.extensions?.unauthorized() == true } ?: false
+
+    fun tilPdlUnauthorizedDetails(): List<PdlUnauthorizedDetails> =
+        errors?.filter { it.extensions?.unauthorized() == true }?.map { it.extensions?.details as PdlUnauthorizedDetails } ?: emptyList()
 }
 
 data class PersonDataBolk<T>(
@@ -79,6 +82,12 @@ data class PdlErrorExtensions(
 
     fun unauthorized() = code == "unauthorized"
 }
+
+data class PdlUnauthorizedDetails(
+    val type: String?,
+    val cause: String?,
+    val policy: String,
+)
 
 data class PdlExtensions(
     val warnings: List<PdlWarning>?,

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlResponse.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlResponse.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.integrasjoner.personopplysning.internal
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.kontrakter.felles.personopplysning.SIVILSTANDTYPE
 
 data class PdlResponse<T>(
@@ -19,7 +20,7 @@ data class PdlResponse<T>(
     fun harUnauthorizedFeil(): Boolean = errors?.any { it.extensions?.unauthorized() == true } ?: false
 
     fun tilPdlUnauthorizedDetails(): List<PdlUnauthorizedDetails> =
-        errors?.filter { it.extensions?.unauthorized() == true }?.map { it.extensions?.details as PdlUnauthorizedDetails } ?: emptyList()
+        errors?.filter { it.extensions?.unauthorized() == true }?.mapNotNull { it.extensions?.details?.let { details -> objectMapper.convertValue(details, PdlUnauthorizedDetails::class.java) } } ?: emptyList()
 }
 
 data class PersonDataBolk<T>(

--- a/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollService.kt
@@ -23,6 +23,10 @@ class CachedTilgangskontrollService(
     private val personopplysningerService: PersonopplysningerService,
     private val tilgangConfig: TilgangConfig,
 ) {
+    init {
+        logger.info(tilgangConfig.kode6.beskrivelse)
+    }
+
     @Cacheable(
         cacheNames = [TILGANG_TIL_BRUKER],
         key = "#jwtToken.subject.concat(#personIdent)",
@@ -37,7 +41,7 @@ class CachedTilgangskontrollService(
             val adressebeskyttelse = personopplysningerService.hentAdressebeskyttelse(personIdent, tema).gradering
             hentTilgang(adressebeskyttelse, jwtToken, personIdent) { egenAnsattService.erEgenAnsatt(personIdent) }
         } catch (pdlUnauthorizedException: PdlUnauthorizedException) {
-            Tilgang(personIdent = personIdent, harTilgang = false)
+            Tilgang(personIdent = personIdent, harTilgang = false, begrunnelse = pdlUnauthorizedException.message)
         }
 
     @Cacheable(
@@ -113,6 +117,7 @@ class CachedTilgangskontrollService(
 
     companion object {
         private val secureLogger = LoggerFactory.getLogger("secureLogger")
+        private val logger = LoggerFactory.getLogger(CachedTilgangskontrollService::class.java)
 
         const val TILGANG_TIL_BRUKER = "tilgangTilBruker"
     }

--- a/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollService.kt
@@ -23,10 +23,6 @@ class CachedTilgangskontrollService(
     private val personopplysningerService: PersonopplysningerService,
     private val tilgangConfig: TilgangConfig,
 ) {
-    init {
-        logger.info(tilgangConfig.kode6.beskrivelse)
-    }
-
     @Cacheable(
         cacheNames = [TILGANG_TIL_BRUKER],
         key = "#jwtToken.subject.concat(#personIdent)",

--- a/src/test/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlResponseTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlResponseTest.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.integrasjoner.personopplysning.internal
 
 import io.mockk.mockk
+import no.nav.familie.kontrakter.felles.objectMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Nested
@@ -12,11 +13,12 @@ class PdlResponseTest {
         @Test
         fun `skal hente ut PdlUnauthorizedDetails fra PdlResponse`() {
             // Arrange
-            val forventetUnauthorizedDetails: Any =
-                PdlUnauthorizedDetails(
-                    type = "pdl-tilgangsstyring",
-                    cause = "Bruker mangler rollen '0000-GA-Strengt_Fortrolig_Adresse'",
-                    policy = "adressebeskyttelse_strengt_fortrolig_adresse",
+            // Details blir deserialisert til `LinkedHashMap` når verdien er Any.
+            val unauthorizedDetailsSomLinkedHashMap: Any =
+                linkedMapOf(
+                    "type" to "pdl-tilgangsstyring",
+                    "cause" to "Bruker mangler rollen '0000-GA-Strengt_Fortrolig_Adresse'",
+                    "policy" to "adressebeskyttelse_strengt_fortrolig_adresse",
                 )
 
             val pdlResponse =
@@ -29,7 +31,7 @@ class PdlResponseTest {
                                 extensions =
                                     PdlErrorExtensions(
                                         code = "unauthorized",
-                                        details = forventetUnauthorizedDetails,
+                                        details = unauthorizedDetailsSomLinkedHashMap,
                                     ),
                             ),
                         ),
@@ -41,7 +43,7 @@ class PdlResponseTest {
 
             // Assert
             assertNotNull(pdlUnauthorizedDetails)
-            assertThat(pdlUnauthorizedDetails).isEqualTo(listOf(forventetUnauthorizedDetails))
+            assertThat(pdlUnauthorizedDetails).isEqualTo(listOf(objectMapper.convertValue(unauthorizedDetailsSomLinkedHashMap, PdlUnauthorizedDetails::class.java)))
         }
     }
 }

--- a/src/test/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlResponseTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/personopplysning/internal/PdlResponseTest.kt
@@ -1,0 +1,47 @@
+package no.nav.familie.integrasjoner.personopplysning.internal
+
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class PdlResponseTest {
+    @Nested
+    inner class TilPdlUnauthorizedDetails {
+        @Test
+        fun `skal hente ut PdlUnauthorizedDetails fra PdlResponse`() {
+            // Arrange
+            val forventetUnauthorizedDetails: Any =
+                PdlUnauthorizedDetails(
+                    type = "pdl-tilgangsstyring",
+                    cause = "Bruker mangler rollen '0000-GA-Strengt_Fortrolig_Adresse'",
+                    policy = "adressebeskyttelse_strengt_fortrolig_adresse",
+                )
+
+            val pdlResponse =
+                PdlResponse<Any>(
+                    data = mockk(),
+                    errors =
+                        listOf(
+                            PdlError(
+                                message = "Ikke tilgang til å se person",
+                                extensions =
+                                    PdlErrorExtensions(
+                                        code = "unauthorized",
+                                        details = forventetUnauthorizedDetails,
+                                    ),
+                            ),
+                        ),
+                    extensions = null,
+                )
+
+            // Act
+            val pdlUnauthorizedDetails: List<PdlUnauthorizedDetails> = pdlResponse.tilPdlUnauthorizedDetails()
+
+            // Assert
+            assertNotNull(pdlUnauthorizedDetails)
+            assertThat(pdlUnauthorizedDetails).isEqualTo(listOf(forventetUnauthorizedDetails))
+        }
+    }
+}


### PR DESCRIPTION
Favro: [NAV-23889](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23889)

Når vi skal sjekke om en saksbehandler har tilgang til en eller flere identer vil kallet mot PDL feile med 403 dersom de ikke har tilgang. For å kunne si noe mer enn at saksbehandler ikke har tilgang legger vi her på litt mer informasjon fra responsen vi mottar fra PDL.