### PR TITLE
Bytter til sts rest klient fra token-klient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <java.version>25</java.version>
         <kotlin.version>2.3.21</kotlin.version>
         <springdoc.version>3.0.3</springdoc.version>
-        <felles.version>4.20260622095330_affbfcf</felles.version>
+        <felles.version>4.20260702123833_b6bbb7f</felles.version>
         <kontrakter.version>4.0_20260622103258_a3e0997</kontrakter.version>
         <token-validation-spring.version>6.0.11</token-validation-spring.version>
         <graphql-kotlin.version>10.0.1</graphql-kotlin.version>
@@ -128,11 +128,6 @@
         <dependency>
             <groupId>no.nav.familie.felles</groupId>
             <artifactId>token-klient</artifactId>
-            <version>${felles.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>no.nav.familie.felles</groupId>
-            <artifactId>rest-klient</artifactId>
             <version>${felles.version}</version>
         </dependency>
         <dependency>

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/SkyggesakRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/SkyggesakRestClient.kt
@@ -1,34 +1,43 @@
 package no.nav.familie.integrasjoner.client.rest
 
+import no.nav.familie.felles.tokenklient.sts.StsRestClient
 import no.nav.familie.integrasjoner.felles.OppslagException
 import no.nav.familie.integrasjoner.sak.Skyggesak
 import no.nav.familie.log.mdc.MDCConstants
-import no.nav.familie.restklient.client.AbstractRestClient
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.HttpStatusCodeException
+import org.springframework.web.client.RestClient
 import org.springframework.web.client.RestClientException
-import org.springframework.web.client.RestOperations
 import java.net.URI
 
 @Component
 class SkyggesakRestClient(
     @Value("\${SKYGGE_SAK_URL}") private val skyggesakUrl: String,
-    @Qualifier("sts") private val restTemplate: RestOperations,
-) : AbstractRestClient(restTemplate, "skyggesak.sak") {
+    @Qualifier("utenAuthHttpClient") private val restClient: RestClient,
+    private val stsRestClient: StsRestClient,
+) {
     private val sakUri = URI.create("$skyggesakUrl/api/v1/saker")
 
     private val logger = LoggerFactory.getLogger(SkyggesakRestClient::class.java)
 
     fun opprettSak(request: Skyggesak) {
         try {
-            postForEntity<Skyggesak>(sakUri, request, httpHeaders())
+            restClient
+                .post()
+                .uri(sakUri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(X_CORRELATION_ID, MDC.get(MDCConstants.MDC_CALL_ID))
+                .headers { it.setBearerAuth(stsRestClient.systemOIDCToken) }
+                .body(request)
+                .retrieve()
+                .toBodilessEntity()
         } catch (e: HttpClientErrorException.Conflict) {
             logger.info("Skyggesak allerede opprettet for fagsak ${request.fagsakNr}")
         } catch (e: RestClientException) {
@@ -45,11 +54,6 @@ class SkyggesakRestClient(
             )
         }
     }
-
-    private fun httpHeaders(): HttpHeaders =
-        HttpHeaders().apply {
-            add(X_CORRELATION_ID, MDC.get(MDCConstants.MDC_CALL_ID))
-        }
 
     companion object {
         private const val X_CORRELATION_ID = "X-Correlation-ID"

--- a/src/main/java/no/nav/familie/integrasjoner/client/rest/SkyggesakRestClient.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/client/rest/SkyggesakRestClient.kt
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
@@ -34,7 +35,7 @@ class SkyggesakRestClient(
                 .uri(sakUri)
                 .contentType(MediaType.APPLICATION_JSON)
                 .header(X_CORRELATION_ID, MDC.get(MDCConstants.MDC_CALL_ID))
-                .headers { it.setBearerAuth(stsRestClient.systemOIDCToken) }
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + stsRestClient.systemOIDCToken)
                 .body(request)
                 .retrieve()
                 .toBodilessEntity()

--- a/src/main/java/no/nav/familie/integrasjoner/config/ApiExceptionHandler.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/config/ApiExceptionHandler.kt
@@ -157,6 +157,7 @@ class ApiExceptionHandler {
 
         return ResponseEntity
             .status(e.httpStatus)
+            .headers { if (e.httpStatus.value() == 401) it.set("WWW-Authenticate", "Bearer") }
             .body(failure(feilmelding, error = e))
     }
 

--- a/src/main/java/no/nav/familie/integrasjoner/config/ApplicationConfig.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/config/ApplicationConfig.kt
@@ -3,8 +3,6 @@ package no.nav.familie.integrasjoner.config
 import no.nav.familie.log.NavSystemtype
 import no.nav.familie.log.filter.LogFilter
 import no.nav.familie.log.filter.RequestTimeFilter
-import no.nav.familie.restklient.config.NaisProxyCustomizer
-import no.nav.familie.restklient.config.RestTemplateSts
 import no.nav.familie.sikkerhet.context.FamilieFellesSpringSecurityKonfigurasjon
 import org.slf4j.LoggerFactory
 import org.springframework.boot.SpringBootConfiguration
@@ -23,7 +21,7 @@ import org.springframework.scheduling.annotation.EnableScheduling
 )
 @ConfigurationPropertiesScan
 @EnableScheduling
-@Import(NaisProxyCustomizer::class, FamilieFellesSpringSecurityKonfigurasjon::class, RestTemplateSts::class)
+@Import(FamilieFellesSpringSecurityKonfigurasjon::class)
 class ApplicationConfig {
     private val logger = LoggerFactory.getLogger(ApplicationConfig::class.java)
 

--- a/src/main/java/no/nav/familie/integrasjoner/config/IntegrasjonConfig.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/config/IntegrasjonConfig.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.integrasjoner.config
 
-import no.nav.familie.kontrakter.felles.jsonMapper
-import no.nav.familie.restklient.sts.StsRestClient
+import no.nav.familie.felles.tokenklient.sts.StsRestClient
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -19,6 +18,6 @@ class IntegrasjonConfig {
     ): StsRestClient {
         val stsFullUrl = URI.create(stsUrl.toString() + "?grant_type=client_credentials&scope=openid")
 
-        return StsRestClient(jsonMapper, stsFullUrl, stsUsername, stsPassword, null)
+        return StsRestClient(stsFullUrl.toString(), stsUsername, stsPassword, null)
     }
 }

--- a/src/main/java/no/nav/familie/integrasjoner/config/SecurityConfig.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/config/SecurityConfig.kt
@@ -110,6 +110,7 @@ class SecurityConfig(
         AuthenticationEntryPoint { _: HttpServletRequest, response: HttpServletResponse, _: AuthenticationException ->
             response.apply {
                 status = HttpServletResponse.SC_UNAUTHORIZED
+                setHeader("WWW-Authenticate", "Bearer")
                 contentType = MediaType.APPLICATION_JSON_VALUE
                 characterEncoding = Charsets.UTF_8.name()
                 jsonMapper.writeValue(

--- a/src/test/java/no/nav/familie/integrasjoner/UnitTestLauncher.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/UnitTestLauncher.kt
@@ -25,7 +25,6 @@ fun main(args: Array<String>) {
                 "mock-oppgave",
                 "mock-personopplysninger",
                 "mock-saf",
-                "mock-sts",
                 "mock-pdl",
                 "mock-regoppslag",
                 "mock-modia-context-holder",

--- a/src/test/java/no/nav/familie/integrasjoner/adramatch/FiloverføringAdraMatchControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/adramatch/FiloverføringAdraMatchControllerTest.kt
@@ -21,7 +21,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.web.util.UriComponentsBuilder
 import java.lang.reflect.Method
 
-@ActiveProfiles("integrasjonstest", "mock-sts", "mock-oauth")
+@ActiveProfiles("integrasjonstest")
 class FiloverføringAdraMatchControllerTest : OppslagSpringRunnerTest() {
     @field:RegisterExtension
     private val sftpServer = FakeSftpServerExtension(MOCK_SFTP_SERVER_PORT)

--- a/src/test/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/dokarkiv/DokarkivControllerTest.kt
@@ -226,6 +226,7 @@ class DokarkivControllerTest : OppslagSpringRunnerTest() {
                 .willReturn(
                     status(401)
                         .withHeader("Content-Type", "application/json;charset=UTF-8")
+                        .withHeader("WWW-Authenticate", "Bearer")
                         .withBody("Tekst fra body"),
                 ),
         )
@@ -242,8 +243,6 @@ class DokarkivControllerTest : OppslagSpringRunnerTest() {
                 HttpEntity(body, headers),
             )
         assertThat(responseDeprecated.statusCode).isEqualTo(HttpStatus.UNAUTHORIZED)
-        assertThat(responseDeprecated.body?.status).isEqualTo(Ressurs.Status.FEILET)
-        assertThat(responseDeprecated.body?.melding).contains("Unauthorized")
     }
 
     @Test

--- a/src/test/java/no/nav/familie/integrasjoner/felles/config/StsTestConfig.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/felles/config/StsTestConfig.kt
@@ -2,18 +2,20 @@ package no.nav.familie.integrasjoner.felles.config
 
 import io.mockk.every
 import io.mockk.mockk
-import no.nav.familie.restklient.sts.StsRestClient
+import no.nav.familie.felles.tokenklient.sts.StsRestClient
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
 import org.springframework.context.annotation.Profile
 
 @Configuration
 class StsTestConfig {
     @Bean
+    @Primary
     @Profile("mock-sts")
     fun stsRestClientMock(): StsRestClient {
         val client = mockk<StsRestClient>()
-        every { client.systemOIDCToken } returns "MOCKED-OIDC-TOKEN"
+        every { client.systemOIDCToken } returns "MOCKED-STS-OIDC-TOKEN"
         return client
     }
 }

--- a/src/test/java/no/nav/familie/integrasjoner/journalpost/HentJournalpostControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/journalpost/HentJournalpostControllerTest.kt
@@ -49,7 +49,7 @@ import java.time.LocalDateTime
     ConfigureWireMock(name = "HentJournalpostControllerTest", port = 28085),
 )
 @TestPropertySource(properties = ["SAF_URL=http://localhost:28085"])
-@ActiveProfiles("integrasjonstest", "mock-sts", "mock-oauth", "mock-egenansatt-false")
+@ActiveProfiles("integrasjonstest", "mock-oauth", "mock-egenansatt-false")
 class HentJournalpostControllerTest : OppslagSpringRunnerTest() {
     private val testLogger = LoggerFactory.getLogger(HentJournalpostController::class.java) as Logger
 

--- a/src/test/java/no/nav/familie/integrasjoner/saksbehandler/SaksbehandlerControllerTest.kt
+++ b/src/test/java/no/nav/familie/integrasjoner/saksbehandler/SaksbehandlerControllerTest.kt
@@ -25,7 +25,7 @@ import org.wiremock.spring.ConfigureWireMock
 import org.wiremock.spring.EnableWireMock
 import java.util.UUID
 
-@ActiveProfiles("integrasjonstest", "mock-sts", "mock-oauth")
+@ActiveProfiles("integrasjonstest", "mock-oauth")
 @TestPropertySource(properties = ["AAD_GRAPH_API_URI=http://localhost:28085"])
 @EnableWireMock(
     ConfigureWireMock(name = "saksbehandler", port = 28085),


### PR DESCRIPTION
Fjerner AbstractRestClient og rest-klient-avhengigheten fra SkyggesakRestClient. Bruker i stedet Spring RestClient direkte med StsRestClient fra token-klient for Bearer-token.

Dette fordi rest-klient-biblioteket er deprecated. Denne PR-en er siste steg for å fjerne avhengigheten helt. SkyggesakRestClient var den eneste gjenværende brukeren av AbstractRestClient og RestTemplateSts.

I tillegg er det en RFC 7235-fiks
Jetty 12 (som brukes av Spring Boot 3.4+ sin TestRestTemplate) krever at 401-responses inneholder WWW-Authenticate-header. Uten denne kastes HttpResponseException: HTTP protocol violation. Headeren er lagt til i både SecurityConfig (autentiseringsfeil) og ApiExceptionHandler (propagerte 401 fra downstream-tjenester). Bump av felles gjorde denne oppgraderingen nødvendig