### PR TITLE
Oppdaterer scope for dokdistfordeling

### DIFF
--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -233,7 +233,7 @@ INTEGRASJONER_CLIENT_ID: ${AZURE_APP_CLIENT_ID}
 CLIENT_SECRET: ${AZURE_APP_CLIENT_SECRET}
 KODEVERK_SCOPE: api://dev-gcp.team-rocket.kodeverk-api/.default
 DOKARKIV_SCOPE: api://dev-fss.teamdokumenthandtering.dokarkiv/.default
-DOKDIST_SCOPE: api://dev-fss.teamdokumenthandtering.saf/.default
+DOKDIST_SCOPE: api://dev-fss.teamdokumenthandtering.dokdistfordeling/.default
 PDL_SCOPE: api://dev-fss.pdl.pdl-api/.default
 DOKDISTKANAL_SCOPE: api://dev-fss.teamdokumenthandtering.dokdistkanal/.default
 REGOPPSLAG_SCOPE: api://dev-fss.teamdokumenthandtering.regoppslag/.default

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -224,7 +224,7 @@ KODEVERK_SCOPE: api://prod-gcp.team-rocket.kodeverk-api/.default
 DOKARKIV_SCOPE: api://prod-fss.teamdokumenthandtering.dokarkiv/.default
 PDL_SCOPE: api://prod-fss.pdl.pdl-api/.default
 DOKDISTKANAL_SCOPE: api://prod-fss.teamdokumenthandtering.dokdistkanal/.default
-DOKDIST_SCOPE: api://prod-fss.teamdokumenthandtering.saf/.default
+DOKDIST_SCOPE: api://prod-fss.teamdokumenthandtering.dokdistfordeling/.default
 REGOPPSLAG_SCOPE: api://prod-fss.teamdokumenthandtering.regoppslag/.default
 AAREG_SCOPE: api://prod-fss.arbeidsforhold.aareg-services-nais/.default
 FORSTESIDEGENERATOR_SCOPE: api://prod-fss.teamdokumenthandtering.foerstesidegenerator/.default


### PR DESCRIPTION
* Fra saf-scope til dokdistfordeling-scope

Som annonsert: https://nav-it.slack.com/archives/C06Q2T7TCJG/p1754469824098999

> Vi gjør endringer på autentisering i dokdistfordeling, for å sørge for at autentisering med EntraID er implementert som tiltenkt. Pr i dag kalles distribuerJournalpost med EntraID tokens scopet mot SAF, hvor dokdistfordeling proxyer dette tokenet videre i kall til SAF. Vi ønsker på sikt å endre dette til av dokdistfordeling kun kan kalles med tokens som er scopet mot seg selv. Steg 1 av denne endringen innføres nå, hvor dokdistfordeling i en overgangsperiode vil akseptere tokens med enten saf- eller dokdistfordeling-scope. Dette innebærer at konsumenter ikke trenger å gjøre noe umiddelbart, men på sikt (helst så snart som mulig) må endre scope for tokenet de kaller dokdistfordeling med. Vi kommer til å bistå konsumenter med denne endringen. Liste med pre-autentiserte applikasjoner er populert for hvert miljø basert på kall mot distribuertJournalpost siste 7 dager.

Har dobbeltsjekket dokdistfordeling config og `prod-fss:teamfamilie:familie-integrasjoner` ligger inne 😄