### PR TITLE
Fjern automatisk deploy til dev ved PR-opprettelse

### DIFF
--- a/.github/workflows/deploy-preprod.yml
+++ b/.github/workflows/deploy-preprod.yml
@@ -45,7 +45,7 @@ jobs:
       image: ${{ steps.docker-push.outputs.image }}
 
   deploy-dev:
-    if: github.event.pull_request.draft == false && github.event.pull_request.user.login != 'dependabot[bot]'
+    if: github.event_name == 'workflow_dispatch'
     name: Deploy to dev-fss
     needs: build-dev
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,5 +1,6 @@
 name: Deploy prod
 on:
+  workflow_dispatch:
   push:
     branches:
       - 'main'

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -52,7 +52,7 @@ jobs:
 
   deploy-prod:
     name: Deploy til prod-fss
-    needs: build
+    needs: [build, deploy-preprod]
     runs-on: ubuntu-latest
     permissions:
       contents: "read"


### PR DESCRIPTION
## Beskrivelse

Fjerner automatisk deploy til `dev-fss` som ble trigget ved opprettelse og oppdatering av pull requests.

Deploy til dev skjer nå kun ved manuell kjøring via `workflow_dispatch` fra GitHub Actions-fanen.

Bygg og Docker push kjører fortsatt automatisk på PR for å fange opp kompileringsfeil.

Stopper deploy til prod hvis deploy preprod feiler ved merging til main

## Endringer

- `deploy-preprod.yml`: Endret condition på `deploy-dev`-jobben fra PR-sjekk til `github.event_name == 'workflow_dispatch'`
- `deploy-prod.yml`: La til `deploy-preprod` i `needs` i `deploy-prod`-jobben, slik at deploy til prod stoppes hvis deploy til preprod feiler