### PR TITLE
Legg til endepunkt for å avslutte sak i joark fra konsumentene til integrasjoner

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <kotlin.version>2.3.20</kotlin.version>
         <springdoc.version>3.0.3</springdoc.version>
         <felles.version>4.20260420125050_76c5fea</felles.version>
-        <kontrakter.version>4.0_20260504134512_03887b7</kontrakter.version>
+        <kontrakter.version>4.0_20260504163558_47138d7</kontrakter.version>
         <token-validation-spring.version>6.0.5</token-validation-spring.version>
         <graphql-kotlin.version>9.1.0</graphql-kotlin.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <kotlin.version>2.3.20</kotlin.version>
         <springdoc.version>3.0.3</springdoc.version>
         <felles.version>4.20260420125050_76c5fea</felles.version>
-        <kontrakter.version>4.0_20260504163558_47138d7</kontrakter.version>
+        <kontrakter.version>4.0_20260505114201_a33e0b9</kontrakter.version>
         <token-validation-spring.version>6.0.5</token-validation-spring.version>
         <graphql-kotlin.version>9.1.0</graphql-kotlin.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <kotlin.version>2.3.20</kotlin.version>
         <springdoc.version>3.0.3</springdoc.version>
         <felles.version>4.20260420125050_76c5fea</felles.version>
-        <kontrakter.version>4.0_20260417102447_88161c0</kontrakter.version>
+        <kontrakter.version>4.0_20260504134512_03887b7</kontrakter.version>
         <token-validation-spring.version>6.0.5</token-validation-spring.version>
         <graphql-kotlin.version>9.1.0</graphql-kotlin.version>
     </properties>

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivRestClient.kt
@@ -106,7 +106,7 @@ class DokarkivRestClient(
         try {
             patchForEntity<String>(uri, request)
         } catch (e: RuntimeException) {
-            throw oppslagExceptionVed("Feil ved ferdigstilling av journalpost", e, request.bruker.id, "dokarkiv.avsluttSak")
+            throw oppslagExceptionVed("Feil ved avslutting av sak", e, request.bruker.id, "dokarkiv.avsluttSak")
         }
     }
 

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivRestClient.kt
@@ -106,7 +106,7 @@ class DokarkivRestClient(
         try {
             patchForEntity<String>(uri, request)
         } catch (e: RuntimeException) {
-            throw oppslagExceptionVed("Feil ved avslutting av sak i dokarkiv", e, request.bruker.id, "dokarkiv.avsluttSak")
+            throw oppslagExceptionVed("avslutting av sak i dokarkiv", e, request.bruker.id, "dokarkiv.avsluttSak")
         }
     }
 

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivRestClient.kt
@@ -6,6 +6,7 @@ import no.nav.familie.integrasjoner.dokarkiv.client.domene.OpprettJournalpostReq
 import no.nav.familie.integrasjoner.dokarkiv.client.domene.OpprettJournalpostResponse
 import no.nav.familie.integrasjoner.felles.MDCOperations
 import no.nav.familie.integrasjoner.felles.OppslagException
+import no.nav.familie.kontrakter.felles.dokarkiv.AvsluttSakRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.OppdaterJournalpostRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.OppdaterJournalpostResponse
 import no.nav.familie.log.NavHttpHeaders
@@ -93,6 +94,22 @@ class DokarkivRestClient(
         ferdigstillJournalPostClient.ferdigstillJournalpost(journalpostId, journalførendeEnhet, navIdent)
     }
 
