### PR TITLE
Legger til endepunkt for å gjenåpne sak i dokarkiv

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <kotlin.version>2.3.21</kotlin.version>
         <springdoc.version>3.0.3</springdoc.version>
         <felles.version>4.20260508110757_96596c8</felles.version>
-        <kontrakter.version>4.0_20260505124916_025d466</kontrakter.version>
+        <kontrakter.version>4.0_20260514200726_bf1a1ee</kontrakter.version>
         <token-validation-spring.version>6.0.7</token-validation-spring.version>
         <graphql-kotlin.version>9.2.0</graphql-kotlin.version>
     </properties>

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivRestClient.kt
@@ -7,6 +7,7 @@ import no.nav.familie.integrasjoner.dokarkiv.client.domene.OpprettJournalpostRes
 import no.nav.familie.integrasjoner.felles.MDCOperations
 import no.nav.familie.integrasjoner.felles.OppslagException
 import no.nav.familie.kontrakter.felles.dokarkiv.AvsluttSakRequest
+import no.nav.familie.kontrakter.felles.dokarkiv.GjenåpneSakRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.OppdaterJournalpostRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.OppdaterJournalpostResponse
 import no.nav.familie.log.NavHttpHeaders
@@ -110,6 +111,22 @@ class DokarkivRestClient(
         }
     }
 
