### PR TITLE
Korriger url for kall til logiskVedlegg på dokarkiv

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivLogiskVedleggRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivLogiskVedleggRestClient.kt
@@ -115,7 +115,7 @@ class DokarkivLogiskVedleggRestClient(
     }
 
     companion object {
-        private const val PATH_LOGISKVEDLEGG = "rest/journalpostapi/v1/dokumentInfo/{dokumentInfo}/logiskVedlegg/"
+        private const val PATH_LOGISKVEDLEGG = "rest/journalpostapi/v1/dokumentInfo/{dokumentInfo}/logiskVedlegg"
         private const val PATH_OPPDATER_LOGISKVEDLEGG = "rest/journalpostapi/v1/dokumentInfo/{dokumentInfo}/logiskVedlegg"
         private const val PATH_SLETT_LOGISK_VEDLEGG = "$PATH_LOGISKVEDLEGG/{logiskVedleggId}"
 

--- a/src/test/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivControllerTest.kt
@@ -476,7 +476,7 @@ class DokarkivControllerTest : OppslagSpringRunnerTest() {
     @Test
     fun `skal opprette logisk vedlegg`() {
         stubFor(
-            post(urlPathEqualTo("/rest/journalpostapi/v1/dokumentInfo/321/logiskVedlegg/"))
+            post(urlPathEqualTo("/rest/journalpostapi/v1/dokumentInfo/321/logiskVedlegg"))
                 .willReturn(okJson(jsonMapper.writeValueAsString(LogiskVedleggResponse(21L)))),
         )
         val response: ResponseEntity<Ressurs<LogiskVedleggResponse>> =
@@ -493,7 +493,7 @@ class DokarkivControllerTest : OppslagSpringRunnerTest() {
     @Test
     fun `skal returnere feil hvis man ikke kan opprette logisk vedlegg`() {
         stubFor(
-            post(urlPathEqualTo("/rest/journalpostapi/v1/dokumentInfo/321/logiskVedlegg/"))
+            post(urlPathEqualTo("/rest/journalpostapi/v1/dokumentInfo/321/logiskVedlegg"))
                 .willReturn(status(404).withBody("melding fra klient")),
         )
         val response: ResponseEntity<Ressurs<LogiskVedleggResponse>> =


### PR DESCRIPTION
Dokarkiv vil snart ikke godta URL-er med trailing slash, derfor må dette endres