### PR TITLE
Går vekk fra STS på Dokarkiv

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivLogiskVedleggRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivLogiskVedleggRestClient.kt
@@ -20,7 +20,7 @@ import java.net.URI
 @Component
 class DokarkivLogiskVedleggRestClient(
     @Value("\${DOKARKIV_V1_URL}") private val dokarkivUrl: URI,
-    @Qualifier("jwtBearerOboOgSts") private val restOperations: RestOperations,
+    @Qualifier("jwtBearer") private val restOperations: RestOperations,
 ) : AbstractRestClient(restOperations, "dokarkiv.logiskvedlegg.opprett") {
     private val slettVedleggClient = SlettLogiskVedleggClient(restOperations)
 

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/DokarkivRestClient.kt
@@ -29,7 +29,7 @@ import java.net.URI
 @Component
 class DokarkivRestClient(
     @Value("\${DOKARKIV_V1_URL}") private val dokarkivUrl: URI,
-    @Qualifier("jwtBearerOboOgSts") private val restOperations: RestOperations,
+    @Qualifier("jwtBearer") private val restOperations: RestOperations,
 ) : AbstractPingableRestClient(restOperations, "dokarkiv.opprett") {
     override val pingUri: URI =
         UriComponentsBuilder

--- a/src/main/resources/application-e2e.yml
+++ b/src/main/resources/application-e2e.yml
@@ -28,6 +28,15 @@ no.nav.security.jwt:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
+      dokarkiv-client-credentials:
+        resource-url: ${DOKARKIV_V1_URL}
+        token-endpoint-url: https://login.microsoftonline.com/navq.onmicrosoft.com/oauth2/v2.0/token
+        grant-type: client_credentials
+        scope: ${DOKARKIV_SCOPE}
+        authentication:
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
+          client-auth-method: client_secret_basic
       saf-selvbetjening-onbehalf-of:
         resource-url: ${SAF_SELVBETJENING_URL}
         token-endpoint-url: ${TOKEN_X_WELL_KNOWN_URL}

--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -28,6 +28,15 @@ no.nav.security.jwt:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
+      dokarkiv-client-credentials:
+        resource-url: ${DOKARKIV_V1_URL}
+        token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+        grant-type: client_credentials
+        scope: ${DOKARKIV_SCOPE}
+        authentication:
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
+          client-auth-method: client_secret_basic
       saf:
         resource-url: ${SAF_URL}
         token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -28,6 +28,15 @@ no.nav.security.jwt:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
+      dokarkiv-client-credentials:
+        resource-url: ${DOKARKIV_V1_URL}
+        token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+        grant-type: client_credentials
+        scope: ${DOKARKIV_SCOPE}
+        authentication:
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
+          client-auth-method: client_secret_basic
       saf:
         resource-url: ${SAF_URL}
         token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}

--- a/src/test/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivControllerTest.kt
@@ -57,7 +57,7 @@ import java.time.LocalDateTime
 import java.util.LinkedList
 import kotlin.test.assertFalse
 
-@ActiveProfiles(profiles = ["integrasjonstest", "mock-sts", "mock-aktor", "mock-personopplysninger", "mock-pdl"])
+@ActiveProfiles(profiles = ["integrasjonstest", "mock-oauth", "mock-aktor", "mock-personopplysninger", "mock-pdl"])
 @TestPropertySource(properties = ["DOKARKIV_V1_URL=http://localhost:28085"])
 @EnableWireMock(
     ConfigureWireMock(name = "integrasjonstest", port = 28085),


### PR DESCRIPTION
Dokarkiv-klientene er satt opp til å bruke servicebruker og STS ved system til system, men azure OBO når det er saksbehandler. Ser ingen grunn til dette at maskin til maskin skal være STS.

Endrer til jwtBearer og legger til client-credentials. Slik at den bruker BearerTokenInterceptor, som bruker azure OBO når det er saksbehandler og azure client credentials når det er maskin til maskin.

Nav-29702