### PR TITLE
Bytt til noAuthorize i ArbeidOgInntektClient, og fjern token config

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/ArbeidOgInntektClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/ArbeidOgInntektClient.kt
@@ -16,7 +16,7 @@ import java.net.URI
 @Component
 class ArbeidOgInntektClient(
     @Value("\${ARBEID_INNTEKT_URL}") private val uri: URI,
-    @Qualifier("jwtBearer") private val restOperations: RestOperations,
+    @Qualifier("noAuthorize") private val restOperations: RestOperations,
 ) : AbstractRestClient(restOperations, "ainntekt") {
     private val redirectUri =
         UriComponentsBuilder
@@ -35,7 +35,6 @@ class ArbeidOgInntektClient(
                 },
             )
         } catch (e: Exception) {
-            secureLogger.warn("Feil med henting av a-inntekt url. Feilmelding: ${e.message}", e)
             throw OppslagException(
                 "Feil ved oppslag av url for a-inntekt.",
                 "ainntekt.hentUrlTilArbeidOgInntekt",

--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -202,7 +202,6 @@ DOKDISTKANAL_SCOPE: api://dev-fss.teamdokumenthandtering.dokdistkanal/.default
 REGOPPSLAG_SCOPE: api://dev-fss.teamdokumenthandtering.regoppslag/.default
 AAREG_SCOPE: api://dev-fss.arbeidsforhold.aareg-services-nais-q1/.default
 MODIA_CONTEXT_HOLDER_SCOPE: api://dev-gcp.personoversikt.modiacontextholder/.default
-ARBEID_INNTEKT_SCOPE: api://dev-fss.team-inntekt.arbeid-og-inntekt-q1/.default
 
 SAF_AUDIENCE: dev-fss:teamdokumenthandtering:safselvbetjening
 

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -188,7 +188,6 @@ DOKDISTKANAL_SCOPE: api://prod-fss.teamdokumenthandtering.dokdistkanal/.default
 REGOPPSLAG_SCOPE: api://prod-fss.teamdokumenthandtering.regoppslag/.default
 AAREG_SCOPE: api://prod-fss.arbeidsforhold.aareg-services-nais/.default
 MODIA_CONTEXT_HOLDER_SCOPE: api://prod-gcp.personoversikt.modiacontextholder/.default
-ARBEID_INNTEKT_SCOPE: api://prod-fss.team-inntekt.arbeid-og-inntekt/.default
 
 SAF_AUDIENCE: prod-fss:teamdokumenthandtering:safselvbetjening
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -18,20 +18,6 @@ springdoc:
   swagger-ui:
     disable-swagger-default-url: true
 
-no.nav.security.jwt:
-  client:
-    registration:
-      arbeid-og-inntekt-onbehalf-of:
-        resource-url: ${ARBEID_INNTEKT_URL}
-        token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
-        grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
-        scope: ${ARBEID_INNTEKT_SCOPE}
-        authentication:
-          client-id: ${AZURE_APP_CLIENT_ID}
-          client-secret: ${AZURE_APP_CLIENT_SECRET}
-          client-auth-method: client_secret_basic
-
-
 tilgang:
   kode6:
     rolle-id: "ad7b87a6-9180-467c-affc-20a566b0fec0"
@@ -93,7 +79,6 @@ DOKARKIV_SCOPE: "dummy-scope"
 DOKDISTKANAL_SCOPE: "dummy-scope"
 REGOPPSLAG_SCOPE: "dummy-scope"
 MODIA_CONTEXT_HOLDER_SCOPE: "dummy-scope"
-ARBEID_INNTEKT_SCOPE: "dummy-scope"
 
 STS_URL: http://security-token-service.default.svc.nais.local/rest/v1/sts/token
 KODEVERK_URL: http://kodeverk.default


### PR DESCRIPTION
Bytter til `noAuthorize` for `ArbeidOgInntektClient`, og fjerner ubrukt token config