### PR TITLE
Bedre feilmelding når PDL returnerer null for Geograisk Tilknytning

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/PdlRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/PdlRestClient.kt
@@ -6,6 +6,7 @@ import no.nav.familie.integrasjoner.geografisktilknytning.GeografiskTilknytningD
 import no.nav.familie.integrasjoner.geografisktilknytning.PdlGeografiskTilknytningRequest
 import no.nav.familie.integrasjoner.geografisktilknytning.PdlGeografiskTilknytningVariables
 import no.nav.familie.integrasjoner.geografisktilknytning.PdlHentGeografiskTilknytning
+import no.nav.familie.integrasjoner.personopplysning.PdlGeografiskTilknytningNotFoundException
 import no.nav.familie.integrasjoner.personopplysning.PdlNotFoundException
 import no.nav.familie.integrasjoner.personopplysning.PdlUnauthorizedException
 import no.nav.familie.integrasjoner.personopplysning.internal.PdlAdressebeskyttelse
@@ -197,7 +198,7 @@ class PdlRestClient(
             }
             if (response.data.hentGeografiskTilknytning == null) {
                 secureLogger.info("Finner ikke geografisk tilknytning for ident=$personIdent i PDL")
-                throw PdlNotFoundException()
+                throw PdlGeografiskTilknytningNotFoundException()
             }
             return response.data.hentGeografiskTilknytning
         } catch (e: Exception) {

--- a/src/main/java/no/nav/familie/integrasjoner/config/ApiExceptionHandler.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/config/ApiExceptionHandler.kt
@@ -5,6 +5,7 @@ import no.nav.familie.integrasjoner.journalpost.JournalpostForbiddenException
 import no.nav.familie.integrasjoner.journalpost.JournalpostNotFoundException
 import no.nav.familie.integrasjoner.journalpost.JournalpostRequestException
 import no.nav.familie.integrasjoner.journalpost.JournalpostRestClientException
+import no.nav.familie.integrasjoner.personopplysning.PdlGeografiskTilknytningNotFoundException
 import no.nav.familie.integrasjoner.personopplysning.PdlNotFoundException
 import no.nav.familie.integrasjoner.personopplysning.PdlUnauthorizedException
 import no.nav.familie.kontrakter.felles.Ressurs
@@ -113,6 +114,12 @@ class ApiExceptionHandler {
     fun handlePdlNotFoundException(feil: PdlNotFoundException): ResponseEntity<Ressurs<Nothing>> {
         logger.info("Finner ikke personen i PDL")
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(failure(frontendFeilmelding = "Finner ikke personen"))
+    }
+
+    @ExceptionHandler(PdlGeografiskTilknytningNotFoundException::class)
+    fun handlePdlGeografiskTilknytningNotFoundException(feil: PdlGeografiskTilknytningNotFoundException): ResponseEntity<Ressurs<Nothing>> {
+        logger.info("Finner ikke geografisk tilknytning for personen i PDL")
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(failure(frontendFeilmelding = "Finner ikke geografisk tilknytning for person"))
     }
 
     @ExceptionHandler(PdlUnauthorizedException::class)

--- a/src/main/java/no/nav/familie/integrasjoner/personopplysning/PdlRequestException.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/personopplysning/PdlRequestException.kt
@@ -6,6 +6,8 @@ open class PdlRequestException(
 
 class PdlNotFoundException : PdlRequestException()
 
+class PdlGeografiskTilknytningNotFoundException : PdlRequestException()
+
 class PdlUnauthorizedException(
     melding: String,
 ) : PdlRequestException(melding = melding)


### PR DESCRIPTION
Kastet bort tid på testing i preprod fordi personen ikke fantes i PDL, men jeg visste at den fantes. Viste seg at man logger person ikke finnes i PDL når geografisk tilknytning er null for en person som finnes. Kaster egen exception når GT = null og som logger bedre feilmelding. Beholdt retur av 404 kode.
