### PR TITLE
Prøve å gå mot ny url i medl og sende ident i header i stede for body

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/MedlRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/MedlRestClient.kt
@@ -3,6 +3,7 @@ package no.nav.familie.integrasjoner.client.rest
 import no.nav.familie.http.client.AbstractPingableRestClient
 import no.nav.familie.integrasjoner.felles.OppslagException
 import no.nav.familie.integrasjoner.medlemskap.MedlemskapsunntakResponse
+import no.nav.familie.integrasjoner.medlemskap.PeriodeSoekRequest
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Component
 import org.springframework.web.client.RestOperations
 import org.springframework.web.util.UriComponentsBuilder
 import java.net.URI
+import java.time.LocalDate
 
 @Component
 class MedlRestClient(
@@ -23,10 +25,10 @@ class MedlRestClient(
             .build()
             .toUri()
 
-    val medlemskapsunntakUri: URI =
+    val medlemskapPeriodeSOekUri: URI =
         UriComponentsBuilder
             .fromUri(medl2BaseUrl)
-            .pathSegment(PATH_MEDLEMSKAPSUNNTAK)
+            .pathSegment(PATH_PERIODE_SOEK)
             .build()
             .toUri()
 
@@ -35,8 +37,8 @@ class MedlRestClient(
         type: String? = null,
         statuser: List<String>? = null,
         ekskluderKilder: List<String>? = null,
-        fraOgMed: String? = null,
-        tilOgMed: String? = null,
+        fraOgMed: LocalDate? = null,
+        tilOgMed: LocalDate? = null,
         inkluderSporingsinfo: Boolean? = null
     ): List<MedlemskapsunntakResponse> {
         val requestBody = PeriodeSoekRequest(
@@ -51,7 +53,7 @@ class MedlRestClient(
 
         try {
             return restTemplate.postForObject(
-                medlemskapsunntakUri,
+                medlemskapPeriodeSOekUri,
                 requestBody,
                 Array<MedlemskapsunntakResponse>::class.java
             )?.toList() ?: emptyList()
@@ -68,16 +70,6 @@ class MedlRestClient(
 
     companion object {
         private const val PATH_PING = "api/ping"
-        private const val PATH_MEDLEMSKAPSUNNTAK = "rest/v1/periode/soek"
+        private const val PATH_PERIODE_SOEK = "rest/v1/periode/soek"
     }
 }
-
-data class PeriodeSoekRequest(
-    val personident: String,
-    val type: String? = null,
-    val statuser: List<String>? = null,
-    val ekskluderKilder: List<String>? = null,
-    val fraOgMed: String? = null,
-    val tilOgMed: String? = null,
-    val inkluderSporingsinfo: Boolean? = null,
-)

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/MedlRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/MedlRestClient.kt
@@ -57,8 +57,8 @@ class MedlRestClient(
             )?.toList() ?: emptyList()
         } catch (e: Exception) {
             throw OppslagException(
-                "Feil ved henting av medlemskapsperioder",
-                "medl.periode.sok",
+                "Feil ved henting av medlemskapsunntak",
+                "medl.unntak",
                 OppslagException.Level.MEDIUM,
                 HttpStatus.INTERNAL_SERVER_ERROR,
                 e,

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/MedlRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/MedlRestClient.kt
@@ -25,7 +25,7 @@ class MedlRestClient(
             .build()
             .toUri()
 
-    val medlemskapPeriodeSOekUri: URI =
+    val medlemskapPeriodeSoekUri: URI =
         UriComponentsBuilder
             .fromUri(medl2BaseUrl)
             .pathSegment(PATH_PERIODE_SOEK)
@@ -53,7 +53,7 @@ class MedlRestClient(
 
         try {
             return restTemplate.postForObject(
-                medlemskapPeriodeSOekUri,
+                medlemskapPeriodeSoekUri,
                 requestBody,
                 Array<MedlemskapsunntakResponse>::class.java
             )?.toList() ?: emptyList()

--- a/src/main/java/no/nav/familie/integrasjoner/medlemskap/PeriodeSoekRequest.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/medlemskap/PeriodeSoekRequest.kt
@@ -1,0 +1,13 @@
+package no.nav.familie.integrasjoner.medlemskap
+
+import java.time.LocalDate
+
+data class PeriodeSoekRequest(
+    val personident: String,
+    val type: String? = null,
+    val statuser: List<String>? = null,
+    val ekskluderKilder: List<String>? = null,
+    val fraOgMed: LocalDate? = null,
+    val tilOgMed: LocalDate? = null,
+    val inkluderSporingsinfo: Boolean? = null,
+)

--- a/src/test/java/no/nav/familie/integrasjoner/client/rest/MedlRestClientTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/client/rest/MedlRestClientTest.kt
@@ -29,7 +29,7 @@ class MedlRestClientTest {
             // Act & Assert
             val oppslagException =
                 assertThrows<OppslagException> {
-                    medlRestClient.hentMedlemskapsUnntakResponse(aktørId = "1234")
+                    medlRestClient.hentMedlemskapsUnntakResponse(personident = "1234")
                 }
 
             assertThat(oppslagException.message).isEqualTo("Feil ved henting av medlemskapsunntak")

--- a/src/test/java/no/nav/familie/integrasjoner/medlemskap/MedlemskapControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/medlemskap/MedlemskapControllerTest.kt
@@ -33,7 +33,7 @@ class MedlemskapControllerTest : OppslagSpringRunnerTest() {
     fun `skal korrekt behandle returobjekt`() {
         WireMock.stubFor(
             WireMock
-                .get(WireMock.urlEqualTo("/api/v1/medlemskapsunntak"))
+                .post(WireMock.urlEqualTo("/rest/v1/periode/soek"))
                 .willReturn(
                     WireMock
                         .aResponse()
@@ -59,7 +59,7 @@ class MedlemskapControllerTest : OppslagSpringRunnerTest() {
     fun `skal kaste feil for ikke funnet`() {
         WireMock.stubFor(
             WireMock
-                .get(WireMock.urlEqualTo("/api/v1/medlemskapsunntak"))
+                .post(WireMock.urlEqualTo("/rest/v1/periode/soek"))
                 .willReturn(
                     WireMock
                         .aResponse()


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? :sparkles:

Det har kommet nytt endepunkt for å hente medl perioder basert på personident.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-24619)
[Medl](https://github.com/navikt/medlemskap-medl/wiki/Slutte-%C3%A5-bruke-Nav%E2%80%90Personident-headeren)