### PR TITLE
Splitt GitHub Actions-workflows i dedikerte filer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,16 @@
-name: Deploy prod
+name: Main
 on:
   workflow_dispatch:
   push:
     branches:
       - 'main'
+    paths-ignore:
+      - '**.md'
+      - '**.MD'
+      - '.github/**.yaml'
+      - '.gitignore'
+      - 'CODEOWNERS'
+      - 'LICENSE'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
@@ -12,19 +19,15 @@ concurrency:
 permissions:
   contents: "read"
   id-token: "write"
+
 jobs:
   build:
-    name: Bygg og test
+    name: Build and test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v4
         with:
           persist-credentials: false
-
-      - name: Sjekk at tag ligger på main
-        run: |
-          commit=$(git rev-parse --short HEAD)
-          if ! [[ $(git branch -r --contains "$commit" | grep -E '(^|\s)origin/main') ]]; then exit 1; fi
 
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # ratchet:actions/setup-java@v4
         with:
@@ -32,44 +35,25 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-      - name: Bygg med maven
+      - name: Build with Maven
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: mvn -B --no-transfer-progress package --settings .m2/maven-settings.xml --file pom.xml
 
-      - uses: nais/docker-build-push@be85229e81c0293c265c646c084f05317fb6e0d2 # ratchet:nais/docker-build-push@v0
+      - name: Build and push docker image
+        uses: nais/docker-build-push@be85229e81c0293c265c646c084f05317fb6e0d2 # ratchet:nais/docker-build-push@v0
         id: docker-push
         with:
           team: teamfamilie
           tag: latest
           byosbom: target/classes/META-INF/sbom/application.cdx.json
 
-      - name: Skriv ut docker-taggen
-        run: echo 'Docker-tag er ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }} ' >> $GITHUB_STEP_SUMMARY
-
     outputs:
       image: ${{ steps.docker-push.outputs.image }}
 
-  deploy-prod:
-    name: Deploy til prod-fss
-    needs: [build, deploy-preprod]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: "read"
-      id-token: "write"
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v4
-
-      - name: Deploy til prod-fss team namespace
-        uses: nais/deploy/actions/deploy@823ec9b7e305ce7cf911d0f9a25f7da9d7486cf2 # ratchet:nais/deploy/actions/deploy@v2
-        env:
-          CLUSTER: prod-fss
-          RESOURCE: .nais/app-prod.yaml
-          VAR: image=${{ needs.build.outputs.image }}
-
-  deploy-preprod:
-    name: Deploy til preprod-fss
+  deploy-dev:
+    name: Deploy to dev-fss
     needs: build
     runs-on: ubuntu-latest
     permissions:
@@ -78,21 +62,38 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v4
 
-      - name: Deploy til dev-fss team namespace
+      - name: Deploy to dev-fss namespace
         uses: nais/deploy/actions/deploy@823ec9b7e305ce7cf911d0f9a25f7da9d7486cf2 # ratchet:nais/deploy/actions/deploy@v2
         env:
           CLUSTER: dev-fss
           RESOURCE: .nais/app-dev.yaml
           VAR: image=${{ needs.build.outputs.image }}
 
+  deploy-prod:
+    name: Deploy to prod-fss
+    needs: deploy-dev
+    runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
+      id-token: "write"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v4
+
+      - name: Deploy to prod-fss namespace
+        uses: nais/deploy/actions/deploy@823ec9b7e305ce7cf911d0f9a25f7da9d7486cf2 # ratchet:nais/deploy/actions/deploy@v2
+        env:
+          CLUSTER: prod-fss
+          RESOURCE: .nais/app-prod.yaml
+          VAR: image=${{ needs.build.outputs.image }}
+
   loggfeil:
-    name: Send logg til slack ved feil
+    name: Send log to Slack on failure
     runs-on: ubuntu-latest
     needs: [deploy-prod]
     if: failure()
     steps:
-      - name: Send logg til slack ved feil
+      - name: Send log to Slack on failure
         run: |
-          curl -X POST --data "{\"text\": \"Deploy av $GITHUB_REPOSITORY feilet - $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}" $WEBHOOK_URL
+          curl -X POST --data "{\"text\": \"Deploy of $GITHUB_REPOSITORY failed - $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}" $WEBHOOK_URL
         env:
           WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/manual-deploy-dev.yml
+++ b/.github/workflows/manual-deploy-dev.yml
@@ -1,0 +1,65 @@
+name: Manual deploy dev
+on:
+  workflow_dispatch:
+    inputs:
+      skip-tests:
+        description: 'Skip tests?'
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: "read"
+  id-token: "write"
+
+jobs:
+  build:
+    name: Build and push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # ratchet:actions/setup-java@v4
+        with:
+          java-version: 25
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Build with Maven
+        env:
+          GITHUB_USERNAME: x-access-token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mvn -B --no-transfer-progress package ${{ inputs.skip-tests && '-DskipTests' || '' }} --settings .m2/maven-settings.xml --file pom.xml
+
+      - name: Build and push docker image
+        uses: nais/docker-build-push@be85229e81c0293c265c646c084f05317fb6e0d2 # ratchet:nais/docker-build-push@v0
+        id: docker-push
+        with:
+          team: teamfamilie
+          tag: latest
+          byosbom: target/classes/META-INF/sbom/application.cdx.json
+    outputs:
+      image: ${{ steps.docker-push.outputs.image }}
+
+  deploy:
+    name: Deploy to dev-fss
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
+      id-token: "write"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v4
+
+      - name: Deploy to dev-fss namespace
+        uses: nais/deploy/actions/deploy@823ec9b7e305ce7cf911d0f9a25f7da9d7486cf2 # ratchet:nais/deploy/actions/deploy@v2
+        env:
+          CLUSTER: dev-fss
+          RESOURCE: .nais/app-dev.yaml
+          VAR: image=${{ needs.build.outputs.image }}