+    fun avsluttSak(
+        request: AvsluttSakRequest,
+    ) {
+        val uri =
+            UriComponentsBuilder
+                .fromUri(dokarkivUrl)
+                .path(PATH_AVSLUTT_SAK)
+                .build()
+                .toUri()
+        try {
+            patchForEntity<String>(uri, request)
+        } catch (e: RuntimeException) {
+            throw oppslagExceptionVed("Feil ved ferdigstilling av journalpost", e, request.bruker.id, "dokarkiv.avsluttSak")
+        }
+    }
+
     private fun oppslagExceptionVed(
         requestType: String,
         e: RuntimeException,
@@ -160,6 +177,7 @@ class DokarkivRestClient(
         private const val PATH_JOURNALPOST = "rest/journalpostapi/v1/journalpost"
         private const val QUERY_FERDIGSTILL = "forsoekFerdigstill={boolean}"
         private const val PATH_FERDIGSTILL_JOURNALPOST = "rest/journalpostapi/v1/journalpost/%s/ferdigstill"
+        private const val PATH_AVSLUTT_SAK = "rest/journalpostapi/v1/sak/avsluttSak"
         private const val NAV_CALL_ID = "Nav-Callid"
 
         private val NAVIDENT_REGEX = """^[a-zA-Z]\d{6}$""".toRegex()

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivRestClient.kt
@@ -106,7 +106,7 @@ class DokarkivRestClient(
         try {
             patchForEntity<String>(uri, request)
         } catch (e: RuntimeException) {
-            throw oppslagExceptionVed("Feil ved avslutting av sak", e, request.bruker.id, "dokarkiv.avsluttSak")
+            throw oppslagExceptionVed("Feil ved avslutting av sak i dokarkiv", e, request.bruker.id, "dokarkiv.avsluttSak")
         }
     }
 

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivController.kt
@@ -6,6 +6,7 @@ import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.Ressurs.Companion.failure
 import no.nav.familie.kontrakter.felles.Ressurs.Companion.success
 import no.nav.familie.kontrakter.felles.dokarkiv.ArkiverDokumentResponse
+import no.nav.familie.kontrakter.felles.dokarkiv.AvsluttSakRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.BulkOppdaterLogiskVedleggRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.LogiskVedleggRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.LogiskVedleggResponse
@@ -22,6 +23,7 @@ import org.springframework.validation.ObjectError
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -83,6 +85,20 @@ class DokarkivController(
     ): ResponseEntity<Ressurs<OppdaterJournalpostResponse>> {
         val response = journalføringService.oppdaterJournalpost(oppdaterJournalpostRequest, journalpostId, navIdent)
         return ResponseEntity.ok(success(response, "Oppdatert journalpost $journalpostId sakstilknyttning"))
+    }
+
+    @PatchMapping(path = ["/v2/avsluttSak"], produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun avsluttSak(
+        @RequestBody @Valid
+        avsluttSakRequest: AvsluttSakRequest,
+    ): ResponseEntity<Ressurs<Map<String, String>>> {
+        journalføringService.avsluttSak(avsluttSakRequest)
+        return ResponseEntity.ok(
+            success(
+                mapOf("fagsakId" to avsluttSakRequest.fagsakId),
+                "Avsluttet sak ${avsluttSakRequest.fagsakId} i fagsaksystem ${avsluttSakRequest.fagsaksystem}",
+            ),
+        )
     }
 
     @PutMapping("/v2/{journalpostId}/ferdigstill")

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivController.kt
@@ -87,7 +87,7 @@ class DokarkivController(
         return ResponseEntity.ok(success(response, "Oppdatert journalpost $journalpostId sakstilknyttning"))
     }
 
-    @PatchMapping(path = ["/v2/avsluttSak"], produces = [MediaType.APPLICATION_JSON_VALUE])
+    @PatchMapping(path = ["/avsluttSak"], produces = [MediaType.APPLICATION_JSON_VALUE])
     fun avsluttSak(
         @RequestBody @Valid
         avsluttSakRequest: AvsluttSakRequest,

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivService.kt
@@ -14,6 +14,7 @@ import no.nav.familie.kontrakter.felles.BrukerIdType
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.dokarkiv.ArkiverDokumentResponse
 import no.nav.familie.kontrakter.felles.dokarkiv.AvsenderMottaker
+import no.nav.familie.kontrakter.felles.dokarkiv.AvsluttSakRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.BulkOppdaterLogiskVedleggRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.DokarkivBruker
 import no.nav.familie.kontrakter.felles.dokarkiv.LogiskVedleggRequest
@@ -42,6 +43,10 @@ class DokarkivService(
     ) {
         dokarkivRestClient.ferdigstillJournalpost(journalpost, journalførendeEnhet, navIdent)
     }
+
+    fun avsluttSak(
+        request: AvsluttSakRequest,
+    ) = dokarkivRestClient.avsluttSak(request)
 
     fun lagJournalpost(
         arkiverDokumentRequest: ArkiverDokumentRequest,

--- a/src/test/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivControllerTest.kt
@@ -17,9 +17,11 @@ import com.github.tomakehurst.wiremock.client.WireMock.verify
 import no.nav.familie.integrasjoner.OppslagSpringRunnerTest
 import no.nav.familie.integrasjoner.dokarkiv.client.domene.OpprettJournalpostResponse
 import no.nav.familie.kontrakter.felles.BrukerIdType
+import no.nav.familie.kontrakter.felles.Fagsystem
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.dokarkiv.ArkiverDokumentResponse
+import no.nav.familie.kontrakter.felles.dokarkiv.AvsluttSakRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.BulkOppdaterLogiskVedleggRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.DokarkivBruker
 import no.nav.familie.kontrakter.felles.dokarkiv.Dokumenttype
@@ -50,6 +52,7 @@ import org.wiremock.spring.EnableWireMock
 import java.io.IOException
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
+import java.time.LocalDateTime
 import java.util.LinkedList
 import kotlin.test.assertFalse
 
@@ -331,6 +334,86 @@ class DokarkivControllerTest : OppslagSpringRunnerTest() {
         assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
         assertThat(response.body?.status).isEqualTo(Ressurs.Status.FEILET)
         assertThat(response.body?.melding).contains("Kan ikke ferdigstille journalpost 123")
+    }
+
+    @Test
+    fun `avsluttSak returnerer ok og kaller dokarkiv`() {
+        stubFor(
+            patch(urlPathEqualTo("/rest/journalpostapi/v1/sak/avsluttSak"))
+                .willReturn(status(200).withBody("OK")),
+        )
+
+        val body =
+            AvsluttSakRequest(
+                tema = Tema.BAR,
+                fagsakId = "123",
+                fagsaksystem = Fagsystem.BA,
+                bruker = DokarkivBruker(BrukerIdType.FNR, "12345678910"),
+                opprettetDato = LocalDateTime.of(2024, 1, 1, 0, 0),
+                administrativEnhet = "9999",
+            )
+
+        val response: ResponseEntity<Ressurs<Map<String, String>>> =
+            restTemplate.exchange(
+                localhost("$DOKARKIV_URL/avsluttSak"),
+                HttpMethod.PATCH,
+                HttpEntity(body, headers),
+            )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body?.status).isEqualTo(Ressurs.Status.SUKSESS)
+        assertThat(response.body?.data).isEqualTo(mapOf("fagsakId" to "123"))
+        assertThat(response.body?.melding).isEqualTo("Avsluttet sak 123 i fagsaksystem BA")
+        verify(patchRequestedFor(urlPathEqualTo("/rest/journalpostapi/v1/sak/avsluttSak")))
+    }
+
+    @Test
+    fun `avsluttSak returnerer feil hvis dokarkiv feiler`() {
+        stubFor(
+            patch(urlPathEqualTo("/rest/journalpostapi/v1/sak/avsluttSak"))
+                .willReturn(status(500)),
+        )
+
+        val body =
+            AvsluttSakRequest(
+                tema = Tema.BAR,
+                fagsakId = "123",
+                fagsaksystem = Fagsystem.BA,
+                bruker = DokarkivBruker(BrukerIdType.FNR, "12345678910"),
+                opprettetDato = LocalDateTime.of(2024, 1, 1, 0, 0),
+                administrativEnhet = "9999",
+            )
+
+        val response: ResponseEntity<Ressurs<Map<String, String>>> =
+            restTemplate.exchange(
+                localhost("$DOKARKIV_URL/avsluttSak"),
+                HttpMethod.PATCH,
+                HttpEntity(body, headers),
+            )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        assertThat(response.body?.status).isEqualTo(Ressurs.Status.FEILET)
+        assertThat(response.body?.melding).contains("Feil ved avslutting av sak i dokarkiv av journalpost")
+    }
+
+    @Test
+    fun `avsluttSak returnerer bad request ved valideringsfeil`() {
+        val invalidBody = """{"tema":"BAR"}"""
+        val jsonHeaders =
+            HttpHeaders().apply {
+                putAll(headers)
+                contentType = org.springframework.http.MediaType.APPLICATION_JSON
+            }
+
+        val response: ResponseEntity<Ressurs<Map<String, String>>> =
+            restTemplate.exchange(
+                localhost("$DOKARKIV_URL/avsluttSak"),
+                HttpMethod.PATCH,
+                HttpEntity(invalidBody, jsonHeaders),
+            )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+        assertThat(response.body?.status).isEqualTo(Ressurs.Status.FEILET)
     }
 
     @Test

--- a/src/test/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivServiceTest.kt
@@ -3,6 +3,8 @@ package no.nav.familie.integrasjoner.dokarkiv
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.just
+import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
 import no.nav.familie.integrasjoner.client.rest.DokarkivLogiskVedleggRestClient
@@ -21,6 +23,7 @@ import no.nav.familie.kontrakter.felles.BrukerIdType
 import no.nav.familie.kontrakter.felles.Fagsystem
 import no.nav.familie.kontrakter.felles.Språkkode
 import no.nav.familie.kontrakter.felles.Tema
+import no.nav.familie.kontrakter.felles.dokarkiv.AvsluttSakRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.DokarkivBruker
 import no.nav.familie.kontrakter.felles.dokarkiv.Dokumenttype
 import no.nav.familie.kontrakter.felles.dokarkiv.OppdaterJournalpostRequest
@@ -73,6 +76,27 @@ class DokarkivServiceTest {
     @AfterEach
     internal fun tearDown() {
         MDC.remove(MDCConstants.MDC_CALL_ID)
+    }
+
+    @Test
+    fun `avsluttSak skal kalle videre på dokarkiv klient ved avslutting av sak`() {
+        val slot = slot<AvsluttSakRequest>()
+        every { dokarkivRestClient.avsluttSak(capture(slot)) } just runs
+
+        val request =
+            AvsluttSakRequest(
+                tema = Tema.BAR,
+                fagsakId = "123",
+                fagsaksystem = Fagsystem.BA,
+                bruker = DokarkivBruker(BrukerIdType.FNR, "12345678910"),
+                opprettetDato = java.time.LocalDateTime.of(2024, 1, 1, 0, 0),
+                administrativEnhet = "9999",
+            )
+
+        dokarkivService.avsluttSak(request)
+
+        verify(exactly = 1) { dokarkivRestClient.avsluttSak(request) }
+        assertThat(slot.captured).isEqualTo(request)
     }
 
     @Test


### PR DESCRIPTION
Favrokort: 
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-28903

I Team BAKS har vi startet med å se litt på låsing og kassering av fagsak.
For å starte i gang denne prosessen må vi først avslutte sak i joark først, og jeg legger derfor til et endepunkt som kaller videre på dokarkiv. 

Dokumentasjon for endepunktet vi kaller videre på:
https://dokarkiv.intern.dev.nav.no/swagger-ui/index.html#/journalpostapi%20-%20sak/avsluttSak