+    fun gjenaapneSak(
+        request: GjenåpneSakRequest,
+    ) {
+        val uri =
+            UriComponentsBuilder
+                .fromUri(dokarkivUrl)
+                .path(PATH_GJENAAPNE_SAK)
+                .build()
+                .toUri()
+        try {
+            patchForEntity<String>(uri, request)
+        } catch (e: RuntimeException) {
+            throw oppslagExceptionVed("gjenåpning av sak i dokarkiv", e, request.bruker.id, "dokarkiv.gjenaapneSak")
+        }
+    }
+
     private fun oppslagExceptionVed(
         requestType: String,
         e: RuntimeException,
@@ -178,6 +195,7 @@ class DokarkivRestClient(
         private const val QUERY_FERDIGSTILL = "forsoekFerdigstill={boolean}"
         private const val PATH_FERDIGSTILL_JOURNALPOST = "rest/journalpostapi/v1/journalpost/%s/ferdigstill"
         private const val PATH_AVSLUTT_SAK = "rest/journalpostapi/v1/sak/avsluttSak"
+        private const val PATH_GJENAAPNE_SAK = "rest/journalpostapi/v1/sak/gjenaapneSak"
         private const val NAV_CALL_ID = "Nav-Callid"
 
         private val NAVIDENT_REGEX = """^[a-zA-Z]\d{6}$""".toRegex()

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivRestClient.kt
@@ -111,19 +111,19 @@ class DokarkivRestClient(
         }
     }
 
-    fun gjenaapneSak(
-        request: GjenåpneSakRequest,
+    fun gjenåpneSak(
+        gjenåpneSakRequest: GjenåpneSakRequest,
     ) {
         val uri =
             UriComponentsBuilder
                 .fromUri(dokarkivUrl)
-                .path(PATH_GJENAAPNE_SAK)
+                .path(PATH_GJENÅPNE_SAK)
                 .build()
                 .toUri()
         try {
-            patchForEntity<String>(uri, request)
+            patchForEntity<String>(uri, gjenåpneSakRequest)
         } catch (e: RuntimeException) {
-            throw oppslagExceptionVed("gjenåpning av sak i dokarkiv", e, request.bruker.id, "dokarkiv.gjenaapneSak")
+            throw oppslagExceptionVed("gjenåpning av sak i dokarkiv", e, gjenåpneSakRequest.bruker.id, "dokarkiv.gjenaapneSak")
         }
     }
 
@@ -195,7 +195,7 @@ class DokarkivRestClient(
         private const val QUERY_FERDIGSTILL = "forsoekFerdigstill={boolean}"
         private const val PATH_FERDIGSTILL_JOURNALPOST = "rest/journalpostapi/v1/journalpost/%s/ferdigstill"
         private const val PATH_AVSLUTT_SAK = "rest/journalpostapi/v1/sak/avsluttSak"
-        private const val PATH_GJENAAPNE_SAK = "rest/journalpostapi/v1/sak/gjenaapneSak"
+        private const val PATH_GJENÅPNE_SAK = "rest/journalpostapi/v1/sak/gjenaapneSak"
         private const val NAV_CALL_ID = "Nav-Callid"
 
         private val NAVIDENT_REGEX = """^[a-zA-Z]\d{6}$""".toRegex()

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivController.kt
@@ -8,6 +8,7 @@ import no.nav.familie.kontrakter.felles.Ressurs.Companion.success
 import no.nav.familie.kontrakter.felles.dokarkiv.ArkiverDokumentResponse
 import no.nav.familie.kontrakter.felles.dokarkiv.AvsluttSakRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.BulkOppdaterLogiskVedleggRequest
+import no.nav.familie.kontrakter.felles.dokarkiv.GjenåpneSakRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.LogiskVedleggRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.LogiskVedleggResponse
 import no.nav.familie.kontrakter.felles.dokarkiv.OppdaterJournalpostRequest
@@ -97,6 +98,20 @@ class DokarkivController(
             success(
                 mapOf("fagsakId" to avsluttSakRequest.fagsakId),
                 "Avsluttet sak ${avsluttSakRequest.fagsakId} i fagsaksystem ${avsluttSakRequest.fagsaksystem}",
+            ),
+        )
+    }
+
+    @PatchMapping(path = ["/gjenaapneSak"], produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun gjenaapneSak(
+        @RequestBody @Valid
+        gjenåpneSakRequest: GjenåpneSakRequest,
+    ): ResponseEntity<Ressurs<Map<String, String>>> {
+        journalføringService.gjenaapneSak(gjenåpneSakRequest)
+        return ResponseEntity.ok(
+            success(
+                mapOf("fagsakId" to gjenåpneSakRequest.fagsakId),
+                "Gjenåpnet sak ${gjenåpneSakRequest.fagsakId} i fagsaksystem ${gjenåpneSakRequest.fagsaksystem}",
             ),
         )
     }

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivController.kt
@@ -103,11 +103,11 @@ class DokarkivController(
     }
 
     @PatchMapping(path = ["/gjenaapneSak"], produces = [MediaType.APPLICATION_JSON_VALUE])
-    fun gjenaapneSak(
+    fun gjenåpneSak(
         @RequestBody @Valid
         gjenåpneSakRequest: GjenåpneSakRequest,
     ): ResponseEntity<Ressurs<Map<String, String>>> {
-        journalføringService.gjenaapneSak(gjenåpneSakRequest)
+        journalføringService.gjenåpneSak(gjenåpneSakRequest)
         return ResponseEntity.ok(
             success(
                 mapOf("fagsakId" to gjenåpneSakRequest.fagsakId),

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivService.kt
@@ -49,9 +49,9 @@ class DokarkivService(
         request: AvsluttSakRequest,
     ) = dokarkivRestClient.avsluttSak(request)
 
-    fun gjenaapneSak(
+    fun gjenåpneSak(
         request: GjenåpneSakRequest,
-    ) = dokarkivRestClient.gjenaapneSak(request)
+    ) = dokarkivRestClient.gjenåpneSak(request)
 
     fun lagJournalpost(
         arkiverDokumentRequest: ArkiverDokumentRequest,

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivService.kt
@@ -17,6 +17,7 @@ import no.nav.familie.kontrakter.felles.dokarkiv.AvsenderMottaker
 import no.nav.familie.kontrakter.felles.dokarkiv.AvsluttSakRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.BulkOppdaterLogiskVedleggRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.DokarkivBruker
+import no.nav.familie.kontrakter.felles.dokarkiv.GjenåpneSakRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.LogiskVedleggRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.LogiskVedleggResponse
 import no.nav.familie.kontrakter.felles.dokarkiv.OppdaterJournalpostRequest
@@ -47,6 +48,10 @@ class DokarkivService(
     fun avsluttSak(
         request: AvsluttSakRequest,
     ) = dokarkivRestClient.avsluttSak(request)
+
+    fun gjenaapneSak(
+        request: GjenåpneSakRequest,
+    ) = dokarkivRestClient.gjenaapneSak(request)
 
     fun lagJournalpost(
         arkiverDokumentRequest: ArkiverDokumentRequest,

--- a/src/test/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivControllerTest.kt
@@ -25,6 +25,7 @@ import no.nav.familie.kontrakter.felles.dokarkiv.AvsluttSakRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.BulkOppdaterLogiskVedleggRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.DokarkivBruker
 import no.nav.familie.kontrakter.felles.dokarkiv.Dokumenttype
+import no.nav.familie.kontrakter.felles.dokarkiv.GjenåpneSakRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.LogiskVedleggRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.LogiskVedleggResponse
 import no.nav.familie.kontrakter.felles.dokarkiv.OppdaterJournalpostRequest
@@ -414,6 +415,62 @@ class DokarkivControllerTest : OppslagSpringRunnerTest() {
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
         assertThat(response.body?.status).isEqualTo(Ressurs.Status.FEILET)
+    }
+
+    @Test
+    fun `gjenaapneSak returnerer ok og kaller dokarkiv`() {
+        stubFor(
+            patch(urlPathEqualTo("/rest/journalpostapi/v1/sak/gjenaapneSak"))
+                .willReturn(status(200).withBody("OK")),
+        )
+
+        val body =
+            GjenåpneSakRequest(
+                tema = Tema.BAR,
+                fagsakId = "123",
+                fagsaksystem = Fagsystem.BA,
+                bruker = DokarkivBruker(BrukerIdType.FNR, "12345678910"),
+            )
+
+        val response: ResponseEntity<Ressurs<Map<String, String>>> =
+            restTemplate.exchange(
+                localhost("$DOKARKIV_URL/gjenaapneSak"),
+                HttpMethod.PATCH,
+                HttpEntity(body, headers),
+            )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body?.status).isEqualTo(Ressurs.Status.SUKSESS)
+        assertThat(response.body?.data).isEqualTo(mapOf("fagsakId" to "123"))
+        assertThat(response.body?.melding).isEqualTo("Gjenåpnet sak 123 i fagsaksystem BA")
+        verify(patchRequestedFor(urlPathEqualTo("/rest/journalpostapi/v1/sak/gjenaapneSak")))
+    }
+
+    @Test
+    fun `gjenaapneSak returnerer feil hvis dokarkiv feiler`() {
+        stubFor(
+            patch(urlPathEqualTo("/rest/journalpostapi/v1/sak/gjenaapneSak"))
+                .willReturn(status(500)),
+        )
+
+        val body =
+            GjenåpneSakRequest(
+                tema = Tema.BAR,
+                fagsakId = "123",
+                fagsaksystem = Fagsystem.BA,
+                bruker = DokarkivBruker(BrukerIdType.FNR, "12345678910"),
+            )
+
+        val response: ResponseEntity<Ressurs<Map<String, String>>> =
+            restTemplate.exchange(
+                localhost("$DOKARKIV_URL/gjenaapneSak"),
+                HttpMethod.PATCH,
+                HttpEntity(body, headers),
+            )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        assertThat(response.body?.status).isEqualTo(Ressurs.Status.FEILET)
+        assertThat(response.body?.melding).contains("Feil ved gjenåpning av sak i dokarkiv av journalpost")
     }
 
     @Test

--- a/src/test/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivControllerTest.kt
@@ -418,7 +418,7 @@ class DokarkivControllerTest : OppslagSpringRunnerTest() {
     }
 
     @Test
-    fun `gjenaapneSak returnerer ok og kaller dokarkiv`() {
+    fun `gjenåpneSak returnerer ok og kaller dokarkiv`() {
         stubFor(
             patch(urlPathEqualTo("/rest/journalpostapi/v1/sak/gjenaapneSak"))
                 .willReturn(status(200).withBody("OK")),
@@ -447,7 +447,7 @@ class DokarkivControllerTest : OppslagSpringRunnerTest() {
     }
 
     @Test
-    fun `gjenaapneSak returnerer feil hvis dokarkiv feiler`() {
+    fun `gjenåpneSak returnerer feil hvis dokarkiv feiler`() {
         stubFor(
             patch(urlPathEqualTo("/rest/journalpostapi/v1/sak/gjenaapneSak"))
                 .willReturn(status(500)),

--- a/src/test/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivServiceTest.kt
@@ -101,9 +101,9 @@ class DokarkivServiceTest {
     }
 
     @Test
-    fun `gjenaapneSak skal kalle videre på dokarkiv klient ved gjenåpning av sak`() {
+    fun `gjenåpneSak skal kalle videre på dokarkiv klient ved gjenåpning av sak`() {
         val slot = slot<GjenåpneSakRequest>()
-        every { dokarkivRestClient.gjenaapneSak(capture(slot)) } just runs
+        every { dokarkivRestClient.gjenåpneSak(capture(slot)) } just runs
 
         val request =
             GjenåpneSakRequest(
@@ -113,9 +113,9 @@ class DokarkivServiceTest {
                 bruker = DokarkivBruker(BrukerIdType.FNR, "12345678910"),
             )
 
-        dokarkivService.gjenaapneSak(request)
+        dokarkivService.gjenåpneSak(request)
 
-        verify(exactly = 1) { dokarkivRestClient.gjenaapneSak(request) }
+        verify(exactly = 1) { dokarkivRestClient.gjenåpneSak(request) }
         assertThat(slot.captured).isEqualTo(request)
     }
 

--- a/src/test/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivServiceTest.kt
@@ -26,6 +26,7 @@ import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.dokarkiv.AvsluttSakRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.DokarkivBruker
 import no.nav.familie.kontrakter.felles.dokarkiv.Dokumenttype
+import no.nav.familie.kontrakter.felles.dokarkiv.GjenåpneSakRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.OppdaterJournalpostRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.OppdaterJournalpostResponse
 import no.nav.familie.kontrakter.felles.dokarkiv.Sak
@@ -96,6 +97,25 @@ class DokarkivServiceTest {
         dokarkivService.avsluttSak(request)
 
         verify(exactly = 1) { dokarkivRestClient.avsluttSak(request) }
+        assertThat(slot.captured).isEqualTo(request)
+    }
+
+    @Test
+    fun `gjenaapneSak skal kalle videre på dokarkiv klient ved gjenåpning av sak`() {
+        val slot = slot<GjenåpneSakRequest>()
+        every { dokarkivRestClient.gjenaapneSak(capture(slot)) } just runs
+
+        val request =
+            GjenåpneSakRequest(
+                tema = Tema.BAR,
+                fagsakId = "123",
+                fagsaksystem = Fagsystem.BA,
+                bruker = DokarkivBruker(BrukerIdType.FNR, "12345678910"),
+            )
+
+        dokarkivService.gjenaapneSak(request)
+
+        verify(exactly = 1) { dokarkivRestClient.gjenaapneSak(request) }
         assertThat(slot.captured).isEqualTo(request)
     }
 


### PR DESCRIPTION
Favrokort: 
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-29110

I Team BAKS har vi startet med å se litt på låsing og kassering av fagsak.
Tidligere har vi lagt til et endepunkt som går mot dokarkiv for å avslutte en sak.
Jeg legger nå til enda et endepunkt for å gjenåpne saken.

Dokumentasjon for endepunktet vi kaller videre på:
https://dokarkiv.intern.dev.nav.no/swagger-ui/index.html#/journalpostapi%20-%20sak/gjenaapneSak