### PR TITLE
Legg til top for å øke antall grupepr tilbake fra azure ad

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/AzureGraphRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/AzureGraphRestClient.kt
@@ -36,14 +36,16 @@ class AzureGraphRestClient(
             .buildAndExpand(navIdent)
             .toUri()
 
-    private fun hentGruppeneTilSaksbehandlerUri(azureUUID: String): URI =
-        UriComponentsBuilder
+    private fun hentGruppeneTilSaksbehandlerUri(azureUUID: String): URI {
+        return UriComponentsBuilder
             .fromUri(aadGraphURI)
             .pathSegment(USERS)
             .pathSegment(azureUUID)
             .pathSegment(GRUPPER)
+            .queryParam("\$top", MAX_ANTALL_GRUPPER)
             .build()
             .toUri()
+    }
 
     fun finnSaksbehandler(navIdent: String): AzureAdBrukere =
         try {
@@ -98,5 +100,6 @@ class AzureGraphRestClient(
         private const val USERS = "users"
         private const val GRUPPER = "memberOf"
         private const val FELTER = "givenName,surname,onPremisesSamAccountName,id,userPrincipalName,streetAddress,city"
+        private const val MAX_ANTALL_GRUPPER = 250
     }
 }

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/AzureGraphRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/AzureGraphRestClient.kt
@@ -36,8 +36,8 @@ class AzureGraphRestClient(
             .buildAndExpand(navIdent)
             .toUri()
 
-    private fun hentGruppeneTilSaksbehandlerUri(azureUUID: String): URI {
-        return UriComponentsBuilder
+    private fun hentGruppeneTilSaksbehandlerUri(azureUUID: String): URI =
+        UriComponentsBuilder
             .fromUri(aadGraphURI)
             .pathSegment(USERS)
             .pathSegment(azureUUID)
@@ -45,7 +45,6 @@ class AzureGraphRestClient(
             .queryParam("\$top", MAX_ANTALL_GRUPPER)
             .build()
             .toUri()
-    }
 
     fun finnSaksbehandler(navIdent: String): AzureAdBrukere =
         try {


### PR DESCRIPTION
Setter TOP slik at vi utvider antall grupper vi henter ut til 250 da vi har støtt på SB med over 100.