### PR TITLE
Migrer fra token-support til Spring Security

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <dependency>
             <groupId>no.nav.security</groupId>
             <artifactId>mock-oauth2-server</artifactId>
-            <version>2.1.10</version>
+            <version>4.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
 
 
         <dependency>
@@ -112,13 +116,8 @@
         </dependency>
         <dependency>
             <groupId>no.nav.security</groupId>
-            <artifactId>token-validation-spring</artifactId>
-            <version>${token-validation-spring.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>no.nav.security</groupId>
-            <artifactId>token-validation-spring-test</artifactId>
-            <version>${token-validation-spring.version}</version>
+            <artifactId>mock-oauth2-server</artifactId>
+            <version>2.1.10</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -138,7 +137,7 @@
         </dependency>
         <dependency>
             <groupId>no.nav.familie.felles</groupId>
-            <artifactId>sikkerhet-token-support</artifactId>
+            <artifactId>sikkerhet-spring-security</artifactId>
             <version>${felles.version}</version>
         </dependency>
         <dependency>

--- a/src/main/java/no/nav/familie/integrasjoner/aareg/AaregController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/aareg/AaregController.kt
@@ -3,7 +3,6 @@ package no.nav.familie.integrasjoner.aareg
 import no.nav.familie.integrasjoner.aareg.domene.Arbeidsforhold
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.Ressurs.Companion.success
-import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.PostMapping
@@ -14,7 +13,6 @@ import java.time.LocalDate
 
 @RestController
 @RequestMapping("/api/aareg")
-@ProtectedWithClaims(issuer = "azuread")
 class AaregController(
     val aaregService: AaregService,
 ) {

--- a/src/main/java/no/nav/familie/integrasjoner/adramatch/FiloverføringAdraMatchController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/adramatch/FiloverføringAdraMatchController.kt
@@ -2,7 +2,6 @@ package no.nav.familie.integrasjoner.adramatch
 
 import no.nav.familie.kontrakter.felles.Fil
 import no.nav.familie.kontrakter.felles.Ressurs
-import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.context.annotation.Profile
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -16,7 +15,6 @@ class FiloverføringAdraMatchController(
     private val sftpClient: FiloverføringAdraMatchClient,
 ) {
     @PutMapping
-    @ProtectedWithClaims(issuer = "azuread")
     fun lastOppFil(
         @RequestBody fil: Fil,
     ): Ressurs<String> {

--- a/src/main/java/no/nav/familie/integrasjoner/aktør/AktørController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/aktør/AktørController.kt
@@ -3,7 +3,6 @@ package no.nav.familie.integrasjoner.aktør
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.Ressurs.Companion.success
 import no.nav.familie.kontrakter.felles.Tema
-import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -12,7 +11,6 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@ProtectedWithClaims(issuer = "azuread")
 @RequestMapping("/api/aktoer")
 class AktørController(
     private val aktørService: AktørService,

--- a/src/main/java/no/nav/familie/integrasjoner/arbeidoginntekt/ArbeidOgInntektController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/arbeidoginntekt/ArbeidOgInntektController.kt
@@ -2,7 +2,6 @@ package no.nav.familie.integrasjoner.arbeidoginntekt
 
 import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.kontrakter.felles.Ressurs
-import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -10,7 +9,6 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/arbeid-og-inntekt")
-@ProtectedWithClaims(issuer = "azuread")
 class ArbeidOgInntektController(
     private val arbeidOgInntektService: ArbeidOgInntektService,
 ) {

--- a/src/main/java/no/nav/familie/integrasjoner/arbeidsfordeling/ArbeidsfordelingController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/arbeidsfordeling/ArbeidsfordelingController.kt
@@ -7,7 +7,6 @@ import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.arbeidsfordeling.Enhet
 import no.nav.familie.kontrakter.felles.navkontor.NavKontorEnhet
 import no.nav.familie.kontrakter.felles.oppgave.Behandlingstype
-import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -19,7 +18,6 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/arbeidsfordeling")
-@ProtectedWithClaims(issuer = "azuread")
 class ArbeidsfordelingController(
     private val service: ArbeidsfordelingService,
 ) {

--- a/src/main/java/no/nav/familie/integrasjoner/config/ApiExceptionHandler.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/config/ApiExceptionHandler.kt
@@ -10,7 +10,6 @@ import no.nav.familie.integrasjoner.personopplysning.PdlUnauthorizedException
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.Ressurs.Companion.failure
 import no.nav.security.token.support.client.core.OAuth2ClientException
-import no.nav.security.token.support.spring.validation.interceptor.JwtTokenUnauthorizedException
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
@@ -28,14 +27,6 @@ import org.springframework.web.context.request.async.AsyncRequestNotUsableExcept
 @ControllerAdvice
 class ApiExceptionHandler {
     private val logger = LoggerFactory.getLogger(ApiExceptionHandler::class.java)
-
-    @ExceptionHandler(JwtTokenUnauthorizedException::class)
-    fun handleUnauthorizedException(e: JwtTokenUnauthorizedException?): ResponseEntity<Ressurs<Any>> {
-        logger.warn("Kan ikke logget inn.", e)
-        return ResponseEntity
-            .status(HttpStatus.UNAUTHORIZED)
-            .body(failure(errorMessage = "Du er ikke logget inn.", frontendFeilmelding = "Du er ikke logget inn", error = e))
-    }
 
     @ExceptionHandler(ResourceAccessException::class)
     fun handleResourceAccessException(e: ResourceAccessException): ResponseEntity<Ressurs<Any>> {

--- a/src/main/java/no/nav/familie/integrasjoner/config/ApplicationConfig.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/config/ApplicationConfig.kt
@@ -5,7 +5,7 @@ import no.nav.familie.log.filter.LogFilter
 import no.nav.familie.log.filter.RequestTimeFilter
 import no.nav.familie.restklient.client.RetryOAuth2HttpClient
 import no.nav.familie.restklient.config.NaisProxyCustomizer
-import no.nav.familie.sikkerhet.context.FamilieFellesNavTokenSupportKonfigurasjon
+import no.nav.familie.sikkerhet.context.FamilieFellesSpringSecurityKonfigurasjon
 import no.nav.security.token.support.client.core.http.OAuth2HttpClient
 import no.nav.security.token.support.client.spring.oauth2.EnableOAuth2Client
 import no.nav.security.token.support.spring.api.EnableJwtTokenValidation
@@ -29,7 +29,7 @@ import java.time.temporal.ChronoUnit
 @EnableJwtTokenValidation(ignore = ["org.springframework", "org.springdoc"])
 @EnableOAuth2Client(cacheEnabled = true)
 @EnableScheduling
-@Import(NaisProxyCustomizer::class, FamilieFellesNavTokenSupportKonfigurasjon::class)
+@Import(NaisProxyCustomizer::class, FamilieFellesSpringSecurityKonfigurasjon::class)
 class ApplicationConfig {
     private val logger = LoggerFactory.getLogger(ApplicationConfig::class.java)
 

--- a/src/main/java/no/nav/familie/integrasjoner/config/ApplicationConfig.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/config/ApplicationConfig.kt
@@ -8,7 +8,6 @@ import no.nav.familie.restklient.config.NaisProxyCustomizer
 import no.nav.familie.sikkerhet.context.FamilieFellesSpringSecurityKonfigurasjon
 import no.nav.security.token.support.client.core.http.OAuth2HttpClient
 import no.nav.security.token.support.client.spring.oauth2.EnableOAuth2Client
-import no.nav.security.token.support.spring.api.EnableJwtTokenValidation
 import org.slf4j.LoggerFactory
 import org.springframework.boot.SpringBootConfiguration
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
@@ -26,7 +25,6 @@ import java.time.temporal.ChronoUnit
 @SpringBootConfiguration
 @ComponentScan("no.nav.familie.integrasjoner", "no.nav.familie.metrikker")
 @ConfigurationPropertiesScan
-@EnableJwtTokenValidation(ignore = ["org.springframework", "org.springdoc"])
 @EnableOAuth2Client(cacheEnabled = true)
 @EnableScheduling
 @Import(NaisProxyCustomizer::class, FamilieFellesSpringSecurityKonfigurasjon::class)

--- a/src/main/java/no/nav/familie/integrasjoner/config/AzureAdAuthenticationManager.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/config/AzureAdAuthenticationManager.kt
@@ -1,0 +1,37 @@
+package no.nav.familie.integrasjoner.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Primary
+import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.authentication.ProviderManager
+import org.springframework.security.core.Authentication
+import org.springframework.security.oauth2.jwt.JwtAudienceValidator
+import org.springframework.security.oauth2.jwt.JwtIssuerValidator
+import org.springframework.security.oauth2.jwt.JwtValidators.createDefaultWithValidators
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationProvider
+import org.springframework.stereotype.Component
+
+@Primary
+@Component("azureAdAuthenticationManager")
+class AzureAdAuthenticationManager(
+    @Value("\${AZURE_OPENID_CONFIG_JWKS_URI}") jwksUri: String,
+    @Value("\${AZURE_OPENID_CONFIG_ISSUER}") issuer: String,
+    @Value("\${AZURE_APP_CLIENT_ID}") audience: String,
+) : AuthenticationManager {
+    private val providerManager: ProviderManager =
+        run {
+            val decoder =
+                NimbusJwtDecoder.withJwkSetUri(jwksUri).build().also {
+                    it.setJwtValidator(
+                        createDefaultWithValidators(
+                            JwtIssuerValidator(issuer),
+                            JwtAudienceValidator(audience),
+                        ),
+                    )
+                }
+            ProviderManager(JwtAuthenticationProvider(decoder))
+        }
+
+    override fun authenticate(authentication: Authentication): Authentication = providerManager.authenticate(authentication)
+}

--- a/src/main/java/no/nav/familie/integrasjoner/config/GraphQLWebClientConfig.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/config/GraphQLWebClientConfig.kt
@@ -7,12 +7,12 @@ import no.nav.familie.log.NavHttpHeaders
 import no.nav.familie.log.mdc.MDCConstants
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
 import no.nav.security.token.support.client.spring.ClientConfigurationProperties
-import no.nav.security.token.support.core.exceptions.JwtTokenValidatorException
 import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.ClientRequest
 import org.springframework.web.reactive.function.client.ClientResponse
@@ -61,7 +61,7 @@ class GraphQLWebClientConfig {
 
             val accessToken: String =
                 oAuth2AccessTokenService.getAccessToken(clientProperties).access_token
-                    ?: throw JwtTokenValidatorException("Kunne ikke hente accesstoken")
+                    ?: throw AuthenticationCredentialsNotFoundException("Kunne ikke hente accesstoken")
             val filtered =
                 ClientRequest
                     .from(request)

--- a/src/main/java/no/nav/familie/integrasjoner/config/SecurityConfig.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/config/SecurityConfig.kt
@@ -1,0 +1,71 @@
+package no.nav.familie.integrasjoner.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.annotation.Order
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.annotation.web.invoke
+import org.springframework.security.web.SecurityFilterChain
+
+@Configuration
+@EnableWebSecurity
+class SecurityConfig(
+    private val azureAdAuthenticationManager: AzureAdAuthenticationManager,
+    private val tokenXAuthenticationManager: TokenXAuthenticationManager,
+) {
+    @Bean
+    @Order(1)
+    fun publicFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http {
+            securityMatcher(
+                "/internal/**",
+                "/v3/api-docs/**",
+                "/swagger-ui/**",
+                "/api/kodeverk/**",
+                "/api/ping",
+                "/favicon.ico",
+            )
+            csrf { disable() }
+            authorizeHttpRequests {
+                authorize(anyRequest, permitAll)
+            }
+        }
+        return http.build()
+    }
+
+    @Bean
+    @Order(2)
+    fun tokenXFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http {
+            securityMatcher("/api/journalpostselvbetjening/**")
+            csrf { disable() }
+            authorizeHttpRequests {
+                authorize(anyRequest, authenticated)
+            }
+            oauth2ResourceServer {
+                jwt {
+                    authenticationManager = tokenXAuthenticationManager
+                }
+            }
+        }
+        return http.build()
+    }
+
+    @Bean
+    @Order(3)
+    fun azureAdFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http {
+            csrf { disable() }
+            authorizeHttpRequests {
+                authorize(anyRequest, authenticated)
+            }
+            oauth2ResourceServer {
+                jwt {
+                    authenticationManager = azureAdAuthenticationManager
+                }
+            }
+        }
+        return http.build()
+    }
+}

--- a/src/main/java/no/nav/familie/integrasjoner/config/SecurityConfig.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/config/SecurityConfig.kt
@@ -1,12 +1,22 @@
 package no.nav.familie.integrasjoner.config
 
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.felles.Ressurs.Companion.failure
+import no.nav.familie.kontrakter.felles.jsonMapper
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.annotation.Order
+import org.springframework.http.MediaType
+import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.invoke
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.access.AccessDeniedHandler
 
 @Configuration
 @EnableWebSecurity
@@ -48,6 +58,10 @@ class SecurityConfig(
                     authenticationManager = tokenXAuthenticationManager
                 }
             }
+            exceptionHandling {
+                accessDeniedHandler = accessDeniedHandler()
+                authenticationEntryPoint = authenticationEntryPoint()
+            }
         }
         return http.build()
     }
@@ -65,7 +79,46 @@ class SecurityConfig(
                     authenticationManager = azureAdAuthenticationManager
                 }
             }
+            exceptionHandling {
+                accessDeniedHandler = accessDeniedHandler()
+                authenticationEntryPoint = authenticationEntryPoint()
+            }
         }
         return http.build()
     }
+
+    private fun accessDeniedHandler(): AccessDeniedHandler =
+        AccessDeniedHandler { _: HttpServletRequest, response: HttpServletResponse, _: AccessDeniedException ->
+            response.apply {
+                status = HttpServletResponse.SC_FORBIDDEN
+                contentType = MediaType.APPLICATION_JSON_VALUE
+                characterEncoding = Charsets.UTF_8.name()
+                jsonMapper.writeValue(
+                    writer,
+                    Ressurs(
+                        data = null,
+                        status = Ressurs.Status.IKKE_TILGANG,
+                        melding = "Bruker har ikke tilgang",
+                        frontendFeilmelding = "Du mangler tilgang",
+                        stacktrace = null,
+                    ),
+                )
+            }
+        }
+
+    private fun authenticationEntryPoint(): AuthenticationEntryPoint =
+        AuthenticationEntryPoint { _: HttpServletRequest, response: HttpServletResponse, _: AuthenticationException ->
+            response.apply {
+                status = HttpServletResponse.SC_UNAUTHORIZED
+                contentType = MediaType.APPLICATION_JSON_VALUE
+                characterEncoding = Charsets.UTF_8.name()
+                jsonMapper.writeValue(
+                    writer,
+                    failure<Nothing>(
+                        errorMessage = "401 Unauthorized",
+                        frontendFeilmelding = "Kall ikke autorisert",
+                    ),
+                )
+            }
+        }
 }

--- a/src/main/java/no/nav/familie/integrasjoner/config/TokenValidationContextHolderConfig.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/config/TokenValidationContextHolderConfig.kt
@@ -7,7 +7,7 @@ import no.nav.security.token.support.core.jwt.JwtToken
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
-// TODO: Fjern denne klassen når alle klienter er skrevet om til å bruke Texas.Expand annotationCheck warning on line R11
+// TODO: Fjern denne klassen når alle klienter er skrevet om til å bruke Texas.
 
 /**
  * Midlertidig konfigurasjon i overgangen fra Nav token-support til Spring Security.

--- a/src/main/java/no/nav/familie/integrasjoner/config/TokenValidationContextHolderConfig.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/config/TokenValidationContextHolderConfig.kt
@@ -1,0 +1,39 @@
+package no.nav.familie.integrasjoner.config
+
+import no.nav.familie.integrasjoner.sikkerhet.SikkerhetsContext.hentJwt
+import no.nav.security.token.support.core.context.TokenValidationContext
+import no.nav.security.token.support.core.context.TokenValidationContextHolder
+import no.nav.security.token.support.core.jwt.JwtToken
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+// TODO: Fjern denne klassen når alle klienter er skrevet om til å bruke Texas.Expand annotationCheck warning on line R11
+
+/**
+ * Midlertidig konfigurasjon i overgangen fra Nav token-support til Spring Security.
+ *
+ * Eksponerer en [TokenValidationContextHolder]-bønne som leser token fra Spring Securitys
+ * [SecurityContextHolder] i stedet for Nav token-support sin egen kontekst.
+ *
+ * [EnableOAuth2Client][no.nav.security.token.support.client.spring.oauth2.EnableOAuth2Client] i [ApplicationConfig] aktiverer
+ * `token-client-spring` sin OAuth2-klientinfrastruktur, som internt bruker [TokenValidationContextHolder] til å
+ * hente brukerens innkommende token ved on-behalf-of-utveksling mot andre tjenester. Denne bønnen sørger for at
+ * det fungerer selv om Nav token-support ellers ikke er aktivt i applikasjonen.
+ *
+ */
+@Configuration
+class TokenValidationContextHolderConfig {
+    @Bean
+    fun tokenValidationContextHolder(): TokenValidationContextHolder = SpringSecurityTokenValidationContextHolder()
+
+    class SpringSecurityTokenValidationContextHolder : TokenValidationContextHolder {
+        override fun getTokenValidationContext(): TokenValidationContext {
+            val validatedTokens = hentJwt().let { mapOf(it.issuer.toString() to JwtToken(it.tokenValue)) }.orEmpty()
+            return TokenValidationContext(validatedTokens)
+        }
+
+        override fun setTokenValidationContext(tokenValidationContext: TokenValidationContext?) {
+            // No-op: Spring Security manages the token context
+        }
+    }
+}

--- a/src/main/java/no/nav/familie/integrasjoner/config/TokenXAuthenticationManager.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/config/TokenXAuthenticationManager.kt
@@ -1,0 +1,37 @@
+package no.nav.familie.integrasjoner.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.authentication.ProviderManager
+import org.springframework.security.core.Authentication
+import org.springframework.security.oauth2.jwt.JwtAudienceValidator
+import org.springframework.security.oauth2.jwt.JwtClaimValidator
+import org.springframework.security.oauth2.jwt.JwtIssuerValidator
+import org.springframework.security.oauth2.jwt.JwtValidators
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationProvider
+import org.springframework.stereotype.Component
+
+@Component("tokenXAuthenticationManager")
+class TokenXAuthenticationManager(
+    @Value("\${TOKEN_X_JWKS_URI}") jwksUri: String,
+    @Value("\${TOKEN_X_ISSUER}") issuer: String,
+    @Value("\${TOKEN_X_CLIENT_ID}") audience: String,
+) : AuthenticationManager {
+    private val providerManager: ProviderManager =
+        run {
+            val decoder =
+                NimbusJwtDecoder.withJwkSetUri(jwksUri).build().also {
+                    it.setJwtValidator(
+                        JwtValidators.createDefaultWithValidators(
+                            JwtIssuerValidator(issuer),
+                            JwtAudienceValidator(audience),
+                            JwtClaimValidator<String>("acr") { acr -> acr == "Level4" || acr == "idporten-loa-high" },
+                        ),
+                    )
+                }
+            ProviderManager(JwtAuthenticationProvider(decoder))
+        }
+
+    override fun authenticate(authentication: Authentication): Authentication = providerManager.authenticate(authentication)
+}

--- a/src/main/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivController.kt
@@ -14,7 +14,6 @@ import no.nav.familie.kontrakter.felles.dokarkiv.LogiskVedleggResponse
 import no.nav.familie.kontrakter.felles.dokarkiv.OppdaterJournalpostRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.OppdaterJournalpostResponse
 import no.nav.familie.kontrakter.felles.dokarkiv.v2.ArkiverDokumentRequest
-import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -37,7 +36,6 @@ import org.springframework.web.bind.annotation.RestController
 import java.util.function.Consumer
 
 @RestController
-@ProtectedWithClaims(issuer = "azuread")
 @RequestMapping("/api/arkiv")
 class DokarkivController(
     private val journalføringService: DokarkivService,

--- a/src/main/java/no/nav/familie/integrasjoner/dokdist/DokdistController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokdist/DokdistController.kt
@@ -4,7 +4,6 @@ import jakarta.validation.Valid
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.Ressurs.Companion.success
 import no.nav.familie.kontrakter.felles.dokdist.DistribuerJournalpostRequest
-import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -17,7 +16,6 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.client.HttpClientErrorException
 
 @RestController
-@ProtectedWithClaims(issuer = "azuread")
 @RequestMapping("/api/dist")
 class DokdistController(
     private val dokdistService: DokdistService,

--- a/src/main/java/no/nav/familie/integrasjoner/dokdistkanal/DokdistkanalController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/dokdistkanal/DokdistkanalController.kt
@@ -12,7 +12,6 @@ import no.nav.familie.kontrakter.felles.Ressurs.Companion.success
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.dokdistkanal.Distribusjonskanal
 import no.nav.familie.kontrakter.felles.dokdistkanal.DokdistkanalRequest
-import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.apache.commons.lang3.StringUtils.isNumeric
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -26,7 +25,6 @@ import java.util.Locale
 import java.util.stream.Collectors
 
 @RestController
-@ProtectedWithClaims(issuer = "azuread")
 @RequestMapping("/api/dokdistkanal")
 class DokdistkanalController(
     private val dokdistkanalRestClient: DokdistkanalRestClient,

--- a/src/main/java/no/nav/familie/integrasjoner/egenansatt/EgenAnsattController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/egenansatt/EgenAnsattController.kt
@@ -4,7 +4,6 @@ import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.Ressurs.Companion.success
 import no.nav.familie.kontrakter.felles.egenansatt.EgenAnsattResponse
 import no.nav.familie.kontrakter.felles.personopplysning.Ident
-import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -13,7 +12,6 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@ProtectedWithClaims(issuer = "azuread")
 @RequestMapping("/api/egenansatt")
 class EgenAnsattController(
     private val egenAnsattService: EgenAnsattService,

--- a/src/main/java/no/nav/familie/integrasjoner/helse/PingController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/helse/PingController.kt
@@ -1,12 +1,10 @@
 package no.nav.familie.integrasjoner.helse
 
-import no.nav.security.token.support.core.api.Unprotected
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
-@Unprotected
 @RestController
 @RequestMapping("/api/ping")
 class PingController {

--- a/src/main/java/no/nav/familie/integrasjoner/journalpost/HentJournalpostController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/journalpost/HentJournalpostController.kt
@@ -6,7 +6,6 @@ import no.nav.familie.kontrakter.felles.Ressurs.Companion.success
 import no.nav.familie.kontrakter.felles.journalpost.Journalpost
 import no.nav.familie.kontrakter.felles.journalpost.JournalposterForBrukerRequest
 import no.nav.familie.kontrakter.felles.journalpost.TilgangsstyrtJournalpost
-import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -18,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/journalpost")
-@ProtectedWithClaims(issuer = "azuread")
 class HentJournalpostController(
     private val journalpostService: JournalpostService,
 ) {

--- a/src/main/java/no/nav/familie/integrasjoner/journalpost/selvbetjening/JournalpostSelvbetjeningController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/journalpost/selvbetjening/JournalpostSelvbetjeningController.kt
@@ -4,8 +4,6 @@ import kotlinx.coroutines.runBlocking
 import no.nav.familie.integrasjoner.safselvbetjening.generated.enums.Tema
 import no.nav.familie.integrasjoner.safselvbetjening.generated.hentdokumentoversikt.Dokumentoversikt
 import no.nav.familie.sikkerhet.EksternBrukerUtils
-import no.nav.security.token.support.core.api.ProtectedWithClaims
-import no.nav.security.token.support.core.api.RequiredIssuers
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -14,9 +12,6 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/journalpostselvbetjening")
-@RequiredIssuers(
-    ProtectedWithClaims(issuer = EksternBrukerUtils.ISSUER_TOKENX, claimMap = ["acr=Level4"]),
-)
 class JournalpostSelvbetjeningController(
     private val safSelvbetjeningService: SafSelvbetjeningService,
 ) {

--- a/src/main/java/no/nav/familie/integrasjoner/journalpost/versjonertsøknad/BaksVersjonertSøknadController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/journalpost/versjonertsøknad/BaksVersjonertSøknadController.kt
@@ -4,7 +4,6 @@ import no.nav.familie.kontrakter.ba.søknad.VersjonertBarnetrygdSøknad
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.Ressurs.Companion.success
 import no.nav.familie.kontrakter.ks.søknad.VersjonertKontantstøtteSøknad
-import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -17,7 +16,6 @@ import org.springframework.web.bind.annotation.RestController
  */
 @RestController
 @RequestMapping("/api/baks/versjonertsoknad")
-@ProtectedWithClaims(issuer = "azuread")
 class BaksVersjonertSøknadController(
     private val baksVersjonertSøknadService: BaksVersjonertSøknadService,
 ) {

--- a/src/main/java/no/nav/familie/integrasjoner/kodeverk/KodeverkController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/kodeverk/KodeverkController.kt
@@ -3,7 +3,6 @@ package no.nav.familie.integrasjoner.kodeverk
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.kodeverk.InntektKodeverkDto
 import no.nav.familie.kontrakter.felles.kodeverk.KodeverkDto
-import no.nav.security.token.support.core.api.Unprotected
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -15,7 +14,6 @@ import org.springframework.web.bind.annotation.RestController
  * UNPROTECTED
  * Hvis man legger til noe her må man vurdere at det er greit å hente informasjonen uten ProtectedWithClaims
  */
-@Unprotected
 @RestController
 @RequestMapping(path = ["/api/kodeverk"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class KodeverkController(

--- a/src/main/java/no/nav/familie/integrasjoner/modiacontextholder/ModiaContextHolderController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/modiacontextholder/ModiaContextHolderController.kt
@@ -5,7 +5,6 @@ import no.nav.familie.integrasjoner.modiacontextholder.domene.ModiaContextHolder
 import no.nav.familie.integrasjoner.modiacontextholder.domene.ModiaContextHolderResponse
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.Ressurs.Companion.success
-import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
@@ -14,7 +13,6 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@ProtectedWithClaims(issuer = "azuread")
 @RequestMapping("/api/modia-context-holder")
 class ModiaContextHolderController(
     private val modiaContextHolderClient: ModiaContextHolderClient,

--- a/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/oppgave/OppgaveController.kt
@@ -12,7 +12,6 @@ import no.nav.familie.kontrakter.felles.oppgave.MappeDto
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
 import no.nav.familie.kontrakter.felles.oppgave.OppgaveResponse
 import no.nav.familie.kontrakter.felles.oppgave.OpprettOppgaveRequest
-import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -26,7 +25,6 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@ProtectedWithClaims(issuer = "azuread")
 @RequestMapping("/api/oppgave")
 class OppgaveController(
     private val oppgaveService: OppgaveService,

--- a/src/main/java/no/nav/familie/integrasjoner/organisasjon/OrganisasjonController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/organisasjon/OrganisasjonController.kt
@@ -3,7 +3,6 @@ package no.nav.familie.integrasjoner.organisasjon
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.Ressurs.Companion.success
 import no.nav.familie.kontrakter.felles.organisasjon.Organisasjon
-import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.context.annotation.Profile
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
@@ -12,7 +11,6 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@ProtectedWithClaims(issuer = "azuread")
 @RequestMapping("/api/organisasjon")
 @Profile("!e2e")
 class OrganisasjonController(

--- a/src/main/java/no/nav/familie/integrasjoner/organisasjon/OrganisasjonControllerE2E.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/organisasjon/OrganisasjonControllerE2E.kt
@@ -3,7 +3,6 @@ package no.nav.familie.integrasjoner.organisasjon
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.Ressurs.Companion.success
 import no.nav.familie.kontrakter.felles.organisasjon.Organisasjon
-import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.context.annotation.Profile
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
@@ -12,7 +11,6 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@ProtectedWithClaims(issuer = "azuread")
 @RequestMapping("/api/organisasjon")
 @Profile("e2e")
 class OrganisasjonControllerE2E {

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/PersonopplysningerController.kt
@@ -10,7 +10,6 @@ import no.nav.familie.kontrakter.felles.Ressurs.Companion.success
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.personopplysning.FinnPersonidenterResponse
 import no.nav.familie.kontrakter.felles.personopplysning.Ident
-import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -25,7 +24,6 @@ import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.HttpClientErrorException.Forbidden
 
 @RestController
-@ProtectedWithClaims(issuer = "azuread")
 @RequestMapping("/api/personopplysning")
 class PersonopplysningerController(
     private val personopplysningerService: PersonopplysningerService,

--- a/src/main/java/no/nav/familie/integrasjoner/sak/SkyggesakController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/sak/SkyggesakController.kt
@@ -3,7 +3,6 @@ package no.nav.familie.integrasjoner.sak
 import no.nav.familie.integrasjoner.client.rest.SkyggesakRestClient
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.Ressurs.Companion.success
-import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -12,7 +11,6 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@ProtectedWithClaims(issuer = "azuread")
 @RequestMapping("/api/skyggesak")
 class SkyggesakController(
     private val skyggesakRestClient: SkyggesakRestClient,

--- a/src/main/java/no/nav/familie/integrasjoner/saksbehandler/SaksbehandlerController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/saksbehandler/SaksbehandlerController.kt
@@ -3,7 +3,6 @@ package no.nav.familie.integrasjoner.saksbehandler
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.saksbehandler.Saksbehandler
 import no.nav.familie.kontrakter.felles.saksbehandler.SaksbehandlerGrupper
-import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.context.annotation.Profile
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -17,7 +16,6 @@ class SaksbehandlerController(
     private val saksbehandlerService: SaksbehandlerService,
 ) {
     @GetMapping(path = ["/{id}"])
-    @ProtectedWithClaims(issuer = "azuread")
     fun hentSaksbehandler(
         @PathVariable id: String,
     ): Ressurs<Saksbehandler> { // id kan være azure-id, e-post eller nav-ident
@@ -25,7 +23,6 @@ class SaksbehandlerController(
     }
 
     @GetMapping(path = ["/{id}/grupper"])
-    @ProtectedWithClaims(issuer = "azuread")
     fun hentSaksbehandlerGrupper(
         @PathVariable id: String,
     ): Ressurs<SaksbehandlerGrupper> { // id kan være azure-id, e-post eller nav-ident

--- a/src/main/java/no/nav/familie/integrasjoner/saksbehandler/SaksbehandlerControllerE2E.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/saksbehandler/SaksbehandlerControllerE2E.kt
@@ -2,7 +2,6 @@ package no.nav.familie.integrasjoner.saksbehandler
 
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.saksbehandler.Saksbehandler
-import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.context.annotation.Profile
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -15,7 +14,6 @@ import java.util.UUID
 @Profile("e2e")
 class SaksbehandlerControllerE2E {
     @GetMapping(path = ["/{id}"])
-    @ProtectedWithClaims(issuer = "azuread")
     fun hentSaksbehandler(
         @PathVariable id: String,
     ): Ressurs<Saksbehandler> =

--- a/src/main/java/no/nav/familie/integrasjoner/sikkerhet/SikkerhetsContext.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/sikkerhet/SikkerhetsContext.kt
@@ -1,38 +1,23 @@
 package no.nav.familie.integrasjoner.sikkerhet
 
-import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
 
 object SikkerhetsContext {
     private const val SYSTEM_NAVN = "System"
     const val SYSTEM_FORKORTELSE = "VL"
 
-    fun hentSaksbehandler(): String {
-        val result = hentSaksbehandlerEllerSystembruker()
-
-        if (result == SYSTEM_FORKORTELSE) {
-            error("Finner ikke NAVident i token")
-        }
-        return result
-    }
-
-    fun hentSaksbehandlerEllerSystembruker() =
-        Result
-            .runCatching { SpringTokenValidationContextHolder().getTokenValidationContext() }
-            .fold(
-                onSuccess = {
-                    it.getClaims("azuread")?.get("NAVident")?.toString() ?: SYSTEM_FORKORTELSE
-                },
-                onFailure = { SYSTEM_FORKORTELSE },
-            )
+    fun hentSaksbehandlerEllerSystembruker(): String = hentClaim<String>("NAVident") ?: SYSTEM_FORKORTELSE
 
     fun hentSaksbehandlerNavn(strict: Boolean = false): String =
-        Result
-            .runCatching { SpringTokenValidationContextHolder().getTokenValidationContext() }
-            .fold(
-                onSuccess = {
-                    it.getClaims("azuread")?.get("name")?.toString()
-                        ?: if (strict) error("Finner ikke navn i azuread token") else SYSTEM_NAVN
-                },
-                onFailure = { if (strict) error("Finner ikke navn på innlogget bruker") else SYSTEM_NAVN },
-            )
+        hentClaim<String>("name")
+            ?: if (strict) error("Finner ikke navn i azuread token") else SYSTEM_NAVN
+
+    fun <T> hentClaim(claim: String): T? = hentJwt().getClaim(claim)
+
+    fun hentJwt(): Jwt =
+        (SecurityContextHolder.getContext().authentication as? JwtAuthenticationToken)?.token
+            ?: throw AuthenticationCredentialsNotFoundException("Klarte ikke hente token fra context")
 }

--- a/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollService.kt
@@ -9,12 +9,16 @@ import no.nav.familie.integrasjoner.personopplysning.internal.ADRESSEBESKYTTELSE
 import no.nav.familie.integrasjoner.personopplysning.internal.ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG
 import no.nav.familie.integrasjoner.personopplysning.internal.ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG_UTLAND
 import no.nav.familie.integrasjoner.personopplysning.internal.PersonMedRelasjoner
+import no.nav.familie.integrasjoner.sikkerhet.SikkerhetsContext.hentClaim
+import no.nav.familie.integrasjoner.sikkerhet.SikkerhetsContext.hentJwt
 import no.nav.familie.integrasjoner.tilgangskontroll.domene.AdRolle
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.tilgangskontroll.Tilgang
-import no.nav.security.token.support.core.jwt.JwtToken
 import org.slf4j.LoggerFactory
 import org.springframework.cache.annotation.Cacheable
+import org.springframework.cache.interceptor.KeyGenerator
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.stereotype.Service
 
 @Service
@@ -25,52 +29,49 @@ class CachedTilgangskontrollService(
 ) {
     @Cacheable(
         cacheNames = [TILGANG_TIL_BRUKER],
-        key = "#jwtToken.subject.concat(#personIdent)",
-        condition = "#personIdent != null && #jwtToken.subject != null",
+        keyGenerator = "tilgangCacheKeyGenerator",
+        condition = "#personIdent != null",
     )
     fun sjekkTilgang(
         personIdent: String,
-        jwtToken: JwtToken,
         tema: Tema,
     ): Tilgang =
         try {
             val adressebeskyttelse = personopplysningerService.hentAdressebeskyttelse(personIdent, tema).gradering
-            hentTilgang(adressebeskyttelse, jwtToken, personIdent) { egenAnsattService.erEgenAnsatt(personIdent) }
+            hentTilgang(adressebeskyttelse, personIdent) { egenAnsattService.erEgenAnsatt(personIdent) }
         } catch (pdlUnauthorizedException: PdlUnauthorizedException) {
             Tilgang(personIdent = personIdent, harTilgang = false, begrunnelse = pdlUnauthorizedException.message)
         }
 
     @Cacheable(
         cacheNames = ["TILGANG_TIL_PERSON_MED_RELASJONER"],
-        key = "#jwtToken.subject.concat(#personIdent)",
-        condition = "#jwtToken.subject != null",
+        keyGenerator = "tilgangCacheKeyGenerator",
+        condition = "#personIdent != null",
     )
     fun sjekkTilgangTilPersonMedRelasjoner(
         personIdent: String,
-        jwtToken: JwtToken,
         tema: Tema,
     ): Tilgang {
         val personMedRelasjoner = personopplysningerService.hentPersonMedRelasjoner(personIdent, tema)
         secureLogger.info("Sjekker tilgang til {}", personMedRelasjoner.personIdent)
 
         val høyesteGraderingen = TilgangskontrollUtil.høyesteGraderingen(personMedRelasjoner)
-        return hentTilgang(høyesteGraderingen, jwtToken, personIdent) { erEgenAnsatt(personMedRelasjoner) }
+        return hentTilgang(høyesteGraderingen, personIdent) { erEgenAnsatt(personMedRelasjoner) }
     }
 
     private fun hentTilgang(
         adressebeskyttelsegradering: ADRESSEBESKYTTELSEGRADERING?,
-        jwtToken: JwtToken,
         personIdent: String,
         egenAnsattSjekk: () -> Boolean,
     ): Tilgang {
         val tilgang =
             when (adressebeskyttelsegradering) {
                 FORTROLIG -> {
-                    hentTilgangForRolle(tilgangConfig.kode7, jwtToken, personIdent)
+                    hentTilgangForRolle(tilgangConfig.kode7, personIdent)
                 }
 
                 STRENGT_FORTROLIG, STRENGT_FORTROLIG_UTLAND -> {
-                    hentTilgangForRolle(tilgangConfig.kode6, jwtToken, personIdent)
+                    hentTilgangForRolle(tilgangConfig.kode6, personIdent)
                 }
 
                 else -> {
@@ -81,7 +82,7 @@ class CachedTilgangskontrollService(
             return tilgang
         }
         if (egenAnsattSjekk()) {
-            return hentTilgangForRolle(tilgangConfig.egenAnsatt, jwtToken, personIdent)
+            return hentTilgangForRolle(tilgangConfig.egenAnsatt, personIdent)
         }
         return Tilgang(personIdent = personIdent, harTilgang = true)
     }
@@ -103,17 +104,13 @@ class CachedTilgangskontrollService(
 
     private fun hentTilgangForRolle(
         adRolle: AdRolle?,
-        jwtToken: JwtToken,
         personIdent: String,
     ): Tilgang {
-        val grupper = jwtToken.jwtTokenClaims.getAsList("groups")
+        val grupper = hentClaim<List<String>>("groups") ?: emptyList()
         if (grupper.any { it == adRolle?.rolleId }) {
             return Tilgang(personIdent, true)
         }
-        secureLogger.info(
-            "${jwtToken.jwtTokenClaims.get("preferred_username")} " +
-                "har ikke tilgang ${adRolle?.beskrivelse} for $personIdent",
-        )
+        secureLogger.info("${hentClaim<String>("preferred_username")} har ikke tilgang ${adRolle?.beskrivelse} for $personIdent")
         return Tilgang(personIdent = personIdent, harTilgang = false, begrunnelse = adRolle?.beskrivelse)
     }
 
@@ -122,4 +119,15 @@ class CachedTilgangskontrollService(
 
         const val TILGANG_TIL_BRUKER = "tilgangTilBruker"
     }
+}
+
+@Configuration
+class TilgangskontrollCacheConfig {
+    @Bean
+    fun tilgangCacheKeyGenerator(): KeyGenerator =
+        KeyGenerator { _, _, params ->
+            val personIdent = params[0] as String
+            val subject = hentJwt().subject
+            "$subject:$personIdent"
+        }
 }

--- a/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollService.kt
@@ -30,7 +30,7 @@ class CachedTilgangskontrollService(
     @Cacheable(
         cacheNames = [TILGANG_TIL_BRUKER],
         keyGenerator = "tilgangCacheKeyGenerator",
-        condition = "#personIdent != null",
+        condition = "@tilgangskontrollCacheConfig.skalCache(#personIdent)",
     )
     fun sjekkTilgang(
         personIdent: String,
@@ -46,7 +46,7 @@ class CachedTilgangskontrollService(
     @Cacheable(
         cacheNames = ["TILGANG_TIL_PERSON_MED_RELASJONER"],
         keyGenerator = "tilgangCacheKeyGenerator",
-        condition = "#personIdent != null",
+        condition = "@tilgangskontrollCacheConfig.skalCache(#personIdent)",
     )
     fun sjekkTilgangTilPersonMedRelasjoner(
         personIdent: String,
@@ -123,11 +123,13 @@ class CachedTilgangskontrollService(
 
 @Configuration
 class TilgangskontrollCacheConfig {
+    fun skalCache(personIdent: String?): Boolean = personIdent != null && runCatching { hentJwt().subject != null }.getOrDefault(false)
+
     @Bean
     fun tilgangCacheKeyGenerator(): KeyGenerator =
         KeyGenerator { _, _, params ->
             val personIdent = params[0] as String
-            val subject = hentJwt().subject
+            val subject = hentJwt().subject!!
             "$subject:$personIdent"
         }
 }

--- a/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/FaviconController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/FaviconController.kt
@@ -1,13 +1,11 @@
 package no.nav.familie.integrasjoner.tilgangskontroll
 
-import no.nav.security.token.support.core.api.Unprotected
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class FaviconController {
     @GetMapping("favicon.ico")
-    @Unprotected
     fun dummyFavicon() {
         // nop
     }

--- a/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/TilgangskontrollController.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/TilgangskontrollController.kt
@@ -3,7 +3,6 @@ package no.nav.familie.integrasjoner.tilgangskontroll
 import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.tilgangskontroll.Tilgang
-import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.context.annotation.Profile
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -18,14 +17,12 @@ class TilgangskontrollController(
     private val tilgangskontrollService: TilgangskontrollService,
 ) {
     @PostMapping(path = ["/v2/personer"])
-    @ProtectedWithClaims(issuer = "azuread")
     fun tilgangTilPersoner(
         @RequestBody personIdenter: List<String>,
         @RequestHeader(name = "Nav-Tema") tema: Tema,
     ): List<Tilgang> = tilgangskontrollService.sjekkTilgangTilBrukere(personIdenter, tema)
 
     @PostMapping(path = ["/person-med-relasjoner"])
-    @ProtectedWithClaims(issuer = "azuread")
     fun tilgangTilPersonMedRelasjoner(
         @RequestBody personIdent: PersonIdent,
         @RequestHeader(name = "Nav-Tema") tema: Tema,

--- a/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/TilgangskontrollService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/tilgangskontroll/TilgangskontrollService.kt
@@ -2,9 +2,6 @@ package no.nav.familie.integrasjoner.tilgangskontroll
 
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.tilgangskontroll.Tilgang
-import no.nav.security.token.support.core.exceptions.JwtTokenValidatorException
-import no.nav.security.token.support.core.jwt.JwtToken
-import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
 import org.springframework.stereotype.Service
 
 @Service
@@ -19,16 +16,12 @@ class TilgangskontrollService(
     fun sjekkTilgangTilBruker(
         personIdent: String,
         tema: Tema = Tema.BAR,
-    ): Tilgang {
-        val jwtToken = SpringTokenValidationContextHolder().getTokenValidationContext().getJwtToken("azuread") ?: throw JwtTokenValidatorException("Klarte ikke hente token fra issuer azuread")
-        return cachedTilgangskontrollService.sjekkTilgang(personIdent, jwtToken, tema)
-    }
+    ): Tilgang = cachedTilgangskontrollService.sjekkTilgang(personIdent, tema)
 
     fun sjekkTilgang(
         personIdent: String,
-        jwtToken: JwtToken,
         tema: Tema = Tema.BAR,
-    ): Tilgang = cachedTilgangskontrollService.sjekkTilgang(personIdent, jwtToken, tema)
+    ): Tilgang = cachedTilgangskontrollService.sjekkTilgang(personIdent, tema)
 
     fun sjekkTilgangTilPersonMedRelasjoner(
         personIdent: String,
@@ -37,7 +30,6 @@ class TilgangskontrollService(
         if (tema != Tema.ENF && tema != Tema.BAR && tema != Tema.TSO) {
             throw IllegalArgumentException("Har ikke lagt inn støtte for andre enn ENF, BAR eller TSO")
         }
-        val jwtToken = SpringTokenValidationContextHolder().getTokenValidationContext().getJwtToken("azuread") ?: throw JwtTokenValidatorException("Klarte ikke hente token fra issuer azuread")
-        return cachedTilgangskontrollService.sjekkTilgangTilPersonMedRelasjoner(personIdent, jwtToken, tema)
+        return cachedTilgangskontrollService.sjekkTilgangTilPersonMedRelasjoner(personIdent, tema)
     }
 }

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,7 +1,4 @@
 no.nav.security.jwt:
-  issuer.azuread:
-    discoveryurl: ${AZURE_APP_WELL_KNOWN_URL}
-    accepted_audience: ${AZURE_APP_CLIENT_ID}
   client:
     registration:
       aad-graph-onbehalfof:
@@ -222,7 +219,6 @@ SFTP_PASSPHRASE: Palpatine
 # mock-server
 PDL_URL: http://localhost:1337/rest/api/pdl
 
-AZURE_APP_WELL_KNOWN_URL: http://localhost:${mock-oauth2-server.port}/selvbetjening/.well-known/openid-configuration
 AZURE_OPENID_CONFIG_TOKEN_ENDPOINT: https://login.microsoftonline.com/navq.onmicrosoft.com/oauth2/v2.0/token
 
 NAIS_APP_NAME: familie-integrasjoner

--- a/src/main/resources/application-e2e.yml
+++ b/src/main/resources/application-e2e.yml
@@ -1,7 +1,4 @@
 no.nav.security.jwt:
-  issuer.azuread:
-    discoveryurl: http://mock-oauth2-server:1111/v2.0/.well-known/openid-configuration
-    accepted_audience: api://${AZURE_APP_CLIENT_ID}/.default
   client:
     registration:
       aad-graph-onbehalfof:

--- a/src/main/resources/application-integrasjonstest.yaml
+++ b/src/main/resources/application-integrasjonstest.yaml
@@ -1,7 +1,4 @@
 no.nav.security.jwt:
-  issuer.azuread:
-    discoveryurl: http://localhost:${mock-oauth2-server.port}/azuread/.well-known/openid-configuration
-    accepted_audience: aud-localhost
   client:
     registration:
       aad-graph-onbehalfof:

--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -1,11 +1,4 @@
 no.nav.security.jwt:
-  issuer.azuread:
-    discoveryurl: ${AZURE_APP_WELL_KNOWN_URL}
-    accepted_audience: ${AZURE_APP_CLIENT_ID}
-    proxyurl: http://webproxy-nais.nav.no:8088
-  issuer.tokenx:
-    discoveryurl: ${TOKEN_X_WELL_KNOWN_URL}
-    accepted_audience: ${TOKEN_X_CLIENT_ID}
   client:
     registration:
       aad-graph-onbehalfof:

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,11 +1,4 @@
 no.nav.security.jwt:
-  issuer.azuread:
-    discoveryurl: ${AZURE_APP_WELL_KNOWN_URL}
-    accepted_audience: ${AZURE_APP_CLIENT_ID}
-    proxyurl: http://webproxy-nais.nav.no:8088
-  issuer.tokenx:
-    discoveryurl: ${TOKEN_X_WELL_KNOWN_URL}
-    accepted_audience: ${TOKEN_X_CLIENT_ID}
   client:
     registration:
       aad-graph-onbehalfof:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -55,6 +55,11 @@ familie:
 
 AZURE_APP_CLIENT_ID: "dummy-klient-id"
 AZURE_APP_CLIENT_SECRET: "dummy-klient-secret"
+AZURE_OPENID_CONFIG_JWKS_URI: "dummy-azure-openid-config-jwks-uri"
+AZURE_OPENID_CONFIG_ISSUER: "dummy-azure-openid-config-issuer-uri"
+  
+TOKEN_X_JWKS_URI: "dummy-token-x-jwks-uri"
+TOKEN_X_ISSUER: "dummy-token-x-issuer"
 TOKEN_X_WELL_KNOWN_URL: "dummy-token-x-well-known-url"
 #Dummy private jwk
 TOKEN_X_PRIVATE_JWK: '{

--- a/src/test/java/no/nav/familie/integrasjoner/DevLauncher.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/DevLauncher.kt
@@ -1,12 +1,12 @@
 package no.nav.familie.integrasjoner
 
 import no.nav.familie.integrasjoner.config.ApplicationConfig
-import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
 import org.springframework.boot.builder.SpringApplicationBuilder
 import org.springframework.context.annotation.Import
+import org.springframework.test.context.ContextConfiguration
 
 @Import(ApplicationConfig::class)
-@EnableMockOAuth2Server
+@ContextConfiguration(initializers = [MockOAuth2ServerInitializer::class])
 class DevLauncher
 
 fun main(args: Array<String>) {

--- a/src/test/java/no/nav/familie/integrasjoner/MockOAuth2ServerInitializer.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/MockOAuth2ServerInitializer.kt
@@ -1,0 +1,35 @@
+package no.nav.familie.integrasjoner
+
+import no.nav.security.mock.oauth2.MockOAuth2Server
+import org.springframework.context.ApplicationContextInitializer
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.core.env.MapPropertySource
+
+class MockOAuth2ServerInitializer : ApplicationContextInitializer<ConfigurableApplicationContext> {
+    override fun initialize(applicationContext: ConfigurableApplicationContext) {
+        val properties =
+            mapOf<String, Any>(
+                "AZURE_OPENID_CONFIG_ISSUER" to server.issuerUrl("azuread").toString(),
+                "AZURE_APP_CLIENT_ID" to "aud-localhost",
+                "AZURE_OPENID_CONFIG_JWKS_URI" to server.jwksUrl("azuread").toString(),
+                "TOKEN_X_ISSUER" to server.issuerUrl("tokenx").toString(),
+                "TOKEN_X_CLIENT_ID" to "aud-localhost",
+                "TOKEN_X_JWKS_URI" to server.jwksUrl("tokenx").toString(),
+            )
+
+        applicationContext.environment.propertySources.addFirst(
+            MapPropertySource("mockOAuth2Server", properties),
+        )
+
+        applicationContext.beanFactory.registerSingleton("mockOAuth2Server", server)
+    }
+
+    companion object {
+        val server: MockOAuth2Server by lazy {
+            MockOAuth2Server().also { server ->
+                server.start()
+                Runtime.getRuntime().addShutdownHook(Thread { server.shutdown() })
+            }
+        }
+    }
+}

--- a/src/test/java/no/nav/familie/integrasjoner/OppslagSpringRunnerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/OppslagSpringRunnerTest.kt
@@ -4,7 +4,6 @@ import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.read.ListAppender
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
-import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
@@ -13,12 +12,13 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.cache.CacheManager
 import org.springframework.http.HttpHeaders
+import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.util.UUID
 
-@EnableMockOAuth2Server
 @ExtendWith(SpringExtension::class)
 @SpringBootTest(classes = [UnitTestLauncher::class], webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ContextConfiguration(initializers = [MockOAuth2ServerInitializer::class])
 abstract class OppslagSpringRunnerTest {
     protected val listAppender = initLoggingEventListAppender()
     protected val loggingEvents: MutableList<ILoggingEvent> = listAppender.list

--- a/src/test/java/no/nav/familie/integrasjoner/adramatch/FiloverføringAdraMatchControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/adramatch/FiloverføringAdraMatchControllerTest.kt
@@ -5,22 +5,28 @@ import no.nav.familie.integrasjoner.OppslagSpringRunnerTest
 import no.nav.familie.kontrakter.felles.Fil
 import no.nav.familie.kontrakter.felles.Ressurs
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.InvocationInterceptor
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
 import org.springframework.boot.resttestclient.exchange
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpMethod
 import org.springframework.http.ResponseEntity
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.web.util.UriComponentsBuilder
+import java.lang.reflect.Method
 
 @ActiveProfiles("integrasjonstest", "mock-sts", "mock-oauth")
 class FiloverføringAdraMatchControllerTest : OppslagSpringRunnerTest() {
-    @get:Rule
-    val sftpServer: FakeSftpServerRule = FakeSftpServerRule().apply { port = MOCK_SFTP_SERVER_PORT }
+    @field:RegisterExtension
+    private val sftpServer = FakeSftpServerExtension(MOCK_SFTP_SERVER_PORT)
 
-    @Before
+    @BeforeEach
     fun setUp() {
         headers.setBearerAuth(lokalTestToken)
     }
@@ -44,5 +50,37 @@ class FiloverføringAdraMatchControllerTest : OppslagSpringRunnerTest() {
     companion object {
         const val BASE_URL = "/api/adramatch/avstemming"
         const val MOCK_SFTP_SERVER_PORT = 18321
+    }
+}
+
+/**
+ * JUnit 5-extension som wrapper [FakeSftpServerRule] (JUnit 4) via [InvocationInterceptor].
+ */
+internal class FakeSftpServerExtension(
+    port: Int,
+) : InvocationInterceptor {
+    private val rule = FakeSftpServerRule().setPort(port)
+
+    fun createDirectory(path: String) = rule.createDirectory(path)
+
+    fun getFileContent(path: String): ByteArray = rule.getFileContent(path)
+
+    override fun interceptTestMethod(
+        invocation: InvocationInterceptor.Invocation<Void?>,
+        invocationContext: ReflectiveInvocationContext<Method>,
+        extensionContext: ExtensionContext,
+    ) {
+        rule
+            .apply(
+                object : Statement() {
+                    override fun evaluate() {
+                        invocation.proceed()
+                    }
+                },
+                Description.createTestDescription(
+                    extensionContext.requiredTestClass,
+                    extensionContext.displayName,
+                ),
+            ).evaluate()
     }
 }

--- a/src/test/java/no/nav/familie/integrasjoner/config/GraphQLWebClientConfigTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/config/GraphQLWebClientConfigTest.kt
@@ -9,13 +9,13 @@ import no.nav.security.token.support.client.core.ClientProperties
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenResponse
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
 import no.nav.security.token.support.client.spring.ClientConfigurationProperties
-import no.nav.security.token.support.core.exceptions.JwtTokenValidatorException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException
 import org.springframework.web.reactive.function.client.ClientRequest
 import org.springframework.web.reactive.function.client.ClientResponse
 import org.springframework.web.reactive.function.client.ExchangeFunction
@@ -104,7 +104,7 @@ class GraphQLWebClientConfigTest {
 
             // Act & Assert
             val exception =
-                assertThrows<JwtTokenValidatorException> {
+                assertThrows<AuthenticationCredentialsNotFoundException> {
                     exchangeTokenXBearerTokenFilter.filter(request, mockedExchangeFunction).block()
                 }
             assertThat(exception.message).isEqualTo("Kunne ikke hente accesstoken")

--- a/src/test/java/no/nav/familie/integrasjoner/config/SecurityConfigTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/config/SecurityConfigTest.kt
@@ -1,0 +1,161 @@
+package no.nav.familie.integrasjoner.config
+
+import no.nav.familie.integrasjoner.MockOAuth2ServerInitializer
+import no.nav.familie.integrasjoner.OppslagSpringRunnerTest
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.resttestclient.exchange
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus.FORBIDDEN
+import org.springframework.http.HttpStatus.UNAUTHORIZED
+import org.springframework.http.ResponseEntity
+import org.springframework.test.context.ActiveProfiles
+import java.util.UUID
+
+@ActiveProfiles("integrasjonstest", "mock-oauth")
+class SecurityConfigTest : OppslagSpringRunnerTest() {
+    @Test
+    fun `api-ping er tilgjengelig uten token`() {
+        val response =
+            restTemplate.exchange<String>(
+                localhost("/api/ping"),
+                HttpMethod.GET,
+                HttpEntity<Any>(headers),
+            )
+
+        assertThat(response.statusCode).isNotIn(UNAUTHORIZED, FORBIDDEN)
+    }
+
+    @Test
+    fun `internal-endepunkt er tilgjengelig uten token`() {
+        val response =
+            restTemplate.exchange<String>(
+                localhost("/internal/health"),
+                HttpMethod.GET,
+                HttpEntity<Any>(headers),
+            )
+
+        assertThat(response.statusCode).isNotIn(UNAUTHORIZED, FORBIDDEN)
+    }
+
+    @Test
+    fun `beskyttet endepunkt returnerer 401 uten token`() {
+        val response: ResponseEntity<String> =
+            restTemplate.exchange(
+                localhost("/api/organisasjon/123456789"),
+                HttpMethod.GET,
+                HttpEntity<Any>(headers),
+            )
+
+        assertThat(response.statusCode).isEqualTo(UNAUTHORIZED)
+    }
+
+    @Test
+    fun `beskyttet endepunkt returnerer 401 med ugyldig token`() {
+        headers.setBearerAuth("dette.er.ikke.et.gyldig.jwt")
+
+        val response: ResponseEntity<String> =
+            restTemplate.exchange(
+                localhost("/api/organisasjon/123456789"),
+                HttpMethod.GET,
+                HttpEntity<Any>(headers),
+            )
+
+        assertThat(response.statusCode).isEqualTo(UNAUTHORIZED)
+    }
+
+    @Test
+    fun `beskyttet endepunkt passerer autentisering med gyldig Azure AD-token`() {
+        headers.setBearerAuth(lokalTestToken)
+
+        val response: ResponseEntity<String> =
+            restTemplate.exchange(
+                localhost("/api/organisasjon/123456789"),
+                HttpMethod.GET,
+                HttpEntity<Any>(headers),
+            )
+
+        assertThat(response.statusCode).isNotIn(UNAUTHORIZED, FORBIDDEN)
+    }
+
+    @Test
+    fun `journalpostselvbetjening returnerer 401 uten token`() {
+        val response: ResponseEntity<String> =
+            restTemplate.exchange(
+                localhost("/api/journalpostselvbetjening/dokumentoversikt/BAR"),
+                HttpMethod.GET,
+                HttpEntity<Any>(headers),
+            )
+
+        assertThat(response.statusCode).isEqualTo(UNAUTHORIZED)
+    }
+
+    @Test
+    fun `journalpostselvbetjening returnerer 401 med Azure AD-token`() {
+        // Azure AD-token er ikke gyldig for TokenX-kjeden
+        headers.setBearerAuth(lokalTestToken)
+
+        val response: ResponseEntity<String> =
+            restTemplate.exchange(
+                localhost("/api/journalpostselvbetjening/dokumentoversikt/BAR"),
+                HttpMethod.GET,
+                HttpEntity<Any>(headers),
+            )
+
+        assertThat(response.statusCode).isEqualTo(UNAUTHORIZED)
+    }
+
+    @Test
+    fun `journalpostselvbetjening passerer autentisering med gyldig TokenX-token`() {
+        headers.setBearerAuth(lagTokenXToken())
+
+        val response: ResponseEntity<String> =
+            restTemplate.exchange(
+                localhost("/api/journalpostselvbetjening/dokumentoversikt/BAR"),
+                HttpMethod.GET,
+                HttpEntity<Any>(headers),
+            )
+
+        assertThat(response.statusCode).isNotIn(UNAUTHORIZED, FORBIDDEN)
+    }
+
+    @Test
+    fun `401-respons inneholder korrekt JSON-body`() {
+        val response: ResponseEntity<Ressurs<Nothing>> =
+            restTemplate.exchange(
+                localhost("/api/organisasjon/123456789"),
+                HttpMethod.GET,
+                HttpEntity<Any>(headers),
+            )
+
+        assertThat(response.statusCode).isEqualTo(UNAUTHORIZED)
+        assertThat(response.body?.status).isEqualTo(Ressurs.Status.FEILET)
+        assertThat(response.body?.melding).contains("401 Unauthorized")
+        assertThat(response.body?.frontendFeilmelding).isEqualTo("Kall ikke autorisert")
+    }
+
+    private fun lagTokenXToken(): String {
+        val clientId = UUID.randomUUID().toString()
+        val brukerId = UUID.randomUUID().toString()
+        val issuerId = "tokenx"
+        return MockOAuth2ServerInitializer.server
+            .issueToken(
+                issuerId = issuerId,
+                clientId = clientId,
+                DefaultOAuth2TokenCallback(
+                    issuerId = issuerId,
+                    subject = brukerId,
+                    audience = listOf("aud-localhost"),
+                    claims =
+                        mapOf(
+                            "acr" to "Level4",
+                            "pid" to brukerId,
+                        ),
+                    expiry = 3600,
+                ),
+            ).serialize()
+    }
+}

--- a/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveServiceTest.kt
@@ -348,10 +348,6 @@ internal class OppgaveServiceTest {
 
     @Nested
     inner class TilbakestillFordelingPåOppgaveTest {
-        @BeforeEach
-        fun setUp() {
-        }
-
         @Test
         fun `Skal sette endretAvEnhetsnr til SB sin enhet hvis det er SB som har gjort endringen`() {
             // Arrange

--- a/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/oppgave/OppgaveServiceTest.kt
@@ -23,6 +23,7 @@ import no.nav.familie.kontrakter.felles.oppgave.StatusEnum
 import no.nav.familie.kontrakter.felles.saksbehandler.Saksbehandler
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
@@ -347,6 +348,10 @@ internal class OppgaveServiceTest {
 
     @Nested
     inner class TilbakestillFordelingPåOppgaveTest {
+        @BeforeEach
+        fun setUp() {
+        }
+
         @Test
         fun `Skal sette endretAvEnhetsnr til SB sin enhet hvis det er SB som har gjort endringen`() {
             // Arrange
@@ -362,6 +367,7 @@ internal class OppgaveServiceTest {
             val oppgaveSlot = slot<Oppgave>()
 
             every { SikkerhetsContext.hentSaksbehandlerEllerSystembruker() } returns "Z444444"
+            every { SikkerhetsContext.hentSaksbehandlerNavn() } returns "Saksbehandler"
 
             every { saksbehandlerService.hentSaksbehandler("Z444444") } returns
                 Saksbehandler(
@@ -400,6 +406,7 @@ internal class OppgaveServiceTest {
             val oppgaveSlot = slot<Oppgave>()
 
             every { SikkerhetsContext.hentSaksbehandlerEllerSystembruker() } returns SYSTEM_FORKORTELSE
+            every { SikkerhetsContext.hentSaksbehandlerNavn() } returns "Saksbehandler"
             every { oppgaveRestClient.finnOppgaveMedId(oppgaveId) } returns originalOppgave
             every { oppgaveRestClient.oppdaterOppgave(capture(oppgaveSlot)) } returns originalOppgave
 

--- a/src/test/java/no/nav/familie/integrasjoner/sikkerhet/SikkerhetsContextTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/sikkerhet/SikkerhetsContextTest.kt
@@ -1,0 +1,109 @@
+package no.nav.familie.integrasjoner.sikkerhet
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+
+class SikkerhetsContextTest {
+    @AfterEach
+    fun cleanUp() {
+        SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `hentSaksbehandlerEllerSystembruker returnerer NAVident når claim finnes`() {
+        mockToken(mapOf("NAVident" to "Z999999"))
+
+        assertThat(SikkerhetsContext.hentSaksbehandlerEllerSystembruker()).isEqualTo("Z999999")
+    }
+
+    @Test
+    fun `hentSaksbehandlerEllerSystembruker returnerer VL når NAVident mangler`() {
+        mockToken(mapOf("sub" to "maskinsystem"))
+
+        assertThat(SikkerhetsContext.hentSaksbehandlerEllerSystembruker()).isEqualTo("VL")
+    }
+
+    @Test
+    fun `hentSaksbehandlerNavn returnerer name når claim finnes`() {
+        mockToken(mapOf("name" to "Ola Nordmann"))
+
+        assertThat(SikkerhetsContext.hentSaksbehandlerNavn()).isEqualTo("Ola Nordmann")
+    }
+
+    @Test
+    fun `hentSaksbehandlerNavn returnerer System når name mangler og strict er false`() {
+        mockToken(mapOf("sub" to "maskinsystem"))
+
+        assertThat(SikkerhetsContext.hentSaksbehandlerNavn(strict = false)).isEqualTo("System")
+    }
+
+    @Test
+    fun `hentSaksbehandlerNavn kaster feil når name mangler og strict er true`() {
+        mockToken(mapOf("sub" to "maskinsystem"))
+
+        assertThatThrownBy { SikkerhetsContext.hentSaksbehandlerNavn(strict = true) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("Finner ikke navn i azuread token")
+    }
+
+    @Test
+    fun `hentClaim returnerer claim-verdi når claim finnes`() {
+        mockToken(mapOf("custom-claim" to "custom-value"))
+
+        assertThat(SikkerhetsContext.hentClaim<String>("custom-claim")).isEqualTo("custom-value")
+    }
+
+    @Test
+    fun `hentClaim returnerer null når claim ikke finnes`() {
+        mockToken(mapOf("sub" to "test"))
+
+        assertThat(SikkerhetsContext.hentClaim<String>("finnes-ikke")).isNull()
+    }
+
+    @Test
+    fun `hentJwt returnerer JWT når JwtAuthenticationToken er i context`() {
+        mockToken(mapOf("sub" to "test-subject"))
+
+        val jwt = SikkerhetsContext.hentJwt()
+
+        assertThat(jwt).isNotNull()
+        assertThat(jwt.subject).isEqualTo("test-subject")
+    }
+
+    @Test
+    fun `hentJwt kaster AuthenticationCredentialsNotFoundException når SecurityContext er tomt`() {
+        assertThatThrownBy { SikkerhetsContext.hentJwt() }
+            .isInstanceOf(AuthenticationCredentialsNotFoundException::class.java)
+            .hasMessageContaining("Klarte ikke hente token fra context")
+    }
+
+    @Test
+    fun `hentJwt kaster AuthenticationCredentialsNotFoundException når auth ikke er JwtAuthenticationToken`() {
+        val securityContext = SecurityContextHolder.createEmptyContext()
+        securityContext.authentication = UsernamePasswordAuthenticationToken("user", "pass")
+        SecurityContextHolder.setContext(securityContext)
+
+        assertThatThrownBy { SikkerhetsContext.hentJwt() }
+            .isInstanceOf(AuthenticationCredentialsNotFoundException::class.java)
+            .hasMessageContaining("Klarte ikke hente token fra context")
+    }
+
+    private fun mockToken(claims: Map<String, Any>) {
+        val jwt =
+            Jwt
+                .withTokenValue("token")
+                .header("alg", "RS256")
+                .apply { claims.forEach { (key, value) -> claim(key, value) } }
+                .build()
+        val securityContext = SecurityContextHolder.createEmptyContext()
+        securityContext.authentication = JwtAuthenticationToken(jwt)
+        SecurityContextHolder.setContext(securityContext)
+    }
+}

--- a/src/test/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollServiceCacheTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollServiceCacheTest.kt
@@ -1,0 +1,170 @@
+package no.nav.familie.integrasjoner.tilgangskontroll
+
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.familie.integrasjoner.config.TilgangConfig
+import no.nav.familie.integrasjoner.egenansatt.EgenAnsattService
+import no.nav.familie.integrasjoner.personopplysning.PersonopplysningerService
+import no.nav.familie.integrasjoner.personopplysning.internal.ADRESSEBESKYTTELSEGRADERING.UGRADERT
+import no.nav.familie.integrasjoner.personopplysning.internal.Adressebeskyttelse
+import no.nav.familie.integrasjoner.personopplysning.internal.PersonMedRelasjoner
+import no.nav.familie.integrasjoner.tilgangskontroll.domene.AdRolle
+import no.nav.familie.kontrakter.felles.Tema
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+@ContextConfiguration(
+    classes = [
+        CachedTilgangskontrollServiceCacheTest.CacheTestConfig::class,
+        TilgangskontrollCacheConfig::class,
+    ],
+)
+internal class CachedTilgangskontrollServiceCacheTest {
+    @Autowired
+    lateinit var cachedTilgangskontrollService: CachedTilgangskontrollService
+
+    @Autowired
+    lateinit var cacheManager: CacheManager
+
+    private val egenAnsattService = CacheTestConfig.egenAnsattService
+    private val personopplysningerService = CacheTestConfig.personopplysningerService
+
+    @BeforeEach
+    fun setUp() {
+        clearMocks(egenAnsattService, personopplysningerService)
+        every { egenAnsattService.erEgenAnsatt(any<String>()) } returns false
+        every { egenAnsattService.erEgenAnsatt(any<Set<String>>()) } answers { firstArg<Set<String>>().associateWith { false } }
+        every { personopplysningerService.hentAdressebeskyttelse(any(), any()) } returns Adressebeskyttelse(UGRADERT)
+        every { personopplysningerService.hentPersonMedRelasjoner(any(), any()) } returns lagPersonMedRelasjoner()
+
+        mockToken("saksbehandler-1")
+
+        cacheManager.resetCaches()
+    }
+
+    @AfterEach
+    fun cleanUp() {
+        SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `sjekkTilgang - andre kall med samme personIdent og saksbehandler skal hentes fra cache`() {
+        cachedTilgangskontrollService.sjekkTilgang(PERSON_IDENT, Tema.BAR)
+        cachedTilgangskontrollService.sjekkTilgang(PERSON_IDENT, Tema.BAR)
+
+        verify(exactly = 1) { personopplysningerService.hentAdressebeskyttelse(PERSON_IDENT, any()) }
+    }
+
+    @Test
+    fun `sjekkTilgang - kall med ulik personIdent skal ikke treffe cache`() {
+        cachedTilgangskontrollService.sjekkTilgang(PERSON_IDENT, Tema.BAR)
+        cachedTilgangskontrollService.sjekkTilgang(ANNEN_PERSON_IDENT, Tema.BAR)
+
+        verify(exactly = 1) { personopplysningerService.hentAdressebeskyttelse(PERSON_IDENT, any()) }
+        verify(exactly = 1) { personopplysningerService.hentAdressebeskyttelse(ANNEN_PERSON_IDENT, any()) }
+    }
+
+    @Test
+    fun `sjekkTilgang - kall med ulik saksbehandler skal ikke treffe cache`() {
+        cachedTilgangskontrollService.sjekkTilgang(PERSON_IDENT, Tema.BAR)
+        mockToken("saksbehandler-2")
+        cachedTilgangskontrollService.sjekkTilgang(PERSON_IDENT, Tema.BAR)
+
+        verify(exactly = 2) { personopplysningerService.hentAdressebeskyttelse(PERSON_IDENT, any()) }
+    }
+
+    @Test
+    fun `sjekkTilgangTilPersonMedRelasjoner - andre kall med samme personIdent og saksbehandler skal hentes fra cache`() {
+        cachedTilgangskontrollService.sjekkTilgangTilPersonMedRelasjoner(PERSON_IDENT, Tema.ENF)
+        cachedTilgangskontrollService.sjekkTilgangTilPersonMedRelasjoner(PERSON_IDENT, Tema.ENF)
+
+        verify(exactly = 1) { personopplysningerService.hentPersonMedRelasjoner(PERSON_IDENT, any()) }
+    }
+
+    @Test
+    fun `sjekkTilgangTilPersonMedRelasjoner - kall med ulik personIdent skal ikke treffe cache`() {
+        cachedTilgangskontrollService.sjekkTilgangTilPersonMedRelasjoner(PERSON_IDENT, Tema.ENF)
+        cachedTilgangskontrollService.sjekkTilgangTilPersonMedRelasjoner(ANNEN_PERSON_IDENT, Tema.ENF)
+
+        verify(exactly = 1) { personopplysningerService.hentPersonMedRelasjoner(PERSON_IDENT, any()) }
+        verify(exactly = 1) { personopplysningerService.hentPersonMedRelasjoner(ANNEN_PERSON_IDENT, any()) }
+    }
+
+    @Test
+    fun `sjekkTilgangTilPersonMedRelasjoner - kall med ulik saksbehandler skal ikke treffe cache`() {
+        cachedTilgangskontrollService.sjekkTilgangTilPersonMedRelasjoner(PERSON_IDENT, Tema.ENF)
+        mockToken("saksbehandler-2")
+        cachedTilgangskontrollService.sjekkTilgangTilPersonMedRelasjoner(PERSON_IDENT, Tema.ENF)
+
+        verify(exactly = 2) { personopplysningerService.hentPersonMedRelasjoner(PERSON_IDENT, any()) }
+    }
+
+    private fun mockToken(subject: String) {
+        val jwt =
+            Jwt
+                .withTokenValue("token")
+                .header("header", "header value")
+                .subject(subject)
+                .claim("groups", emptyList<String>())
+                .build()
+        val securityContext = SecurityContextHolder.createEmptyContext()
+        securityContext.authentication = JwtAuthenticationToken(jwt)
+        SecurityContextHolder.setContext(securityContext)
+    }
+
+    private fun lagPersonMedRelasjoner(): PersonMedRelasjoner =
+        PersonMedRelasjoner(
+            personIdent = PERSON_IDENT,
+            adressebeskyttelse = null,
+            sivilstand = emptyList(),
+            barn = emptyList(),
+            barnsForeldrer = emptyList(),
+        )
+
+    @Configuration
+    @EnableCaching
+    class CacheTestConfig {
+        @Bean
+        fun cacheManager(): CacheManager = ConcurrentMapCacheManager()
+
+        @Bean
+        fun cachedTilgangskontrollService() =
+            CachedTilgangskontrollService(
+                egenAnsattService,
+                personopplysningerService,
+                tilgangConfig,
+            )
+
+        companion object {
+            val egenAnsattService: EgenAnsattService = mockk()
+            val personopplysningerService: PersonopplysningerService = mockk()
+            private val tilgangConfig =
+                TilgangConfig(
+                    kode6 = AdRolle("kode6-gruppe", "Strengt fortrolig adresse"),
+                    kode7 = AdRolle("kode7-gruppe", "Fortrolig adresse"),
+                    egenAnsatt = AdRolle("egenansatt-gruppe", "Egen ansatt"),
+                )
+        }
+    }
+
+    companion object {
+        private const val PERSON_IDENT = "12345678901"
+        private const val ANNEN_PERSON_IDENT = "99999999999"
+    }
+}

--- a/src/test/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollServiceCacheTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollServiceCacheTest.kt
@@ -53,8 +53,6 @@ internal class CachedTilgangskontrollServiceCacheTest {
         every { personopplysningerService.hentAdressebeskyttelse(any(), any()) } returns Adressebeskyttelse(UGRADERT)
         every { personopplysningerService.hentPersonMedRelasjoner(any(), any()) } returns lagPersonMedRelasjoner()
 
-        mockToken("saksbehandler-1")
-
         cacheManager.resetCaches()
     }
 
@@ -65,6 +63,7 @@ internal class CachedTilgangskontrollServiceCacheTest {
 
     @Test
     fun `sjekkTilgang - andre kall med samme personIdent og saksbehandler skal hentes fra cache`() {
+        mockToken("saksbehandler-1")
         cachedTilgangskontrollService.sjekkTilgang(PERSON_IDENT, Tema.BAR)
         cachedTilgangskontrollService.sjekkTilgang(PERSON_IDENT, Tema.BAR)
 
@@ -73,6 +72,7 @@ internal class CachedTilgangskontrollServiceCacheTest {
 
     @Test
     fun `sjekkTilgang - kall med ulik personIdent skal ikke treffe cache`() {
+        mockToken("saksbehandler-1")
         cachedTilgangskontrollService.sjekkTilgang(PERSON_IDENT, Tema.BAR)
         cachedTilgangskontrollService.sjekkTilgang(ANNEN_PERSON_IDENT, Tema.BAR)
 
@@ -82,6 +82,7 @@ internal class CachedTilgangskontrollServiceCacheTest {
 
     @Test
     fun `sjekkTilgang - kall med ulik saksbehandler skal ikke treffe cache`() {
+        mockToken("saksbehandler-1")
         cachedTilgangskontrollService.sjekkTilgang(PERSON_IDENT, Tema.BAR)
         mockToken("saksbehandler-2")
         cachedTilgangskontrollService.sjekkTilgang(PERSON_IDENT, Tema.BAR)
@@ -91,6 +92,7 @@ internal class CachedTilgangskontrollServiceCacheTest {
 
     @Test
     fun `sjekkTilgangTilPersonMedRelasjoner - andre kall med samme personIdent og saksbehandler skal hentes fra cache`() {
+        mockToken("saksbehandler-1")
         cachedTilgangskontrollService.sjekkTilgangTilPersonMedRelasjoner(PERSON_IDENT, Tema.ENF)
         cachedTilgangskontrollService.sjekkTilgangTilPersonMedRelasjoner(PERSON_IDENT, Tema.ENF)
 
@@ -99,6 +101,7 @@ internal class CachedTilgangskontrollServiceCacheTest {
 
     @Test
     fun `sjekkTilgangTilPersonMedRelasjoner - kall med ulik personIdent skal ikke treffe cache`() {
+        mockToken("saksbehandler-1")
         cachedTilgangskontrollService.sjekkTilgangTilPersonMedRelasjoner(PERSON_IDENT, Tema.ENF)
         cachedTilgangskontrollService.sjekkTilgangTilPersonMedRelasjoner(ANNEN_PERSON_IDENT, Tema.ENF)
 
@@ -108,6 +111,7 @@ internal class CachedTilgangskontrollServiceCacheTest {
 
     @Test
     fun `sjekkTilgangTilPersonMedRelasjoner - kall med ulik saksbehandler skal ikke treffe cache`() {
+        mockToken("saksbehandler-1")
         cachedTilgangskontrollService.sjekkTilgangTilPersonMedRelasjoner(PERSON_IDENT, Tema.ENF)
         mockToken("saksbehandler-2")
         cachedTilgangskontrollService.sjekkTilgangTilPersonMedRelasjoner(PERSON_IDENT, Tema.ENF)
@@ -115,12 +119,30 @@ internal class CachedTilgangskontrollServiceCacheTest {
         verify(exactly = 2) { personopplysningerService.hentPersonMedRelasjoner(PERSON_IDENT, any()) }
     }
 
-    private fun mockToken(subject: String) {
+    @Test
+    fun `sjekkTilgang - kall uten sub i token skal ikke caches`() {
+        mockToken(null)
+        cachedTilgangskontrollService.sjekkTilgang(PERSON_IDENT, Tema.BAR)
+        cachedTilgangskontrollService.sjekkTilgang(PERSON_IDENT, Tema.BAR)
+
+        verify(exactly = 2) { personopplysningerService.hentAdressebeskyttelse(PERSON_IDENT, any()) }
+    }
+
+    @Test
+    fun `sjekkTilgangTilPersonMedRelasjoner - kall uten sub i token skal ikke caches`() {
+        mockToken(null)
+        cachedTilgangskontrollService.sjekkTilgangTilPersonMedRelasjoner(PERSON_IDENT, Tema.ENF)
+        cachedTilgangskontrollService.sjekkTilgangTilPersonMedRelasjoner(PERSON_IDENT, Tema.ENF)
+
+        verify(exactly = 2) { personopplysningerService.hentPersonMedRelasjoner(PERSON_IDENT, any()) }
+    }
+
+    private fun mockToken(subject: String?) {
         val jwt =
             Jwt
                 .withTokenValue("token")
                 .header("header", "header value")
-                .subject(subject)
+                .apply { subject?.let { subject(subject) } }
                 .claim("groups", emptyList<String>())
                 .build()
         val securityContext = SecurityContextHolder.createEmptyContext()

--- a/src/test/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/tilgangskontroll/CachedTilgangskontrollServiceTest.kt
@@ -12,11 +12,13 @@ import no.nav.familie.integrasjoner.personopplysning.internal.PersonMedAdresseBe
 import no.nav.familie.integrasjoner.personopplysning.internal.PersonMedRelasjoner
 import no.nav.familie.integrasjoner.tilgangskontroll.domene.AdRolle
 import no.nav.familie.kontrakter.felles.Tema
-import no.nav.security.token.support.core.jwt.JwtToken
-import no.nav.security.token.support.core.jwt.JwtTokenClaims
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
 
 internal class CachedTilgangskontrollServiceTest {
     private val egenAnsattService = mockk<EgenAnsattService>()
@@ -37,25 +39,17 @@ internal class CachedTilgangskontrollServiceTest {
             tilgangConfig,
         )
 
-    private val jwtToken = mockk<JwtToken>(relaxed = true)
-    private val jwtTokenClaims = mockk<JwtTokenClaims>()
-
     @BeforeEach
     internal fun setUp() {
-        every { jwtToken.jwtTokenClaims } returns jwtTokenClaims
-        every { jwtTokenClaims.get("preferred_username") }.returns(listOf("bob"))
-        every { jwtTokenClaims.getAsList(any()) }.returns(emptyList())
         every { egenAnsattService.erEgenAnsatt(any<String>()) } returns false
-        every { egenAnsattService.erEgenAnsatt(any<Set<String>>()) } answers
-            { firstArg<Set<String>>().associateWith { false } }
+        every { egenAnsattService.erEgenAnsatt(any<Set<String>>()) } answers { firstArg<Set<String>>().associateWith { false } }
+
+        mockToken(tilganger = emptyList())
     }
 
-    private fun mockHarKode7() {
-        every { jwtTokenClaims.getAsList(any()) }.returns(listOf(kode7Id))
-    }
-
-    private fun mockHarKode6() {
-        every { jwtTokenClaims.getAsList(any()) }.returns(listOf(kode6Id))
+    @AfterEach
+    fun cleanUp() {
+        SecurityContextHolder.clearContext()
     }
 
     @Test
@@ -88,7 +82,7 @@ internal class CachedTilgangskontrollServiceTest {
 
     @Test
     internal fun `har ikke tilgang når søkeren er STRENGT_FORTROLIG og saksbehandler har kode7`() {
-        mockHarKode7()
+        mockToken(tilganger = listOf(kode7Id))
         every { personopplysningerService.hentPersonMedRelasjoner(any(), Tema.ENF) } returns
             lagPersonMedRelasjoner(ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG)
         assertThat(sjekkTilgangTilPersonMedRelasjoner()).isFalse
@@ -96,7 +90,7 @@ internal class CachedTilgangskontrollServiceTest {
 
     @Test
     internal fun `har tilgang når søkeren er STRENGT_FORTROLIG og saksbehandler har kode6`() {
-        mockHarKode6()
+        mockToken(tilganger = listOf(kode6Id))
         every { personopplysningerService.hentPersonMedRelasjoner(any(), Tema.ENF) } returns
             lagPersonMedRelasjoner(ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG)
         assertThat(sjekkTilgangTilPersonMedRelasjoner()).isTrue
@@ -154,7 +148,7 @@ internal class CachedTilgangskontrollServiceTest {
     fun `skal returnere ident til etterspurt person når relasjon er fortrolig`() {
         every { personopplysningerService.hentPersonMedRelasjoner(any(), Tema.ENF) } returns
             lagPersonMedRelasjoner(barnsForeldrer = ADRESSEBESKYTTELSEGRADERING.FORTROLIG)
-        val tilgang = cachedTilgangskontrollService.sjekkTilgangTilPersonMedRelasjoner("søker", jwtToken, Tema.ENF)
+        val tilgang = cachedTilgangskontrollService.sjekkTilgangTilPersonMedRelasjoner("søker", Tema.ENF)
         assertThat(tilgang.harTilgang).isFalse
         assertThat(tilgang.personIdent).isEqualTo("søker")
     }
@@ -166,14 +160,14 @@ internal class CachedTilgangskontrollServiceTest {
         every { egenAnsattService.erEgenAnsatt(any<Set<String>>()) } answers {
             firstArg<Set<String>>().associateWith { it == "sivilstand" }
         }
-        val tilgang = cachedTilgangskontrollService.sjekkTilgangTilPersonMedRelasjoner("søker", jwtToken, Tema.ENF)
+        val tilgang = cachedTilgangskontrollService.sjekkTilgangTilPersonMedRelasjoner("søker", Tema.ENF)
         assertThat(tilgang.harTilgang).isFalse
         assertThat(tilgang.personIdent).isEqualTo("søker")
     }
 
-    private fun sjekkTilgangTilPersonMedRelasjoner() = cachedTilgangskontrollService.sjekkTilgangTilPersonMedRelasjoner("", jwtToken, Tema.ENF).harTilgang
+    private fun sjekkTilgangTilPersonMedRelasjoner() = cachedTilgangskontrollService.sjekkTilgangTilPersonMedRelasjoner("", Tema.ENF).harTilgang
 
-    private fun sjekkTilgangTilPerson() = cachedTilgangskontrollService.sjekkTilgang("", jwtToken, Tema.ENF).harTilgang
+    private fun sjekkTilgangTilPerson() = cachedTilgangskontrollService.sjekkTilgang("", Tema.ENF).harTilgang
 
     private fun lagPersonMedRelasjoner(
         adressebeskyttelse: ADRESSEBESKYTTELSEGRADERING? = null,
@@ -196,5 +190,17 @@ internal class CachedTilgangskontrollServiceTest {
 
     private fun mockHentPersonMedAdressebeskyttelse(adressebeskyttelse: ADRESSEBESKYTTELSEGRADERING = ADRESSEBESKYTTELSEGRADERING.UGRADERT) {
         every { personopplysningerService.hentAdressebeskyttelse(any(), any()) } returns Adressebeskyttelse(adressebeskyttelse)
+    }
+
+    private fun mockToken(tilganger: List<String>) {
+        val jwt =
+            Jwt
+                .withTokenValue("token")
+                .header("header", "header value")
+                .claim("groups", tilganger)
+                .build()
+        val securityContext = SecurityContextHolder.createEmptyContext()
+        securityContext.authentication = JwtAuthenticationToken(jwt)
+        SecurityContextHolder.setContext(securityContext)
     }
 }

--- a/src/test/java/no/nav/familie/integrasjoner/tilgangskontroll/TilgangskontrollServiceTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/tilgangskontroll/TilgangskontrollServiceTest.kt
@@ -6,17 +6,21 @@ import no.nav.familie.integrasjoner.config.TilgangConfig
 import no.nav.familie.integrasjoner.egenansatt.EgenAnsattService
 import no.nav.familie.integrasjoner.personopplysning.PersonopplysningerService
 import no.nav.familie.integrasjoner.personopplysning.internal.ADRESSEBESKYTTELSEGRADERING
+import no.nav.familie.integrasjoner.personopplysning.internal.ADRESSEBESKYTTELSEGRADERING.FORTROLIG
+import no.nav.familie.integrasjoner.personopplysning.internal.ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG
+import no.nav.familie.integrasjoner.personopplysning.internal.ADRESSEBESKYTTELSEGRADERING.UGRADERT
 import no.nav.familie.integrasjoner.personopplysning.internal.Adressebeskyttelse
 import no.nav.familie.integrasjoner.personopplysning.internal.Person
 import no.nav.familie.integrasjoner.tilgangskontroll.domene.AdRolle
-import no.nav.security.token.support.core.jwt.JwtToken
-import no.nav.security.token.support.core.jwt.JwtTokenClaims
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
 
 class TilgangskontrollServiceTest {
-    private val saksbehandler: JwtToken = mockk(relaxed = true)
-    private val jwtTokenClaims: JwtTokenClaims = mockk()
     private val egenAnsattService: EgenAnsattService = mockk(relaxed = true)
 
     private val tilgangConfig: TilgangConfig =
@@ -35,120 +39,87 @@ class TilgangskontrollServiceTest {
         )
     private var tilgangskontrollService: TilgangskontrollService = TilgangskontrollService(cachedTilgangskontrollService)
 
+    @BeforeEach
+    fun setup() {
+        mockToken(tilganger = emptyList())
+    }
+
+    @AfterEach
+    fun cleanUp() {
+        SecurityContextHolder.clearContext()
+    }
+
     @Test
     fun `tilgang til egen ansatt gir ikke tilgang hvis saksbehandler mangler rollen`() {
-        every { egenAnsattService.erEgenAnsatt(any<String>()) }
-            .returns(true)
-        every { saksbehandler.jwtTokenClaims }
-            .returns(jwtTokenClaims)
-        every { jwtTokenClaims.getAsList(any()) }
-            .returns(listOf("id1"))
-        every { jwtTokenClaims.get("preferred_username") }
-            .returns(listOf("bob"))
+        every { egenAnsattService.erEgenAnsatt(any<String>()) } returns true
 
-        assertThat(
-            tilgangskontrollService
-                .sjekkTilgang(
-                    "123",
-                    saksbehandler,
-                ).harTilgang,
-        ).isFalse
+        assertThat(tilgangskontrollService.sjekkTilgang("123").harTilgang).isFalse
     }
 
     @Test
     fun `tilgang til egen ansatt gir tilgang hvis saksbehandler har rollen`() {
-        every { egenAnsattService.erEgenAnsatt(any<String>()) }
-            .returns(true)
-        every { personopplysningerService.hentAdressebeskyttelse("123", any()) }
-            .returns(Adressebeskyttelse(ADRESSEBESKYTTELSEGRADERING.UGRADERT))
-        every { saksbehandler.jwtTokenClaims }
-            .returns(jwtTokenClaims)
-        every { jwtTokenClaims.getAsList(any()) }
-            .returns(listOf(GRUPPE_EGEN_ANSATT))
-        every { jwtTokenClaims.get("preferred_username") }
-            .returns(listOf("bob"))
+        every { egenAnsattService.erEgenAnsatt(any<String>()) } returns true
+        every { personopplysningerService.hentAdressebeskyttelse("123", any()) } returns Adressebeskyttelse(UGRADERT)
 
-        assertThat(tilgangskontrollService.sjekkTilgang("123", saksbehandler).harTilgang)
-            .isTrue
+        mockToken(tilganger = listOf(GRUPPE_EGEN_ANSATT))
+
+        assertThat(tilgangskontrollService.sjekkTilgang("123").harTilgang).isTrue
     }
 
     @Test
     fun `tilgang til egen ansatt gir ok hvis søker ikke er egen ansatt`() {
-        every { egenAnsattService.erEgenAnsatt(any<String>()) }
-            .returns(false)
-        every { personopplysningerService.hentAdressebeskyttelse("123", any()) }
-            .returns(Adressebeskyttelse(ADRESSEBESKYTTELSEGRADERING.UGRADERT))
+        every { egenAnsattService.erEgenAnsatt(any<String>()) } returns false
+        every { personopplysningerService.hentAdressebeskyttelse("123", any()) } returns Adressebeskyttelse(UGRADERT)
 
-        assertThat(tilgangskontrollService.sjekkTilgang("123", saksbehandler).harTilgang)
-            .isTrue
+        assertThat(tilgangskontrollService.sjekkTilgang("123").harTilgang).isTrue
     }
 
     @Test
     fun `hvis kode6 har ikke saksbehandler uten rollen tilgang`() {
-        every { egenAnsattService.erEgenAnsatt(any<String>()) }
-            .returns(false)
-        every { saksbehandler.jwtTokenClaims }
-            .returns(jwtTokenClaims)
-        every { jwtTokenClaims.getAsList(any()) }
-            .returns(listOf("id1"))
-        every { jwtTokenClaims.get("preferred_username") }
-            .returns(listOf("bob"))
-        every { personopplysningerService.hentPersoninfo("123", any()) }
-            .returns(personMedAdressebeskyttelse(ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG))
+        every { egenAnsattService.erEgenAnsatt(any<String>()) } returns false
+        every { personopplysningerService.hentPersoninfo("123", any()) } returns personMedAdressebeskyttelse(STRENGT_FORTROLIG)
 
-        assertThat(tilgangskontrollService.sjekkTilgang("123", saksbehandler).harTilgang)
-            .isFalse
+        assertThat(tilgangskontrollService.sjekkTilgang("123").harTilgang).isFalse
     }
 
     @Test
     fun `hvis kode7 har ikke saksbehandler uten rollen tilgang`() {
-        every { egenAnsattService.erEgenAnsatt(any<String>()) }
-            .returns(false)
-        every { saksbehandler.jwtTokenClaims }
-            .returns(jwtTokenClaims)
-        every { jwtTokenClaims.getAsList(any()) }
-            .returns(listOf("id1"))
-        every { jwtTokenClaims.get("preferred_username") }
-            .returns(listOf("bob"))
-        every { personopplysningerService.hentPersoninfo("123", any()) }
-            .returns(personMedAdressebeskyttelse(ADRESSEBESKYTTELSEGRADERING.FORTROLIG))
+        every { egenAnsattService.erEgenAnsatt(any<String>()) } returns false
+        every { personopplysningerService.hentPersoninfo("123", any()) } returns personMedAdressebeskyttelse(FORTROLIG)
 
-        assertThat(tilgangskontrollService.sjekkTilgang("123", saksbehandler).harTilgang)
-            .isFalse
+        assertThat(tilgangskontrollService.sjekkTilgang("123").harTilgang).isFalse
     }
 
     @Test
     fun `hvis kode6 har saksbehandler med rollen tilgang`() {
-        every { egenAnsattService.erEgenAnsatt(any<String>()) }
-            .returns(false)
-        every { saksbehandler.jwtTokenClaims }
-            .returns(jwtTokenClaims)
-        every { jwtTokenClaims.get("preferred_username") }
-            .returns(listOf("bob"))
-        every { jwtTokenClaims.getAsList(any()) }
-            .returns(listOf(GRUPPE_TILGANG_6))
-        every { personopplysningerService.hentPersoninfo("123", any()) }
-            .returns(personMedAdressebeskyttelse(ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG))
+        every { egenAnsattService.erEgenAnsatt(any<String>()) } returns false
+        every { personopplysningerService.hentPersoninfo("123", any()) } returns personMedAdressebeskyttelse(STRENGT_FORTROLIG)
 
-        assertThat(tilgangskontrollService.sjekkTilgang("123", saksbehandler).harTilgang)
-            .isTrue
+        mockToken(tilganger = listOf(GRUPPE_TILGANG_6))
+
+        assertThat(tilgangskontrollService.sjekkTilgang("123").harTilgang).isTrue
     }
 
     @Test
     fun `hvis kode7 har saksbehandler med rollen tilgang`() {
-        every { egenAnsattService.erEgenAnsatt(any<String>()) }
-            .returns(false)
-        every { saksbehandler.jwtTokenClaims }
-            .returns(jwtTokenClaims)
-        every { jwtTokenClaims.get("preferred_username") }
-            .returns(listOf("bob"))
-        every { jwtTokenClaims.getAsList(any()) }
-            .returns(listOf(GRUPPE_TILGANG_7))
-        every { personopplysningerService.hentAdressebeskyttelse("123", any()) }
-            .returns(Adressebeskyttelse(ADRESSEBESKYTTELSEGRADERING.FORTROLIG))
+        every { egenAnsattService.erEgenAnsatt(any<String>()) } returns false
+        every { personopplysningerService.hentAdressebeskyttelse("123", any()) } returns Adressebeskyttelse(FORTROLIG)
 
-        assertThat(tilgangskontrollService.sjekkTilgang("123", saksbehandler).harTilgang)
-            .isTrue
+        mockToken(tilganger = listOf(GRUPPE_TILGANG_7))
+
+        assertThat(tilgangskontrollService.sjekkTilgang("123").harTilgang).isTrue
+    }
+
+    private fun mockToken(tilganger: List<String>) {
+        val jwt =
+            Jwt
+                .withTokenValue("token")
+                .header("header", "header value")
+                .claim("groups", tilganger)
+                .build()
+        val securityContext = SecurityContextHolder.createEmptyContext()
+        securityContext.authentication = JwtAuthenticationToken(jwt)
+        SecurityContextHolder.setContext(securityContext)
     }
 
     private fun personMedAdressebeskyttelse(adressebeskyttelsegradering: ADRESSEBESKYTTELSEGRADERING?): Person =


### PR DESCRIPTION
NAV-29146

## Beskrivelse

Migrerer JWT-validering fra Nav sitt `token-support`-bibliotek til Spring Security. 
Alle endepunkter er nå sikret via en `SecurityFilterChain` med egne `AuthenticationManager`-implementasjoner for TokenX og Azure AD.

## Endringer

- Fjerner avhengighet på `token-support` og tilhørende konfigurasjon
- Legger til `SecurityConfig` med `SecurityFilterChain` for TokenX og Azure AD
- Ny `TokenXAuthenticationManager` og `AzureAdAuthenticationManager` for JWT-validering
- Fjerner `@ProtectedWithClaims` og `@Unprotected` fra alle endepunkter
- Bytter ut `SikkerhetsContext` til å bruke `SecurityContextHolder` fra Spring Security
- Oppdaterer `CachedTilgangskontrollService` til å hente JWT via token context
- Legger til feilhåndtering for 401 og 403
- Legger til midlertidig `TokenValidationContextHolderConfig` for bakoverkompatibilitet
- Fikser oppsett for lokal kjøring

## Tester

- Nye tester for `SecurityConfig` og `SikkerhetsContext`
- Oppdaterte tester for `CachedTilgangskontrollService` og `TilgangskontrollService`
- Migrerer `FiloverføringAdraMatchControllerTest` til JUnit 5