### PR TITLE
Propager 404 feil mot ereg hvis det er slik at organisasjon ikke finnes

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/OrganisasjonRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/OrganisasjonRestClient.kt
@@ -1,11 +1,14 @@
 package no.nav.familie.integrasjoner.client.rest
 
 import no.nav.familie.integrasjoner.config.incrementLoggFeil
+import no.nav.familie.integrasjoner.felles.OppslagException
 import no.nav.familie.kontrakter.felles.organisasjon.OrganisasjonAdresse
 import no.nav.familie.restklient.client.AbstractPingableRestClient
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
+import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestOperations
 import org.springframework.web.util.UriComponentsBuilder
 import java.net.URI
@@ -32,6 +35,14 @@ class OrganisasjonRestClient(
     fun hentOrganisasjon(orgnr: String): HentOrganisasjonResponse =
         try {
             getForEntity(nøkkelinfoUri(orgnr))
+        } catch (e: HttpClientErrorException.NotFound) {
+            throw OppslagException(
+                message = "Ingen organisasjon med organisasjonsnummer $orgnr ble funnet",
+                kilde = "organisasjon.hent",
+                level = OppslagException.Level.LAV,
+                httpStatus = HttpStatus.NOT_FOUND,
+                error = e,
+            )
         } catch (e: Exception) {
             incrementLoggFeil("organisasjon.hent")
             throw e

--- a/src/main/java/no/nav/familie/integrasjoner/organisasjon/OrganisasjonService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/organisasjon/OrganisasjonService.kt
@@ -1,10 +1,11 @@
 package no.nav.familie.integrasjoner.organisasjon
 
 import no.nav.familie.integrasjoner.client.rest.OrganisasjonRestClient
+import no.nav.familie.integrasjoner.felles.OppslagException
 import no.nav.familie.kontrakter.felles.organisasjon.Organisasjon
 import org.springframework.cache.annotation.Cacheable
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
-import org.springframework.web.client.HttpClientErrorException
 
 @Service
 class OrganisasjonService(
@@ -21,7 +22,7 @@ class OrganisasjonService(
         try {
             organisasjonRestClient.hentOrganisasjon(orgnr)
             true
-        } catch (e: HttpClientErrorException.NotFound) {
+        } catch (oppslagException: OppslagException) {
             false
         }
 }

--- a/src/test/java/no/nav/familie/integrasjoner/organisasjon/OrganisasjonControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/organisasjon/OrganisasjonControllerTest.kt
@@ -1,0 +1,109 @@
+package no.nav.familie.integrasjoner.organisasjon
+
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.notFound
+import com.github.tomakehurst.wiremock.client.WireMock.okJson
+import com.github.tomakehurst.wiremock.client.WireMock.serverError
+import com.github.tomakehurst.wiremock.client.WireMock.stubFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import no.nav.familie.integrasjoner.OppslagSpringRunnerTest
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.felles.organisasjon.Organisasjon
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.boot.resttestclient.exchange
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+import org.wiremock.spring.ConfigureWireMock
+import org.wiremock.spring.EnableWireMock
+
+@ActiveProfiles("integrasjonstest", "mock-oauth")
+@TestPropertySource(properties = ["ORGANISASJON_URL=http://localhost:28086"])
+@EnableWireMock(
+    ConfigureWireMock(name = "OrganisasjonControllerTest", port = 28086),
+)
+class OrganisasjonControllerTest : OppslagSpringRunnerTest() {
+    @BeforeEach
+    fun setUp() {
+        headers.setBearerAuth(lokalTestToken)
+    }
+
+    @Test
+    fun `hentOrganisasjon returnerer OK når organisasjon finnes`() {
+        stubFor(
+            get(urlEqualTo("/v2/organisasjon/$ORGNR/noekkelinfo"))
+                .willReturn(okJson(BODY_ORG)),
+        )
+
+        val response: ResponseEntity<Ressurs<Organisasjon>> =
+            restTemplate.exchange(
+                localhost("/api/organisasjon/$ORGNR"),
+                HttpMethod.GET,
+                HttpEntity<Any>(headers),
+            )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body?.status).isEqualTo(Ressurs.Status.SUKSESS)
+        assertThat(response.body?.data?.navn).isEqualTo("NAV AS")
+    }
+
+    @Test
+    fun `hentOrganisasjon returnerer 404 når organisasjon ikke finnes i EREG`() {
+        stubFor(
+            get(urlEqualTo("/v2/organisasjon/$ORGNR/noekkelinfo"))
+                .willReturn(notFound().withBody(BODY_ORG_IKKE_FUNNET)),
+        )
+
+        val response: ResponseEntity<Ressurs<Organisasjon>> =
+            restTemplate.exchange(
+                localhost("/api/organisasjon/$ORGNR"),
+                HttpMethod.GET,
+                HttpEntity<Any>(headers),
+            )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+        assertThat(response.body?.status).isEqualTo(Ressurs.Status.FEILET)
+        assertThat(response.body?.melding).contains("Ingen organisasjon med oppgitt organisasjonsnummer ble funnet")
+    }
+
+    @Test
+    fun `hentOrganisasjon returnerer 500 ved andre feil mot EREG`() {
+        stubFor(
+            get(urlEqualTo("/v2/organisasjon/$ORGNR/noekkelinfo"))
+                .willReturn(serverError()),
+        )
+
+        val response: ResponseEntity<Ressurs<Organisasjon>> =
+            restTemplate.exchange(
+                localhost("/api/organisasjon/$ORGNR"),
+                HttpMethod.GET,
+                HttpEntity<Any>(headers),
+            )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        assertThat(response.body?.status).isEqualTo(Ressurs.Status.FEILET)
+    }
+
+    companion object {
+        private const val ORGNR = "123456789"
+
+        private val BODY_ORG =
+            """
+            {
+              "navn": { "sammensattnavn": "NAV AS" }
+            }
+            """.trimIndent()
+
+        private val BODY_ORG_IKKE_FUNNET =
+            """
+            {
+              "melding": "Ingen organisasjon med organisasjonsnummer $ORGNR ble funnet"
+            }
+            """.trimIndent()
+    }
+}

--- a/src/test/java/no/nav/familie/integrasjoner/organisasjon/OrganisasjonControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/organisasjon/OrganisasjonControllerTest.kt
@@ -68,7 +68,7 @@ class OrganisasjonControllerTest : OppslagSpringRunnerTest() {
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
         assertThat(response.body?.status).isEqualTo(Ressurs.Status.FEILET)
-        assertThat(response.body?.melding).contains("Ingen organisasjon med oppgitt organisasjonsnummer ble funnet")
+        assertThat(response.body?.melding).contains("Ingen organisasjon med organisasjonsnummer $ORGNR ble funnet")
     }
 
     @Test

--- a/src/test/java/no/nav/familie/integrasjoner/organisasjon/OrganisasjonServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/organisasjon/OrganisasjonServiceTest.kt
@@ -3,15 +3,19 @@ package no.nav.familie.integrasjoner.organisasjon
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.notFound
 import com.github.tomakehurst.wiremock.client.WireMock.okJson
+import com.github.tomakehurst.wiremock.client.WireMock.serverError
 import com.github.tomakehurst.wiremock.client.WireMock.stubFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import no.nav.familie.integrasjoner.OppslagSpringRunnerTest
+import no.nav.familie.integrasjoner.felles.OppslagException
 import no.nav.familie.kontrakter.felles.organisasjon.Gyldighetsperiode
 import no.nav.familie.kontrakter.felles.organisasjon.Organisasjon
 import no.nav.familie.kontrakter.felles.organisasjon.OrganisasjonAdresse
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestPropertySource
 import org.wiremock.spring.ConfigureWireMock
@@ -67,6 +71,21 @@ internal class OrganisasjonServiceTest : OppslagSpringRunnerTest() {
                 .willReturn(notFound().withBody(bodyOrgIkkeFunnet)),
         )
         assertThat(organisasjonService.validerOrganisasjon("1")).isFalse
+    }
+
+    @Test
+    internal fun `hentOrganisasjon kaster OppslagException med status NOT_FOUND og level LAV når EREG returnerer 404`() {
+        stubFor(
+            get(urlEqualTo("/v2/organisasjon/2/noekkelinfo"))
+                .willReturn(notFound().withBody(bodyOrgIkkeFunnet)),
+        )
+
+        assertThatThrownBy { organisasjonService.hentOrganisasjon("2") }
+            .isInstanceOfSatisfying(OppslagException::class.java) {
+                assertThat(it.httpStatus).isEqualTo(HttpStatus.NOT_FOUND)
+                assertThat(it.level).isEqualTo(OppslagException.Level.LAV)
+                assertThat(it.kilde).isEqualTo("organisasjon.hent")
+            }
     }
 
     private val bodyOrg =


### PR DESCRIPTION
I denne [PR](https://github.com/navikt/familie-ba-sak/pull/6234) så satt jeg ba-sak til å sette ukjent navn på organisasjon hvis det viser seg at vi ikke får hentet det fra e-reg grunnet 404. Men akkurat nå så gjøres alle feil mot e-reg til 500 av integrasjoner. Catcher derfor på not found for å bevare statuskoden man får fra kilden.

Tatt inspirasjon fra hvordan det er gjort i dokdist controller.