--- a/.github/workflows/manual-deploy-prod.yml
+++ b/.github/workflows/manual-deploy-prod.yml
@@ -1,8 +1,12 @@
-name: Deploy preprod
+name: Manual deploy prod
 on:
   workflow_dispatch:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    inputs:
+      skip-tests:
+        description: 'Skip tests?'
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
@@ -11,9 +15,9 @@ concurrency:
 permissions:
   contents: "read"
   id-token: "write"
+
 jobs:
-  build-dev:
-    if: github.event.pull_request.draft == false
+  build:
     name: Build and push
     runs-on: ubuntu-latest
     steps:
@@ -21,33 +25,38 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Check that branch is main
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "::error::This workflow can only be run from the main branch"
+          exit 1
+
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # ratchet:actions/setup-java@v4
         with:
           java-version: 25
           distribution: 'temurin'
           cache: 'maven'
 
-      - name: Bygg med maven
+      - name: Build with Maven
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn -B --no-transfer-progress package --settings .m2/maven-settings.xml --file pom.xml
+        run: mvn -B --no-transfer-progress package ${{ inputs.skip-tests && '-DskipTests' || '' }} --settings .m2/maven-settings.xml --file pom.xml
 
-      - name: Bygg og push docker image
-        if: github.event.pull_request.draft == false && github.event.pull_request.user.login != 'dependabot[bot]'
+      - name: Build and push docker image
         uses: nais/docker-build-push@be85229e81c0293c265c646c084f05317fb6e0d2 # ratchet:nais/docker-build-push@v0
         id: docker-push
         with:
           team: teamfamilie
           tag: latest
           byosbom: target/classes/META-INF/sbom/application.cdx.json
+
     outputs:
       image: ${{ steps.docker-push.outputs.image }}
 
-  deploy-dev:
-    if: github.event_name == 'workflow_dispatch'
-    name: Deploy to dev-fss
-    needs: build-dev
+  deploy-prod:
+    name: Deploy to prod-fss
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: "read"
@@ -55,9 +64,21 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v4
 
-      - name: Deploy til dev-fss team namespace
+      - name: Deploy to prod-fss namespace
         uses: nais/deploy/actions/deploy@823ec9b7e305ce7cf911d0f9a25f7da9d7486cf2 # ratchet:nais/deploy/actions/deploy@v2
         env:
-          CLUSTER: dev-fss
-          RESOURCE: .nais/app-dev.yaml
-          VAR: image=${{ needs.build-dev.outputs.image }}
+          CLUSTER: prod-fss
+          RESOURCE: .nais/app-prod.yaml
+          VAR: image=${{ needs.build.outputs.image }}
+
+  loggfeil:
+    name: Send log to Slack on failure
+    runs-on: ubuntu-latest
+    needs: [deploy-prod]
+    if: failure()
+    steps:
+      - name: Send log to Slack on failure
+        run: |
+          curl -X POST --data "{\"text\": \"Manual deploy to prod of $GITHUB_REPOSITORY failed - $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}" $WEBHOOK_URL
+        env:
+          WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,34 @@
+name: Pull request
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: "read"
+
+jobs:
+  build:
+    if: github.event.pull_request.draft == false
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # ratchet:actions/setup-java@v4
+        with:
+          java-version: 25
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Build with Maven
+        env:
+          GITHUB_USERNAME: x-access-token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mvn -B --no-transfer-progress package --settings .m2/maven-settings.xml --file pom.xml


### PR DESCRIPTION
Favro: NAV-29209

## Beskrivelse

Splitter de eksisterende GitHub Actions-workflowene i fire dedikerte filer med tydelig ansvar:

- **`main.yml`** (tidl. `deploy-prod.yml`): Kjøres ved push til main. Deploy til preprod først, deretter prod. Fikset rekkefølge på deploy-jobb og lagt til `paths-ignore` for å unngå unødvendige bygg.
- **`pull-request.yml`** (ny): Kjøres på pull requests. Bygger og tester, men deployer ikke.
- **`manual-deploy-preprod.yml`** (tidl. `deploy-preprod.yml`): Manuell deploy til preprod med valgfri `skip-tests`-input. PR-trigger fjernet (håndteres nå av `pull-request.yml`).
- **`manual-deploy-prod.yml`** (ny): Manuell deploy til prod med valgfri `skip-tests`-input og en guard som hindrer kjøring fra andre branches enn main.