### PR TITLE
Lagt til endepunkt, POC

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/azure/domene/AzureAdBrukere.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/azure/domene/AzureAdBrukere.kt
@@ -3,3 +3,12 @@ package no.nav.familie.integrasjoner.azure.domene
 data class AzureAdBrukere(
     val value: List<AzureAdBruker>,
 )
+
+data class AzureAdGruppe(
+    val id: String,
+    val displayName: String?,
+)
+
+data class AzureAdGrupper(
+    val value: List<AzureAdGruppe>,
+)

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/AzureGraphRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/AzureGraphRestClient.kt
@@ -3,6 +3,7 @@ package no.nav.familie.integrasjoner.client.rest
 import no.nav.familie.http.client.AbstractRestClient
 import no.nav.familie.integrasjoner.azure.domene.AzureAdBruker
 import no.nav.familie.integrasjoner.azure.domene.AzureAdBrukere
+import no.nav.familie.integrasjoner.azure.domene.AzureAdGrupper
 import no.nav.familie.integrasjoner.felles.OppslagException
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
@@ -35,6 +36,15 @@ class AzureGraphRestClient(
             .buildAndExpand(navIdent)
             .toUri()
 
+    private fun hentGruppeneTilSaksbehandlerUri(azureUUID: String): URI =
+        UriComponentsBuilder
+            .fromUri(aadGraphURI)
+            .pathSegment(USERS)
+            .pathSegment(azureUUID)
+            .pathSegment(GRUPPER)
+            .build()
+            .toUri()
+
     fun finnSaksbehandler(navIdent: String): AzureAdBrukere =
         try {
             getForEntity(
@@ -47,6 +57,24 @@ class AzureGraphRestClient(
             throw OppslagException(
                 "Feil ved henting av saksbehandler med nav ident",
                 "azure.saksbehandler.navIdent",
+                OppslagException.Level.MEDIUM,
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                e,
+            )
+        }
+
+    fun hentGruppeneTilSaksbehandler(azureId: String): AzureAdGrupper =
+        try {
+            getForEntity(
+                hentGruppeneTilSaksbehandlerUri(azureId),
+                HttpHeaders().apply {
+                    add("ConsistencyLevel", "eventual")
+                },
+            )
+        } catch (e: Exception) {
+            throw OppslagException(
+                "Feil ved henting av saksbehandlers grupper med azure id",
+                "azure.saksbehandler.id",
                 OppslagException.Level.MEDIUM,
                 HttpStatus.INTERNAL_SERVER_ERROR,
                 e,
@@ -67,7 +95,6 @@ class AzureGraphRestClient(
         }
 
     companion object {
-        private const val ME = "me"
         private const val USERS = "users"
         private const val GRUPPER = "memberOf"
         private const val FELTER = "givenName,surname,onPremisesSamAccountName,id,userPrincipalName,streetAddress,city"

--- a/src/main/java/no/nav/familie/integrasjoner/saksbehandler/SaksbehandlerController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/saksbehandler/SaksbehandlerController.kt
@@ -1,7 +1,8 @@
 package no.nav.familie.integrasjoner.saksbehandler
 
-import no.nav.familie.kontrakter.felles.saksbehandler.Saksbehandler
+import no.nav.familie.integrasjoner.azure.domene.AzureAdGrupper
 import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.felles.saksbehandler.Saksbehandler
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.context.annotation.Profile
 import org.springframework.web.bind.annotation.GetMapping
@@ -21,5 +22,13 @@ class SaksbehandlerController(
         @PathVariable id: String,
     ): Ressurs<Saksbehandler> { // id kan være azure-id, e-post eller nav-ident
         return Ressurs.success(saksbehandlerService.hentSaksbehandler(id), "Hent saksbehandler OK")
+    }
+
+    @GetMapping(path = ["/{id}/grupper"])
+    @ProtectedWithClaims(issuer = "azuread")
+    fun hentSaksbehandlerGrupper(
+        @PathVariable id: String,
+    ): Ressurs<AzureAdGrupper> { // id kan være azure-id, e-post eller nav-ident
+        return Ressurs.success(saksbehandlerService.hentGruppeneTilSaksbehandler(id), "Hent saksbehandler grupper OK")
     }
 }

--- a/src/main/java/no/nav/familie/integrasjoner/saksbehandler/SaksbehandlerControllerE2E.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/saksbehandler/SaksbehandlerControllerE2E.kt
@@ -26,7 +26,7 @@ class SaksbehandlerControllerE2E {
                 fornavn = "Mocka",
                 etternavn = "Saksbehandler",
                 enhet = "4408",
-                enhetsnavn = "Nav arbeid og ytelser Skien"
+                enhetsnavn = "Nav arbeid og ytelser Skien",
             ),
             "Hent saksbehandler OK",
         )

--- a/src/main/java/no/nav/familie/integrasjoner/saksbehandler/SaksbehandlerService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/saksbehandler/SaksbehandlerService.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.integrasjoner.saksbehandler
 
+import no.nav.familie.integrasjoner.azure.domene.AzureAdGrupper
 import no.nav.familie.integrasjoner.client.rest.AzureGraphRestClient
 import no.nav.familie.kontrakter.felles.saksbehandler.Saksbehandler
 import org.springframework.core.env.Environment
@@ -22,7 +23,7 @@ class SaksbehandlerService(
                 fornavn = "Mocka",
                 etternavn = "Saksbehandler",
                 enhet = "4408",
-                enhetsnavn = "NAV ARBEID OG YTELSER SKIEN"
+                enhetsnavn = "NAV ARBEID OG YTELSER SKIEN",
             )
         }
 
@@ -56,6 +57,23 @@ class SaksbehandlerService(
             enhet = azureAdBruker.streetAddress,
             enhetsnavn = azureAdBruker.city,
         )
+    }
+
+    fun hentGruppeneTilSaksbehandler(id: String): AzureAdGrupper {
+        val azureIdPåBruker =
+            if (id.length == lengdeNavIdent) {
+                val azureAdBrukere = azureGraphRestClient.finnSaksbehandler(id)
+                azureAdBrukere.value
+                    .first()
+                    .id
+                    .toString()
+            } else {
+                id
+            }
+
+        val gruppeneTilSaksbehandler = azureGraphRestClient.hentGruppeneTilSaksbehandler(azureIdPåBruker)
+
+        return gruppeneTilSaksbehandler
     }
 
     fun hentNavIdent(saksbehandlerId: String): String = saksbehandlerId.takeIf { it.length == lengdeNavIdent } ?: hentSaksbehandler(saksbehandlerId).navIdent

--- a/src/test/java/no/nav/familie/integrasjoner/saksbehandler/SaksbehandlerControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/saksbehandler/SaksbehandlerControllerTest.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.integrasjoner.saksbehandler
 
 import no.nav.familie.integrasjoner.OppslagSpringRunnerTest
+import no.nav.familie.integrasjoner.azure.domene.AzureAdGrupper
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.saksbehandler.Saksbehandler
 import org.assertj.core.api.Assertions.assertThat
@@ -136,6 +137,90 @@ class SaksbehandlerControllerTest(
         assertThat(saksbehandler.azureId).isEqualTo(id)
         assertThat(saksbehandler.navIdent).isEqualTo(navIdent)
         assertThat(saksbehandler.enhet).isEqualTo("4415")
+    }
+
+    @Test
+    fun `skal kalle korrekt tjeneste for henting av grupper på navident`() {
+        val navIdent = "B857496"
+        val azureId = UUID.randomUUID()
+
+        client
+            .`when`(
+                HttpRequest
+                    .request()
+                    .withMethod("GET")
+                    .withPath("/users")
+                    .withQueryStringParameters(
+                        Parameter("\$search", "\"onPremisesSamAccountName:B857496\""),
+                        Parameter(
+                            "\$select",
+                            "givenName,surname,onPremisesSamAccountName,id," +
+                                "userPrincipalName,streetAddress,city",
+                        ),
+                    ),
+            ).respond(
+                HttpResponse
+                    .response()
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        """{
+                                           "value": [
+                                               {
+                                                 "givenName": "Bob",
+                                                 "surname": "Burger",
+                                                 "id": "$azureId",
+                                                 "userPrincipalName": "Bob.Burger@nav.no",
+                                                 "onPremisesSamAccountName": "$navIdent",
+                                                 "streetAddress": "4415",
+                                                 "city": "Skien"
+                                               }
+                                           ]
+                                           }""",
+                    ),
+            )
+
+        client
+            .`when`(
+                HttpRequest
+                    .request()
+                    .withMethod("GET")
+                    .withPath("/users/$azureId/memberOf")
+                    .withQueryStringParameters(),
+            ).respond(
+                HttpResponse
+                    .response()
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        """{
+                                  "value": [
+                                    {
+                                      "id": "4c1de7e3-2aa2-41a9-8896-cc39c8f5d1c0",
+                                      "displayName": "ENHET_2103"
+                                    }
+                                  ]
+                                }
+                                """,
+                    ),
+            )
+
+        val uri =
+            UriComponentsBuilder
+                .fromHttpUrl(localhost(BASE_URL))
+                .pathSegment(navIdent)
+                .pathSegment("grupper")
+                .toUriString()
+
+        val response: ResponseEntity<Ressurs<AzureAdGrupper>> =
+            restTemplate.exchange(
+                uri,
+                HttpMethod.GET,
+                HttpEntity<String>(headers),
+            )
+
+        val azureAdMemberOfResponse = response.body!!.data!!
+
+        assertThat(azureAdMemberOfResponse.value.size).isEqualTo(1)
+        assertThat(azureAdMemberOfResponse.value[0].displayName).isEqualTo("ENHET_2103")
     }
 
     companion object {


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25115

Vi oppretter et nytt endepunkt i familie-integrasjoner (api/saksbehandler/{id}/grupper) som henter alle saksbehandler sine grupper. Id kan være navident eller azure id.

Dersom navident sendes inn må vi først hente azure id, deretter gruppene (2x kall).
Dersom azure id sendes inn henter vi gruppene med engang (1x kall)