### PR TITLE
Utvider organisasjonskontrakten til å ha med kommumenummer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <kotlin.version>2.2.10</kotlin.version>
         <springdoc.version>2.8.9</springdoc.version>
         <felles.version>3.20250804101327_a0f5fad</felles.version>
-        <kontrakter.version>3.0_20250805142725_8942276</kontrakter.version>
+        <kontrakter.version>3.0_20250819182959_b55d05b</kontrakter.version>
         <token-validation-spring.version>5.0.34</token-validation-spring.version>
         <graphql-kotlin.version>8.8.1</graphql-kotlin.version>
 

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/OrganisasjonRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/OrganisasjonRestClient.kt
@@ -2,6 +2,7 @@ package no.nav.familie.integrasjoner.client.rest
 
 import no.nav.familie.http.client.AbstractPingableRestClient
 import no.nav.familie.integrasjoner.config.incrementLoggFeil
+import no.nav.familie.kontrakter.felles.organisasjon.OrganisasjonAdresse
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
@@ -39,6 +40,7 @@ class OrganisasjonRestClient(
 
 data class HentOrganisasjonResponse(
     val navn: Navn,
+    val adresse: OrganisasjonAdresse?,
 )
 
 data class Navn(

--- a/src/main/java/no/nav/familie/integrasjoner/organisasjon/OrganisasjonService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/organisasjon/OrganisasjonService.kt
@@ -13,7 +13,7 @@ class OrganisasjonService(
     @Cacheable("hentOrganisasjon")
     fun hentOrganisasjon(orgnr: String): Organisasjon {
         val organisasjonResponse = organisasjonRestClient.hentOrganisasjon(orgnr)
-        return Organisasjon(orgnr, organisasjonResponse.navn.sammensattnavn)
+        return Organisasjon(orgnr, organisasjonResponse.navn.sammensattnavn, organisasjonResponse.adresse)
     }
 
     @Cacheable("validerOrganisasjon")

--- a/src/test/java/no/nav/familie/integrasjoner/organisasjon/OrganisasjonServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/organisasjon/OrganisasjonServiceTest.kt
@@ -7,6 +7,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.stubFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import no.nav.familie.integrasjoner.OppslagSpringRunnerTest
 import no.nav.familie.kontrakter.felles.organisasjon.Organisasjon
+import no.nav.familie.kontrakter.felles.organisasjon.OrganisasjonAdresse
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -31,6 +32,7 @@ internal class OrganisasjonServiceTest : OppslagSpringRunnerTest() {
             Organisasjon(
                 organisasjonsnummer = "1",
                 navn = "NAV AS",
+                OrganisasjonAdresse(type = "Forretningsadresse", kommunenummer = "0301"),
             ),
         )
     }
@@ -58,6 +60,17 @@ internal class OrganisasjonServiceTest : OppslagSpringRunnerTest() {
         {
           "navn": {
            "sammensattnavn": "NAV AS"
+          },
+          "adresse":{
+            "type":"Forretningsadresse",
+            "adresselinje1":"Sannergata 2",
+            "postnummer":"0557",
+            "landkode":"NO",
+            "kommunenummer":"0301",
+            "gyldighetsperiode":
+              {
+                "fom":"2007-08-23"
+              }
           }
         }
         """.trimIndent()

--- a/src/test/java/no/nav/familie/integrasjoner/organisasjon/OrganisasjonTestConfig.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/organisasjon/OrganisasjonTestConfig.kt
@@ -5,6 +5,7 @@ import io.mockk.mockk
 import no.nav.familie.integrasjoner.client.rest.HentOrganisasjonResponse
 import no.nav.familie.integrasjoner.client.rest.Navn
 import no.nav.familie.integrasjoner.client.rest.OrganisasjonRestClient
+import no.nav.familie.kontrakter.felles.organisasjon.OrganisasjonAdresse
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
@@ -20,6 +21,7 @@ class OrganisasjonTestConfig {
         val organisasjon =
             HentOrganisasjonResponse(
                 navn = Navn("Navn på bedrift"),
+                adresse = OrganisasjonAdresse(type = "Forretningsadresse", kommunenummer = "0301"),
             )
         every { organisasjonRestClient.hentOrganisasjon(any()) } returns organisasjon
 


### PR DESCRIPTION
Utvider Organisasjon-responsen fra ereg til å returnere adresse-informasjon. Dette for å kunne identifisere samhandlere som berøres av Finnmarkstillegget.

I første fase er bare kommunenummer og adressetype på nøkkelinfokallet eksponert.