### PR TITLE
Forbedre feilmelding av feil ved deseerialisering

### DIFF
--- a/src/main/java/no/nav/familie/integrasjoner/journalpost/BaksTilgangsstyrtJournalpostService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/journalpost/BaksTilgangsstyrtJournalpostService.kt
@@ -49,13 +49,12 @@ class BaksTilgangsstyrtJournalpostService(
             }
         } catch (e: MissingVersionException) {
             logger.warn("Får ikke sjekket tilgang til digital søknad tilknyttet journalpost ${journalpost.journalpostId}.")
-            secureLogger.warn("Feil ved deserialisering av digital søknad ifbm sjekk av tilgang.", e)
-            // For gamle søknader, før 'kontraktVersjon' ble innført, har vi ingen måte å bestemme konkret klasse å deserialisere til.
+            secureLogger.warn("Feil ved deserialisering av digital søknad ifbm sjekk av tilgang: " + (e.message?.take(50))) // For gamle søknader, før 'kontraktVersjon' ble innført, har vi ingen måte å bestemme konkret klasse å deserialisere til.
             // Gir tilgang basert på antagelsen om at fagsak relatert til gamle søknader allerede er satt til Vikafossen dersom det finnes kode 6, 7 eller 19 personer i søknad.
             JournalpostTilgang(harTilgang = true)
         } catch (e: UnsupportedVersionException) {
             logger.error("Får ikke sjekket tilgang til digital søknad tilknyttet journalpost ${journalpost.journalpostId}, da vi mangler støtte for kontraktversjon.")
-            secureLogger.error("Feil ved deserialisering av digital søknad ifbm sjekk av tilgang.", e)
+            secureLogger.error("Feil ved deserialisering av digital søknad ifbm sjekk av tilgang" + (e.message?.take(50)))
             // Hindrer tilgang og logger Error da vi burde kunne deserialisere alle baks-søknader med feltet `kontraktVersjon`.
             JournalpostTilgang(harTilgang = false)
         }

--- a/src/main/java/no/nav/familie/integrasjoner/journalpost/BaksTilgangsstyrtJournalpostService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/journalpost/BaksTilgangsstyrtJournalpostService.kt
@@ -49,12 +49,13 @@ class BaksTilgangsstyrtJournalpostService(
             }
         } catch (e: MissingVersionException) {
             logger.warn("Får ikke sjekket tilgang til digital søknad tilknyttet journalpost ${journalpost.journalpostId}.")
-            secureLogger.warn("Feil ved deserialisering av digital søknad ifbm sjekk av tilgang: " + (e.message?.take(50))) // For gamle søknader, før 'kontraktVersjon' ble innført, har vi ingen måte å bestemme konkret klasse å deserialisere til.
+            secureLogger.warn("Feil ved deserialisering av digital søknad ifbm sjekk av tilgang.", e)
+            // For gamle søknader, før 'kontraktVersjon' ble innført, har vi ingen måte å bestemme konkret klasse å deserialisere til.
             // Gir tilgang basert på antagelsen om at fagsak relatert til gamle søknader allerede er satt til Vikafossen dersom det finnes kode 6, 7 eller 19 personer i søknad.
             JournalpostTilgang(harTilgang = true)
         } catch (e: UnsupportedVersionException) {
             logger.error("Får ikke sjekket tilgang til digital søknad tilknyttet journalpost ${journalpost.journalpostId}, da vi mangler støtte for kontraktversjon.")
-            secureLogger.error("Feil ved deserialisering av digital søknad ifbm sjekk av tilgang" + (e.message?.take(50)))
+            secureLogger.error("Feil ved deserialisering av digital søknad ifbm sjekk av tilgang.", e)
             // Hindrer tilgang og logger Error da vi burde kunne deserialisere alle baks-søknader med feltet `kontraktVersjon`.
             JournalpostTilgang(harTilgang = false)
         }

--- a/src/main/java/no/nav/familie/integrasjoner/journalpost/BaksTilgangsstyrtJournalpostService.kt
+++ b/src/main/java/no/nav/familie/integrasjoner/journalpost/BaksTilgangsstyrtJournalpostService.kt
@@ -49,13 +49,13 @@ class BaksTilgangsstyrtJournalpostService(
             }
         } catch (e: MissingVersionException) {
             logger.warn("Får ikke sjekket tilgang til digital søknad tilknyttet journalpost ${journalpost.journalpostId}.")
-            secureLogger.warn("Feil ved deserialisering av digital søknad.", e)
+            secureLogger.warn("Feil ved deserialisering av digital søknad ifbm sjekk av tilgang.", e)
             // For gamle søknader, før 'kontraktVersjon' ble innført, har vi ingen måte å bestemme konkret klasse å deserialisere til.
             // Gir tilgang basert på antagelsen om at fagsak relatert til gamle søknader allerede er satt til Vikafossen dersom det finnes kode 6, 7 eller 19 personer i søknad.
             JournalpostTilgang(harTilgang = true)
         } catch (e: UnsupportedVersionException) {
             logger.error("Får ikke sjekket tilgang til digital søknad tilknyttet journalpost ${journalpost.journalpostId}, da vi mangler støtte for kontraktversjon.")
-            secureLogger.error("Feil ved deserialisering av digital søknad.", e)
+            secureLogger.error("Feil ved deserialisering av digital søknad ifbm sjekk av tilgang.", e)
             // Hindrer tilgang og logger Error da vi burde kunne deserialisere alle baks-søknader med feltet `kontraktVersjon`.
             JournalpostTilgang(harTilgang = false)
         }


### PR DESCRIPTION
Vi ønsker å utdype meldingen som dukker opp i securelogger.

Trodde først at det var søknader vi mottok som feilet under deserialisering, men det viser seg det bare ved ved tilgangsjekken her (som er tiltenkt for gamle søknader).  Slik ser det ut nå i familie-integrasjoner:

<img width="755" height="356" alt="Screenshot 2026-07-23 at 09 54 57" src="https://github.com/user-attachments/assets/dc49b3cc-2d9d-4c81-ad6b-87503b665efe" />
